### PR TITLE
Support git builds from source.

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -88,12 +88,18 @@ local M = {BlameInfo = {}, Version = {}, Obj = {}, }
 local Obj = M.Obj
 
 local function parse_version(version)
-   assert(version:match('%d+%.%d+%.%d+'), 'Invalid git version: ' .. version)
+   assert(version:match('%d+%.%d+%.%w+'), 'Invalid git version: ' .. version)
    local ret = {}
    local parts = vim.split(version, '%.')
    ret.major = tonumber(parts[1])
    ret.minor = tonumber(parts[2])
-   ret.patch = tonumber(parts[3])
+
+   if ret.patch == 'GIT' then
+      ret.patch = math.huge
+   else
+      ret.patch = tonumber(parts[3])
+   end
+
    return ret
 end
 


### PR DESCRIPTION
Not sure if this is the best way to do it, but I get problems using `gitsigns` if I have a `git` version that is built from source due to the `%d` match failing.

You can see how they generate this [here](https://github.com/git/git/blob/master/GIT-VERSION-GEN), so I can hack on that a bit rather than making the change here if that is to your liking.

Let me know what you think @lewis6991.