### PR TITLE
Preview: Set tabstop before calculating width

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -683,9 +683,9 @@ local function preview_hunk()
       return
    end
 
-   local winid, bufnr = gs_popup.create(hunk.lines, { relative = 'cursor' })
+   local ts = api.nvim_buf_get_option(cbuf, 'tabstop')
+   local winid, bufnr = gs_popup.create(hunk.lines, { relative = 'cursor', tabstop = ts })
 
-   api.nvim_buf_set_option(bufnr, 'tabstop', api.nvim_buf_get_option(cbuf, 'tabstop'))
    api.nvim_buf_set_option(bufnr, 'filetype', 'diff')
    api.nvim_win_set_option(winid, 'number', false)
    api.nvim_win_set_option(winid, 'relativenumber', false)

--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -27,6 +27,8 @@ function popup.create(what, opts)
 
    opts = opts or {}
 
+
+
    if opts.tabstop then
       api.nvim_buf_set_option(bufnr, 'tabstop', opts.tabstop)
    end

--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -27,6 +27,9 @@ function popup.create(what, opts)
 
    opts = opts or {}
 
+   if opts.tabstop then
+      api.nvim_buf_set_option(bufnr, 'tabstop', opts.tabstop)
+   end
 
    local win_id = api.nvim_open_win(bufnr, false, {
       relative = opts.relative,

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -683,9 +683,9 @@ local function preview_hunk()
     return
   end
 
-  local winid, bufnr = gs_popup.create(hunk.lines, { relative = 'cursor' })
+  local ts = api.nvim_buf_get_option(cbuf, 'tabstop')
+  local winid, bufnr = gs_popup.create(hunk.lines, { relative = 'cursor', tabstop = ts })
 
-  api.nvim_buf_set_option(bufnr, 'tabstop', api.nvim_buf_get_option(cbuf, 'tabstop'))
   api.nvim_buf_set_option(bufnr, 'filetype', 'diff')
   api.nvim_win_set_option(winid, 'number', false)
   api.nvim_win_set_option(winid, 'relativenumber', false)

--- a/teal/gitsigns/popup.tl
+++ b/teal/gitsigns/popup.tl
@@ -27,6 +27,8 @@ function popup.create(what: {string}, opts: {string:any}): number, number
 
   opts = opts or {}
 
+  -- Set tabstop before calculating the buffer width so that the correct width
+  -- is calculated
   if opts.tabstop then
     api.nvim_buf_set_option(bufnr, 'tabstop', opts.tabstop)
   end

--- a/teal/gitsigns/popup.tl
+++ b/teal/gitsigns/popup.tl
@@ -27,6 +27,9 @@ function popup.create(what: {string}, opts: {string:any}): number, number
 
   opts = opts or {}
 
+  if opts.tabstop then
+    api.nvim_buf_set_option(bufnr, 'tabstop', opts.tabstop)
+  end
 
   local win_id = api.nvim_open_win(bufnr, false, {
     relative = opts.relative,


### PR DESCRIPTION
There's an issue in a3ffb07 where the width is incorrect if the global and local `tabstop` differ because it calculates using the global and then sets it to a different value.