### PR TITLE
Fix diff on windows. #61

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -504,6 +504,7 @@ local attach = throttle_leading(100, sync(function()
       return
    end
 
+   await_main()
    cache[cbuf] = {
       file = file,
       relpath = relpath,

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -504,7 +504,9 @@ local attach = throttle_leading(100, sync(function()
       return
    end
 
+
    await_main()
+
    cache[cbuf] = {
       file = file,
       relpath = relpath,

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -203,6 +203,7 @@ function M.run_diff(staged, text, diff_algo)
             '--diff-algorithm=' .. diff_algo,
             '--patch-with-raw',
             '--unified=0',
+
             '--ignore-space-at-eol',
             staged,
             '-',

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -203,6 +203,7 @@ function M.run_diff(staged, text, diff_algo)
             '--diff-algorithm=' .. diff_algo,
             '--patch-with-raw',
             '--unified=0',
+            '--ignore-space-at-eol',
             staged,
             '-',
          },

--- a/lua/gitsigns/types.lua
+++ b/lua/gitsigns/types.lua
@@ -1,0 +1,70 @@
+
+
+
+ CacheEntry = {}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ SignName = {}
+
+
+
+
+
+
+
+ SignsConfig = {}
+
+
+
+
+
+
+
+ StatusObj = {}
+
+
+
+
+
+
+ Config = {watch_index = {}, }
+
+
+
+
+
+
+
+
+
+
+
+
+
+ SignType = {}
+
+
+
+
+
+
+
+ Sign = {}
+
+
+
+
+
+ Hunk = {Node = {}, }

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -504,6 +504,7 @@ local attach = throttle_leading(100, sync(function()
     return
   end
 
+  await_main()
   cache[cbuf] = {
     file          = file,
     relpath       = relpath,

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -504,7 +504,9 @@ local attach = throttle_leading(100, sync(function()
     return
   end
 
+  -- On windows os.tmpname() crashes in callback threads
   await_main()
+
   cache[cbuf] = {
     file          = file,
     relpath       = relpath,

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -203,6 +203,7 @@ function M.run_diff(staged: string, text: {string}, diff_algo: string): cb_funct
         '--diff-algorithm='..diff_algo,
         '--patch-with-raw',
         '--unified=0',
+        -- Prevent diff of whole file if staged use \r\n instead of \n
         '--ignore-space-at-eol',
         staged,
         '-'

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -203,6 +203,7 @@ function M.run_diff(staged: string, text: {string}, diff_algo: string): cb_funct
         '--diff-algorithm='..diff_algo,
         '--patch-with-raw',
         '--unified=0',
+        '--ignore-space-at-eol',
         staged,
         '-'
       },


### PR DESCRIPTION
Sorry for the delay.

`await_main()` prevents `os.tmpname ()` from crashing.
`--ignore-space-at-eol` prevents diff to be the whole file when `bcache.staged` use `\r\n` instead of `\n`.
