### PR TITLE
fixed signcolumn local option in floating window

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -717,6 +717,7 @@ local function preview_hunk()
    api.nvim_buf_set_option(bufnr, 'filetype', 'diff')
    api.nvim_win_set_option(winid, 'number', false)
    api.nvim_win_set_option(winid, 'relativenumber', false)
+   api.nvim_win_set_option(winid, 'signcolumn', 'no')
 end
 
 local function select_hunk()

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -717,6 +717,7 @@ local function preview_hunk()
   api.nvim_buf_set_option(bufnr, 'filetype', 'diff')
   api.nvim_win_set_option(winid, 'number', false)
   api.nvim_win_set_option(winid, 'relativenumber', false)
+  api.nvim_win_set_option(winid, 'signcolumn', 'no')
 end
 
 local function select_hunk()


### PR DESCRIPTION

https://user-images.githubusercontent.com/7649265/112881575-8728da00-90d4-11eb-8ff2-4af591d509df.mp4

I had such issue, possibly due to my config:
```lua
vim.wo.signcolumn = 'yes:2'
```
