### PR TITLE
Implemented `stage_buffer` and `reset_buffer_index`

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -114,6 +114,14 @@ undo_stage_hunk()                                 *gitsigns.undo_stage_hunk()*
                 Undo the last call of stage_hunk(). Note: only the calls to
                 stage_hunk() performed in the current session can be undone.
 
+stage_buffer()                                           *gitsigns.stage_buffer()*
+                Stage all hunks in current buffer.
+
+reset_buffer_index()                                 *gitsigns.reset_buffer_index()*
+                Unstage all hunks for current buffer in the index. Note: Unlike
+                |gitsigns.undo_stage_hunk()| this doesn't simply undo stages, this runs
+                an actual `git reset` on current file.
+
 reset_hunk()                                           *gitsigns.reset_hunk()*
                 Reset the lines of the hunk at the cursor position to what
                 is in Git's index.
@@ -216,6 +224,8 @@ keymaps                                              *gitsigns-config-keymaps*
           ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
           ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
           ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line()<CR>',
+          ['n <leader>hS'] = '<cmd>lua require"gitsigns".stage_buffer()<CR>',
+          ['n <leader>hU'] = '<cmd>lua require"gitsigns".reset_buffer_index()<CR>',
 
           ['o ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>',
           ['x ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>'

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -99,6 +99,8 @@ M.schema = {
       ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
       ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
       ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line()<CR>',
+      ['n <leader>hS'] = '<cmd>lua require"gitsigns".stage_buffer()<CR>',
+      ['n <leader>hU'] = '<cmd>lua require"gitsigns".reset_buffer_index()<CR>',
 
       ['o ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>',
       ['x ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>'

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -50,6 +50,7 @@ local M = {BlameInfo = {}, Version = {}, }
 
 
 
+
 local function parse_version(version)
    assert(version:match('%d+%.%d+%.%d+'), 'Invalid git version: ' .. version)
    local ret = {}
@@ -304,6 +305,28 @@ M.add_file = a.wrap(function(
          if not status then
             local s = table.concat(err, '\n')
             error('Cannot add file. Command stderr:\n\n' .. s)
+         end
+         callback()
+      end,
+   })
+end, 3)
+
+M.unstage_file = a.wrap(function(
+   toplevel, file, callback)
+   local status = true
+   local err = {}
+   util.run_job({
+      command = 'git',
+      args = { 'reset', file },
+      cwd = toplevel,
+      on_stderr = function(_, line)
+         status = false
+         table.insert(err, line)
+      end,
+      on_exit = function()
+         if not status then
+            local s = table.concat(err, '\n')
+            error('Cannot unstage file. Command stderr:\n\n' .. s)
          end
          callback()
       end,

--- a/lua/gitsigns/status.lua
+++ b/lua/gitsigns/status.lua
@@ -34,6 +34,17 @@ function Status:clear(bufnr)
    api.nvim_buf_del_var(bufnr, 'gitsigns_status')
 end
 
+function Status:clear_diff(bufnr)
+   local new_status = {
+      added = 0,
+      removed = 0,
+      changed = 0,
+      head = self.status.head or '',
+   }
+
+   self:update(bufnr, new_status)
+end
+
 function Status:update_head(bufnr, head)
    self.status.head = head
    Status:update(bufnr)

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -69,6 +69,23 @@ end
 
 local cache: {integer:CacheEntry} = {}
 
+local ensure_file_in_index = async(function(bcache: CacheEntry)
+  if not bcache.object_name or bcache.has_conflicts then
+    if not bcache.object_name then
+      -- If there is no object_name then it is not yet in the index so add it
+      await(git.add_file(bcache.toplevel, bcache.relpath))
+    else
+      -- Update the index with the common ancestor (stage 1) which is what bcache
+      -- stores
+      await(git.update_index(bcache.toplevel, bcache.mode_bits, bcache.object_name, bcache.relpath))
+    end
+
+    -- Update the cache
+    _, bcache.object_name, bcache.mode_bits, bcache.has_conflicts =
+      await(git.file_info(bcache.relpath, bcache.toplevel))
+  end
+end)
+
 local function get_cursor_hunk(bufnr: integer, hunks: {Hunk}): Hunk
   bufnr = bufnr or current_buf()
   hunks = hunks or cache[bufnr].hunks
@@ -183,22 +200,9 @@ local stage_hunk = void_async(function()
     return
   end
 
-  if not bcache.object_name or bcache.has_conflicts then
-    if not bcache.object_name then
-      -- If there is no object_name then it is not yet in the index so add it
-      await(git.add_file(bcache.toplevel, bcache.relpath))
-    else
-      -- Update the index with the common ancestor (stage 1) which is what bcache
-      -- stores
-      await(git.update_index(bcache.toplevel, bcache.mode_bits, bcache.object_name, bcache.relpath))
-    end
+  await(ensure_file_in_index(bcache))
 
-    -- Update the cache
-    _, bcache.object_name, bcache.mode_bits, bcache.has_conflicts =
-      await(git.file_info(bcache.relpath, bcache.toplevel))
-  end
-
-  local lines = create_patch(bcache.relpath, hunk, bcache.mode_bits)
+  local lines = create_patch(bcache.relpath, {hunk}, bcache.mode_bits)
 
   await(git.stage_lines(bcache.toplevel, lines))
 
@@ -266,7 +270,7 @@ local undo_stage_hunk = void_async(function()
     return
   end
 
-  local lines = create_patch(bcache.relpath, hunk, bcache.mode_bits, true)
+  local lines = create_patch(bcache.relpath, {hunk}, bcache.mode_bits, true)
 
   await(git.stage_lines(bcache.toplevel, lines))
 
@@ -275,6 +279,70 @@ local undo_stage_hunk = void_async(function()
   local hunk_signs = process_hunks({hunk})
 
   await(scheduler())
+  signs.add(config, bufnr, hunk_signs)
+end)
+
+local stage_buffer = void_async(function()
+  local bufnr = current_buf()
+
+  local bcache = cache[bufnr]
+  if not bcache then
+    return
+  end
+
+  -- Only process files with existing hunks
+  local hunks = bcache.hunks
+  if #hunks == 0 then
+    print("No unstaged changes in file to stage")
+    return 
+  end
+
+  if not util.path_exists(bcache.file) then
+    print("Error: Cannot stage file. Please add it to the working tree.")
+    return
+  end
+
+  await(ensure_file_in_index(bcache))
+
+  local lines = create_patch(bcache.relpath, hunks, bcache.mode_bits)
+
+  await(git.stage_lines(bcache.toplevel, lines))
+
+  for _,hunk in ipairs(hunks) do
+    table.insert(bcache.staged_diffs, hunk)
+  end
+
+  await(scheduler())
+
+  signs.remove(bufnr)
+
+  Status:clear_diff(bufnr)
+end)
+
+local reset_buffer_index = void_async(function()
+  local bufnr = current_buf()
+  local bcache = cache[bufnr]
+  if not bcache then
+    return
+  end
+
+  -- `bcache.staged_diffs` won't contain staged changes outside of current neovim session
+  -- so signs added from this unstage won't be complete
+  -- They will however be fixed by index watcher and properly updated
+  -- We should implement some sort of initial population from git diff,
+  -- after that this function can be improved to check if any staged hunks exists
+  -- and it can undo changes using git apply line by line instead of reseting whole file
+  local hunks = bcache.staged_diffs
+
+  await(git.unstage_file(bcache.toplevel, bcache.file))
+
+  -- Signs need to be generated before the `table.remove` below as it modifies the hunks array
+  local hunk_signs = process_hunks(hunks)
+
+  table.remove(bcache.staged_diffs)
+
+  await(scheduler())
+
   signs.add(config, bufnr, hunk_signs)
 end)
 
@@ -366,7 +434,7 @@ end
 local function get_buf_path(bufnr: integer): string
   return
     uv.fs_realpath(api.nvim_buf_get_name(bufnr))
-    or
+      or
     api.nvim_buf_call(bufnr, function(): string
       return vim.fn.expand('%:p')
     end)
@@ -789,24 +857,26 @@ local function toggle_current_line_blame()
 end
 
 M = {
-  update          = update_debounced,
-  stage_hunk      = mk_repeatable(stage_hunk),
-  undo_stage_hunk = mk_repeatable(undo_stage_hunk),
-  reset_hunk      = mk_repeatable(reset_hunk),
-  next_hunk       = next_hunk,
-  prev_hunk       = prev_hunk,
-  select_hunk     = select_hunk,
-  preview_hunk    = preview_hunk,
-  blame_line      = blame_line,
-  reset_buffer    = reset_buffer,
-  attach          = attach_throttled,
-  detach          = detach,
-  detach_all      = detach_all,
-  setup           = setup,
-  refresh         = refresh,
-  toggle_signs    = toggle_signs,
-  toggle_linehl   = toggle_linehl,
-  toggle_numhl    = toggle_numhl,
+  update               = update_debounced,
+  stage_hunk           = mk_repeatable(stage_hunk),
+  undo_stage_hunk      = mk_repeatable(undo_stage_hunk),
+  reset_hunk           = mk_repeatable(reset_hunk),
+  stage_buffer         = stage_buffer,
+  reset_buffer_index   = reset_buffer_index,
+  next_hunk            = next_hunk,
+  prev_hunk            = prev_hunk,
+  select_hunk          = select_hunk,
+  preview_hunk         = preview_hunk,
+  blame_line           = blame_line,
+  reset_buffer         = reset_buffer,
+  attach               = attach_throttled,
+  detach               = detach,
+  detach_all           = detach_all,
+  setup                = setup,
+  refresh              = refresh,
+  toggle_signs         = toggle_signs,
+  toggle_linehl        = toggle_linehl,
+  toggle_numhl         = toggle_numhl,
 
   _current_line_blame       = _current_line_blame,
   _current_line_blame_reset = _current_line_blame_reset,

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -99,6 +99,8 @@ M.schema = {
       ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
       ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
       ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line()<CR>',
+      ['n <leader>hS'] = '<cmd>lua require"gitsigns".stage_buffer()<CR>',
+      ['n <leader>hU'] = '<cmd>lua require"gitsigns".reset_buffer_index()<CR>',
 
       ['o ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>',
       ['x ih'] = ':<C-U>lua require"gitsigns".select_hunk()<CR>'

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -44,6 +44,7 @@ local record M
   get_repo_info   : function(string): a.future3<string,string,string>
   stage_lines     : function(string, {string}): a.future0
   add_file        : function(string, string, string): a.future0
+  unstage_file    : function(string, string, string): a.future0
   update_index    : function(string, string, string, string): a.future0
   run_diff        : function(string, {string}, string): a.future1<{Hunk}>
   set_version     : function(string): a.future0
@@ -304,6 +305,28 @@ M.add_file = a.wrap(function(
       if not status then
         local s = table.concat(err, '\n')
         error('Cannot add file. Command stderr:\n\n'..s)
+      end
+      callback()
+    end
+  }
+end, 3)
+
+M.unstage_file = a.wrap(function(
+  toplevel: string, file: string, callback: function())
+  local status = true
+  local err = {}
+  util.run_job {
+    command = 'git',
+    args = {'reset', file},
+    cwd = toplevel,
+    on_stderr = function(_, line: string)
+      status = false
+      table.insert(err, line)
+    end,
+    on_exit = function()
+      if not status then
+        local s = table.concat(err, '\n')
+        error('Cannot unstage file. Command stderr:\n\n'..s)
       end
       callback()
     end

--- a/teal/gitsigns/hunks.tl
+++ b/teal/gitsigns/hunks.tl
@@ -115,39 +115,46 @@ function M.process_hunks(hunks: {Hunk}): {integer:Sign}
   return signs
 end
 
-function M.create_patch(relpath: string, hunk: Hunk, mode_bits: string, invert: boolean): {string}
+function M.create_patch(relpath: string, hunks: {Hunk}, mode_bits: string, invert: boolean): {string}
   invert = invert or false
 
-  local start, pre_count, now_count =
-    hunk.removed.start, hunk.removed.count, hunk.added.count
-
-  if hunk.type == 'add' then
-    start = start + 1
-  end
-
-  local lines = hunk.lines
-
-  if invert then
-    pre_count, now_count = now_count, pre_count
-
-    lines = vim.tbl_map(function(l: string): string
-      if vim.startswith(l, '+') then
-        l = '-'..string.sub(l, 2, -1)
-      elseif vim.startswith(l, '-') then
-        l = '+'..string.sub(l, 2, -1)
-      end
-      return l
-    end, lines) as {string}
-  end
-
-  return {
+  local results = {
     string.format('diff --git a/%s b/%s', relpath, relpath),
     'index 000000..000000 '..mode_bits,
     '--- a/'..relpath,
     '+++ b/'..relpath,
-    string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start, now_count),
-    unpack(lines)
   }
+
+  for _, process_hunk in ipairs(hunks) do
+    local start, pre_count, now_count =
+    process_hunk.removed.start, process_hunk.removed.count, process_hunk.added.count
+
+    if process_hunk.type == 'add' then
+      start = start + 1
+    end
+
+    local lines = process_hunk.lines
+
+    if invert then
+      pre_count, now_count = now_count, pre_count
+
+      lines = vim.tbl_map(function(l: string): string
+        if vim.startswith(l, '+') then
+          l = '-'..string.sub(l, 2, -1)
+        elseif vim.startswith(l, '-') then
+          l = '+'..string.sub(l, 2, -1)
+        end
+        return l
+      end, lines) as {string}
+    end
+
+    table.insert(results, string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start, now_count))
+    for _, line in ipairs(lines) do
+      table.insert(results, line)
+    end
+  end
+
+  return results
 end
 
 function M.get_summary(hunks: {Hunk}, head: string): StatusObj
@@ -213,8 +220,8 @@ function M.extract_removed(hunk: Hunk): {string}
   return vim.tbl_map(function(l: string): string
     return string.sub(l, 2, -1)
   end, vim.tbl_filter(function(l: string): boolean
-      return vim.startswith(l, '-')
-    end, hunk.lines)) as {string}
+    return vim.startswith(l, '-')
+  end, hunk.lines)) as {string}
 end
 
 return M

--- a/teal/gitsigns/status.tl
+++ b/teal/gitsigns/status.tl
@@ -34,6 +34,17 @@ function Status:clear(bufnr: number)
   api.nvim_buf_del_var(bufnr, 'gitsigns_status')
 end
 
+function Status:clear_diff(bufnr: number)
+  local new_status: StatusObj = {
+    added = 0,
+    removed = 0,
+    changed = 0,
+    head = self.status.head or ''
+  }
+
+  self:update(bufnr, new_status)
+end
+
 function Status:update_head(bufnr: number, head: string)
   self.status.head = head
   Status:update(bufnr)

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -182,6 +182,8 @@ local test_config = {
     ['n mhu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
     ['n mhr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
     ['n mhp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
+    ['n mhS'] = '<cmd>lua require"gitsigns".stage_buffer()<CR>',
+    ['n mhU'] = '<cmd>lua require"gitsigns".reset_buffer_index()<CR>',
   },
   update_debounce = 5,
 }
@@ -278,6 +280,8 @@ describe('gitsigns', function()
 
       -- Check all keymaps get set
       match_lines(res, {
+        'n  mhS         *@<Cmd>lua require"gitsigns".stage_buffer()<CR>',
+        'n  mhU         *@<Cmd>lua require"gitsigns".reset_buffer_index()<CR>',
         'n  mhp         *@<Cmd>lua require"gitsigns".preview_hunk()<CR>',
         'n  mhr         *@<Cmd>lua require"gitsigns".reset_hunk()<CR>',
         'n  mhs         *@<Cmd>lua require"gitsigns".stage_hunk()<CR>',
@@ -546,15 +550,59 @@ describe('gitsigns', function()
                               |
         ]]}
 
+        -- Add multiple edits
+        feed('gg')
+        sleep(20)
+        feed('cc')
+        sleep(20)
+        feed('That<esc>')
+        sleep(10)
+
+        screen:expect{grid=[[
+          {2:~ }Tha^t              |
+          {1:  }is                |
+          {1:  }a                 |
+          {2:~ }EDIT              |
+          {1:  }used              |
+                              |
+        ]]}
+
+        -- Stage buffer
+        feed("mhS")
+        sleep(10)
+
+        screen:expect{grid=[[
+          {1:  }Tha^t              |
+          {1:  }is                |
+          {1:  }a                 |
+          {1:  }EDIT              |
+          {1:  }used              |
+                              |
+        ]]}
+
+        -- Unstage buffer
+        feed("mhU")
+        sleep(10)
+
+        screen:expect{grid=[[
+          {2:~ }Tha^t              |
+          {1:  }is                |
+          {1:  }a                 |
+          {2:~ }EDIT              |
+          {1:  }used              |
+                              |
+        ]]}
+
+
         -- Reset
         feed("mhr")
         sleep(10)
 
         screen:expect{grid=[[
-          {1:  }This              |
+          {1:  }Thi^s              |
           {1:  }is                |
           {1:  }a                 |
-          {1:  }fil^e              |
+          {2:~ }EDIT              |
           {1:  }used              |
                               |
         ]]}


### PR DESCRIPTION
This allow users to run `lua require"gitsigns".stage_file()` to stage
all changes in a file and `lua require"gitsigns".unstage_file()` to
unstage all changes in a file.

Closes: #127

Also a sidenote, it would be nice to have some sort of "developing" section in readme. Setting up teal isn't the worst, but having the requirements in there would be helpful.