### PR TITLE
Fix changing colorschemes breaking color highlight

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -612,6 +612,7 @@ local function setup(cfg)
 
 
 
+   vim.cmd('augroup gitsigns | autocmd! | augroup END')
 
 
 
@@ -620,10 +621,12 @@ local function setup(cfg)
 
 
 
-   vim.cmd('autocmd BufRead,BufNewFile,BufWritePost ' ..
+
+
+   vim.cmd('autocmd gitsigns BufRead,BufNewFile,BufWritePost ' ..
    '* lua vim.schedule(require("gitsigns").attach)')
 
-   vim.cmd('autocmd VimLeavePre * lua require("gitsigns").detach_all()')
+   vim.cmd('autocmd gitsigns VimLeavePre * lua require("gitsigns").detach_all()')
 
    if config.use_decoration_api then
       local ns = api.nvim_create_namespace('gitsigns')

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -628,6 +628,8 @@ local function setup(cfg)
 
    vim.cmd('autocmd gitsigns VimLeavePre * lua require("gitsigns").detach_all()')
 
+   vim.cmd('autocmd gitsigns ColorScheme * lua require("gitsigns")._update_highlights()')
+
    if config.use_decoration_api then
       local ns = api.nvim_create_namespace('gitsigns')
       api.nvim_set_decoration_provider(ns, {
@@ -761,5 +763,9 @@ return {
    toggle_linehl = function()
       config.linehl = not config.linehl
       refresh()
+   end,
+
+   _update_highlights = function()
+      setup_signs()
    end,
 }

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -17,9 +17,15 @@ local hls = {
    GitSignsDelete = { 'GitGutterDelete', 'SignifySignDelete', 'DiffDelete' },
 }
 
+local function is_hl_set(hl_name)
+
+   local exists, hl = pcall(api.nvim_get_hl_by_name, hl_name, true)
+   local color = hl.foreground or hl.background
+   return exists and color ~= nil
+end
+
 local function hl_link(to, from, reverse)
-   local to_exists, _ = pcall(api.nvim_get_hl_by_name, to, false)
-   if to_exists then
+   if is_hl_set(to) then
       return
    end
 
@@ -59,22 +65,15 @@ function M.setup_highlight(hl_name0)
 
    local hl_name = hl_name0
 
-   local exists, hl = pcall(api.nvim_get_hl_by_name, hl_name, true)
-   if exists and (hl.foreground or hl.background) then
+   if is_hl_set(hl_name) then
 
       return
    end
 
    for _, d in ipairs(hls[hl_name]) do
-      local _, dhl = pcall(api.nvim_get_hl_by_name, d, true)
-      local color = dhl.foreground or dhl.background
-      if color then
+      if is_hl_set(d) then
          dprint(('Deriving %s from %s'):format(hl_name, d))
-         if isStdHl(d) then
-            hl_link(hl_name, d, true)
-         else
-            hl_link(hl_name, d)
-         end
+         hl_link(hl_name, d, isStdHl(d))
          return
       end
    end

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -628,6 +628,8 @@ local function setup(cfg: Config)
 
   vim.cmd('autocmd gitsigns VimLeavePre * lua require("gitsigns").detach_all()')
 
+  vim.cmd('autocmd gitsigns ColorScheme * lua require("gitsigns")._update_highlights()')
+
   if config.use_decoration_api then
     local ns = api.nvim_create_namespace('gitsigns')
     api.nvim_set_decoration_provider(ns, {
@@ -761,5 +763,9 @@ return {
   toggle_linehl = function()
     config.linehl = not config.linehl
     refresh()
+  end,
+
+  _update_highlights = function()
+    setup_signs()
   end
 }

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -611,6 +611,9 @@ local function setup(cfg: Config)
   update_debounced = debounce_trailing(config.update_debounce, arun(update))
     as function(integer)
 
+  -- set up augroup, clear it if setup is run twice.
+  vim.cmd('augroup gitsigns | autocmd! | augroup END')
+
   -- This seems to be triggered twice on the first buffer so we have throttled
   -- the attach function with throttle_leading
   --
@@ -620,10 +623,10 @@ local function setup(cfg: Config)
   -- which suspends itself when it needs to get back onto the main thread in
   -- order to call an API function.
   -- TODO: Figure how to test this.
-  vim.cmd('autocmd BufRead,BufNewFile,BufWritePost '..
+  vim.cmd('autocmd gitsigns BufRead,BufNewFile,BufWritePost '..
     '* lua vim.schedule(require("gitsigns").attach)')
 
-  vim.cmd('autocmd VimLeavePre * lua require("gitsigns").detach_all()')
+  vim.cmd('autocmd gitsigns VimLeavePre * lua require("gitsigns").detach_all()')
 
   if config.use_decoration_api then
     local ns = api.nvim_create_namespace('gitsigns')

--- a/teal/gitsigns/highlight.tl
+++ b/teal/gitsigns/highlight.tl
@@ -17,9 +17,15 @@ local hls: {GitSignHl:{string}} = {
   GitSignsDelete = { 'GitGutterDelete', 'SignifySignDelete', 'DiffDelete' },
 }
 
+local function is_hl_set(hl_name: string): boolean
+   -- TODO: this only works with `set termguicolors`
+  local exists, hl = pcall(api.nvim_get_hl_by_name, hl_name, true)
+  local color = hl.foreground or hl.background
+  return exists and color ~= nil
+end
+
 local function hl_link(to: string, from: string, reverse: boolean)
-  local to_exists, _ = pcall(api.nvim_get_hl_by_name, to, false)
-  if to_exists then
+  if is_hl_set(to) then
     return
   end
 
@@ -59,22 +65,15 @@ function M.setup_highlight(hl_name0: string)
 
   local hl_name = hl_name0 as GitSignHl
 
-  local exists, hl = pcall(api.nvim_get_hl_by_name, hl_name, true)
-  if exists and (hl.foreground or hl.background) then
+  if is_hl_set(hl_name) then
     -- Alread defined
     return
   end
 
   for _, d in ipairs(hls[hl_name]) do
-    local _, dhl = pcall(api.nvim_get_hl_by_name, d, true)
-    local color = dhl.foreground or dhl.background
-    if color then
+    if is_hl_set(d) then
       dprint(('Deriving %s from %s'):format(hl_name, d))
-      if isStdHl(d) then
-        hl_link(hl_name, d, true)
-      else
-        hl_link(hl_name, d)
-      end
+      hl_link(hl_name, d, isStdHl(d))
       return
     end
   end

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -765,6 +765,45 @@ local function testsuite(variant, advanced_features)
 
     end)
 
+    it('updates highlights when colorscheme changes', function()
+      command("set termguicolors")
+
+      local test_config2 = helpers.deepcopy(test_config)
+      test_config2.signs.add.hl = nil
+      test_config2.signs.change.hl = nil
+      test_config2.signs.delete.hl = nil
+      test_config2.signs.changedelete.hl = nil
+      test_config2.signs.topdelete.hl = nil
+      test_config2.linehl = true
+
+      exec_lua('gs.setup(...)', test_config2)
+
+      eq('GitSignsChange xxx gui=reverse guibg=#ffbbff',
+        exec_capture('hi GitSignsChange'))
+
+      eq('GitSignsDelete xxx gui=reverse guifg=#0000ff guibg=#e0ffff',
+        exec_capture('hi GitSignsDelete'))
+
+      eq('GitSignsAdd    xxx gui=reverse guibg=#add8e6',
+        exec_capture('hi GitSignsAdd'))
+
+      eq('GitSignsAddLn  xxx gui=reverse guibg=#add8e6',
+        exec_capture('hi GitSignsAddLn'))
+
+      command('colorscheme blue')
+
+      eq('GitSignsChange xxx gui=reverse guifg=#000000 guibg=#006400',
+        exec_capture('hi GitSignsChange'))
+
+      eq('GitSignsDelete xxx gui=reverse guifg=#000000 guibg=#ff7f50',
+        exec_capture('hi GitSignsDelete'))
+
+      eq('GitSignsAdd    xxx gui=reverse guifg=#000000 guibg=#6a5acd',
+        exec_capture('hi GitSignsAdd'))
+
+      eq('GitSignsAddLn  xxx gui=reverse guifg=#000000 guibg=#6a5acd',
+        exec_capture('hi GitSignsAddLn'))
+    end)
   end)
 end
 


### PR DESCRIPTION
- Update highlights when the colorscheme is changed
- Refactor existing highlight detection into a function
- Add test to prevent regression

Also, prevent multiple autocmds from being defined if `setup()` is called multiple times, for example when a user reloads their config.

- Define an augroup `gitsigns`
- Clear all autocmds
- Use the augroup in all autocmd definitions

Fixes #105 