### PR TITLE
Optionally loop around file when navigation hunks.

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -87,13 +87,25 @@ setup({config})                                             *gitsigns.setup()*
                     {config} Table object containing configuration for
                     Gitsigns. See |gitsigns-usage| for more details.
 
-next_hunk()                                             *gitsigns.next_hunk()*
+next_hunk({opts})                                           *gitsigns.next_hunk()*
                 Jump to the next hunk in the current buffer. Respects
                 |wrapscan|.
 
-prev_hunk()                                             *gitsigns.prev_hunk()*
+                Parameters: ~
+                    {opts}  table|nil Configuration table. Keys:
+                            • {wrap}: (boolean)
+                              Whether to loop around file or not. Defaults
+                              to the value 'wrapscan'
+
+prev_hunk({opts})                                       *gitsigns.prev_hunk()*
                 Jump to the previous hunk in the current buffer. Respects
                 |wrapscan|.
+
+                Parameters: ~
+                    {opts}  table|nil Configuration table. Keys:
+                            • {wrap}: (boolean)
+                              Whether to loop around file or not. Defaults
+                              to the value 'wrapscan'
 
 stage_hunk()                                           *gitsigns.stage_hunk()*
                 Stage the hunk at the cursor position.

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -450,7 +450,8 @@ local undo_stage_hunk = async('undo_stage_hunk', function()
   add_signs(bufnr, signs)
 end)
 
-local function nav_hunk(forwards)
+local function nav_hunk(options)
+  local forwards = options.forwards
   local bcache = get_cache_opt(current_buf())
   if not bcache then
     return
@@ -479,7 +480,8 @@ local function nav_hunk(forwards)
     end
   end
   -- wrap around
-  if not row and vim.o.wrapscan then
+  local wrap = vim.F.if_nil(options.wrap, vim.o.wrapscan)
+  if not row and wrap then
     row = math.max(hunks[forwards and 1 or #hunks].start, 1)
   end
   if row then
@@ -487,8 +489,13 @@ local function nav_hunk(forwards)
   end
 end
 
-local function next_hunk() nav_hunk(true)  end
-local function prev_hunk() nav_hunk(false) end
+local function next_hunk(options)
+  nav_hunk(vim.tbl_extend('keep', { forwards = true }, (options or {})))
+end
+
+local function prev_hunk(options)
+  nav_hunk(vim.tbl_extend('keep', { forwards = false }, (options or {})))
+end
 
 local detach = function(bufnr)
   dprint('Detached', bufnr)


### PR DESCRIPTION
Hello!

First off, thank you very much for gitsigns, I didn't realise how slow other solutions were before trying this.

This pull requests allows passing optional options to `next_hunk` and `prev_hunk` to disable wrapping around the file without having to touch the `wrapscan` global option. I used the LSP's [`goto_next` and `goto_prev`](](https://github.com/neovim/neovim/blob/b931a554d70ef07803da3eb3f98ce4b3a3570d11/runtime/lua/vim/lsp/diagnostic.lua#L568-L592)) as inspiration for how the API should look like but I can change to only pass a boolean to the function if you prefer.

Thanks!