### PR TITLE
Unset cursorline in hunk preview

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -689,6 +689,7 @@ local function preview_hunk()
    api.nvim_win_set_option(winid, 'number', false)
    api.nvim_win_set_option(winid, 'relativenumber', false)
    api.nvim_win_set_option(winid, 'signcolumn', 'no')
+   api.nvim_win_set_option(winid, 'cursorline', false)
 end
 
 local function select_hunk()

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -689,6 +689,7 @@ local function preview_hunk()
   api.nvim_win_set_option(winid, 'number', false)
   api.nvim_win_set_option(winid, 'relativenumber', false)
   api.nvim_win_set_option(winid, 'signcolumn', 'no')
+  api.nvim_win_set_option(winid, 'cursorline', false)
 end
 
 local function select_hunk()


### PR DESCRIPTION
Sets cursorline to false in hunk preview window. Having it set makes it hard to distinguish where the preview window starts.