### PR TITLE
feat: Stage all hunks in a range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ require('gitsigns').setup {
     ['n [c'] = { expr = true, "&diff ? '[c' : '<cmd>lua require\"gitsigns.actions\".prev_hunk()<CR>'"},
 
     ['n <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+    ['v <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
     ['n <leader>hu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
     ['n <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+    ['v <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
     ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
     ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
     ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line(true)<CR>',

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -52,8 +52,10 @@ of the default settings:
         ['n [c'] = { expr = true, "&diff ? '[c' : '<cmd>lua require\"gitsigns\".prev_hunk()<CR>'"},
 
         ['n <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+        ['v <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
         ['n <leader>hu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
         ['n <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+        ['v <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
         ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
         ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
         ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line(true)<CR>',
@@ -122,8 +124,14 @@ prev_hunk({opts})                                       *gitsigns.prev_hunk()*
                               Whether to loop around file or not. Defaults
                               to the value 'wrapscan'
 
-stage_hunk()                                           *gitsigns.stage_hunk()*
-                Stage the hunk at the cursor position.
+stage_hunk({range})                                    *gitsigns.stage_hunk()*
+                Stage the hunk at the cursor position, or all hunks in the
+                given range. If {range} is provided, all hunks that intersect
+                with the given range are staged.
+
+                Parameters:~
+                    {range} table|nil List-like table of two integers making
+                    up the line range from which you want to stage the hunks.
 
 undo_stage_hunk()                                 *gitsigns.undo_stage_hunk()*
                 Undo the last call of stage_hunk(). Note: only the calls to
@@ -137,9 +145,15 @@ reset_buffer_index()                           *gitsigns.reset_buffer_index()*
                 Unlike |gitsigns.undo_stage_hunk()| this doesn't simply undo
                 stages, this runs an `git reset` on current buffers file.
 
-reset_hunk()                                           *gitsigns.reset_hunk()*
-                Reset the lines of the hunk at the cursor position to what
-                is in Git's index.
+reset_hunk({range})                                    *gitsigns.reset_hunk()*
+                Reset the lines of the hunk at the cursor position, or all
+                hunks in the given range, to what it is in Git's index. If
+                {range} is provided, all hunks that intersect with the given
+                range are reset.
+
+                Parameters:~
+                    {range} table|nil List-like table of two integers making
+                    up the line range from which you want to reset the hunks.
 
 reset_buffer()                                       *gitsigns.reset_buffer()*
                 Reset the lines of all hunks in the buffer.
@@ -274,8 +288,10 @@ keymaps                                              *gitsigns-config-keymaps*
           ['n [c'] = { expr = true, "&diff ? '[c' : '<cmd>lua require\"gitsigns\".prev_hunk()<CR>'"},
 
           ['n <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+          ['v <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
           ['n <leader>hu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
           ['n <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+          ['v <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
           ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
           ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
           ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line(true)<CR>',

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -300,8 +300,9 @@ local function _complete(arglead, line)
    return matches
 end
 
-local function _run_func(func, ...)
+local function _run_func(range, func, ...)
    local actions = require('gitsigns.actions')
+   actions._set_user_range(range)
    if type(actions[func]) == 'function' then
       actions[func](...)
       return
@@ -315,10 +316,11 @@ end
 local function setup_command()
    vim.cmd(table.concat({
       'command!',
+      '-range',
       '-nargs=+',
       '-complete=customlist,v:lua.package.loaded.gitsigns._complete',
       'Gitsigns',
-      'lua require("gitsigns")._run_func(<f-args>)',
+      'lua require("gitsigns")._run_func({<line1>, <line2>}, <f-args>)',
    }, ' '))
 end
 

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -105,8 +105,10 @@ M.schema = {
          ['n [c'] = { expr = true, "&diff ? '[c' : '<cmd>lua require\"gitsigns\".prev_hunk()<CR>'" },
 
          ['n <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+         ['v <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
          ['n <leader>hu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
          ['n <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+         ['v <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
          ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
          ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
          ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line(true)<CR>',

--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -117,6 +117,8 @@ function M.create_patch(relpath, hunks, mode_bits, invert)
       '+++ b/' .. relpath,
    }
 
+   local offset = 0
+
    for _, process_hunk in ipairs(hunks) do
       local start, pre_count, now_count = 
       process_hunk.removed.start, process_hunk.removed.count, process_hunk.added.count
@@ -140,10 +142,13 @@ function M.create_patch(relpath, hunks, mode_bits, invert)
          end, lines)
       end
 
-      table.insert(results, string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start, now_count))
+      table.insert(results, string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start + offset, now_count))
       for _, line in ipairs(lines) do
          table.insert(results, line)
       end
+
+      process_hunk.removed.start = start + offset
+      offset = offset + (now_count - pre_count)
    end
 
    return results

--- a/lua/gitsigns/repeat.lua
+++ b/lua/gitsigns/repeat.lua
@@ -1,4 +1,4 @@
-
+local tbl = require('plenary.tbl')
 local M = {}
 
 local repeat_fn
@@ -9,9 +9,9 @@ end
 
 function M.mk_repeatable(fn)
    return function(...)
-      local args = { ... }
+      local args = tbl.pack(...)
       repeat_fn = function()
-         fn(unpack(args))
+         fn(tbl.unpack(args))
          vim.cmd('silent! call repeat#set("\\<Plug>GitsignsRepeat",-1)')
       end
 

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -300,8 +300,9 @@ local function _complete(arglead: string, line: string): {string}
   return matches
 end
 
-local function _run_func(func: string, ...: any)
+local function _run_func(range: {integer, integer}, func: string, ...: any)
   local actions = require('gitsigns.actions') as {string:function}
+  actions._set_user_range(range)
   if type(actions[func]) == 'function' then
     actions[func](...)
     return
@@ -315,10 +316,11 @@ end
 local function setup_command()
   vim.cmd(table.concat({
     'command!',
+    '-range',
     '-nargs=+',
     '-complete=customlist,v:lua.package.loaded.gitsigns._complete',
     'Gitsigns',
-    'lua require("gitsigns")._run_func(<f-args>)'
+    'lua require("gitsigns")._run_func({<line1>, <line2>}, <f-args>)'
   }, ' '))
 end
 

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -6,7 +6,6 @@ local scheduler  = a.scheduler
 local Status        = require("gitsigns.status")
 local cache         = require('gitsigns.cache').cache
 local config        = require('gitsigns.config').config
-local manager       = require('gitsigns.manager')
 local mk_repeatable = require('gitsigns.repeat').mk_repeatable
 local popup         = require('gitsigns.popup')
 local signs         = require('gitsigns.signs')
@@ -17,6 +16,7 @@ local Hunk = gs_hunks.Hunk
 
 local api = vim.api
 local current_buf = api.nvim_get_current_buf
+local user_range: {integer, integer}
 
 local record NavHunkOpts
   forwards: boolean
@@ -41,6 +41,7 @@ local record M
   change_base        : function(base: string)
   diffthis           : function -- function(base: string)
 
+  _set_user_range    : function(range: {integer, integer})
   get_actions        : function(bufnr: integer, lnum: integer)
 end
 
@@ -52,7 +53,39 @@ local function get_cursor_hunk(bufnr: integer, hunks: {Hunk}): Hunk
   return gs_hunks.find_hunk(lnum, hunks)
 end
 
-M.stage_hunk = mk_repeatable(async_void(function()
+---Find all hunks in a given range for a given buffer.
+---@param bufnr
+---@param hunks
+---@param range
+---@param strict If strict: all hunks must be fully contained in the range.
+---   Otherwise all hunks that intersect with the range are returned.
+local function get_range_hunks(bufnr: integer, hunks: {Hunk}, range: {integer, integer}, strict: boolean): {Hunk}
+  bufnr = bufnr or current_buf()
+  hunks = hunks or cache[bufnr].hunks
+
+  local ret: {Hunk} = {}
+  for _, hunk in ipairs(hunks) do
+    if range[1] == 1 and hunk.start == 0 and hunk.vend == 0 then
+      return {hunk}
+    end
+
+    if strict then
+      if (range[1] <= hunk.start and range[2] >= hunk.vend) then
+        ret[#ret+1] = hunk
+      end
+    else
+      if (range[2] >= hunk.start and range[1] <= hunk.vend) then
+        ret[#ret+1] = hunk
+      end
+    end
+  end
+
+  return ret
+end
+
+M.stage_hunk = mk_repeatable(async_void(function(range: {integer, integer})
+  range = range or user_range
+  local valid_range = false
   local bufnr = current_buf()
   local bcache = cache[bufnr]
   if not bcache then
@@ -64,17 +97,29 @@ M.stage_hunk = mk_repeatable(async_void(function()
     return
   end
 
-  local hunk = get_cursor_hunk(bufnr, bcache.hunks)
-  if not hunk then
+  local hunks = {}
+
+  if range is {integer, integer} and range[1] ~= range[2] then
+    valid_range = true
+    table.sort(range)
+    hunks = get_range_hunks(bufnr, bcache.hunks, range)
+  else
+    hunks[1] = get_cursor_hunk(bufnr, bcache.hunks)
+  end
+
+  if #hunks == 0 then
     return
   end
 
-  await(bcache.git_obj:stage_hunks({hunk}))
+  await(bcache.git_obj:stage_hunks(hunks))
 
-  table.insert(bcache.staged_diffs, hunk)
+  for _, hunk in ipairs(hunks) do
+    table.insert(bcache.staged_diffs, hunk)
+  end
+
   bcache.compare_text = nil -- Invalidate
 
-  local hunk_signs = gs_hunks.process_hunks({hunk})
+  local hunk_signs = gs_hunks.process_hunks(hunks)
 
   await(scheduler())
 
@@ -86,29 +131,43 @@ M.stage_hunk = mk_repeatable(async_void(function()
   for lnum, _ in pairs(hunk_signs) do
     signs.remove(bufnr, lnum)
   end
-  await(manager.update(bufnr))
 end))
 
-M.reset_hunk = mk_repeatable(function(bufnr: integer, hunk: Hunk)
-  bufnr = bufnr or current_buf()
-  hunk = hunk or get_cursor_hunk(bufnr)
-  if not hunk then
+M.reset_hunk = mk_repeatable(function(range: {integer, integer})
+  range = range or user_range
+  local bufnr: integer = current_buf()
+  local hunks = {}
+
+  if range is {integer, integer} and range[1] ~= range[2] then
+    table.sort(range)
+    hunks = get_range_hunks(bufnr, nil, range)
+  else
+    hunks[1] = get_cursor_hunk(bufnr)
+  end
+
+  if #hunks == 0 then
     return
   end
 
-  local lstart, lend: integer, integer
-  if hunk.type == 'delete' then
-    lstart = hunk.start
-    lend = hunk.start
-  else
-    local length = vim.tbl_count(vim.tbl_filter(function(l: string): boolean
-      return vim.startswith(l, '+')
-    end, hunk.lines))
+  local offset = 0
 
-    lstart = hunk.start - 1
-    lend = hunk.start - 1 + length
+  for _, hunk in ipairs(hunks) do
+    local lstart, lend: integer, integer
+    if hunk.type == 'delete' then
+      lstart = hunk.start
+      lend = hunk.start
+    else
+      local length = vim.tbl_count(vim.tbl_filter(function(l: string): boolean
+        return vim.startswith(l, '+')
+      end, hunk.lines))
+
+      lstart = hunk.start - 1
+      lend = hunk.start - 1 + length
+    end
+    local lines = gs_hunks.extract_removed(hunk)
+    api.nvim_buf_set_lines(bufnr, lstart + offset, lend + offset, false, lines)
+    offset = offset + (#lines - (lend - lstart))
   end
-  api.nvim_buf_set_lines(bufnr, lstart, lend, false, gs_hunks.extract_removed(hunk))
 end)
 
 M.reset_buffer = function()
@@ -366,6 +425,14 @@ M.diffthis = async_void(function(base: string)
 
   vim.cmd[[windo diffthis]]
 end)
+
+M._set_user_range = function(range: {integer, integer})
+  if range is {integer, integer} and range[1] ~= range[2] then
+    user_range = range
+  else
+    user_range = nil
+  end
+end
 
 M.get_actions = function(): {string:function}
   local hunk = get_cursor_hunk()

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -105,8 +105,10 @@ M.schema = {
       ['n [c'] = { expr = true, "&diff ? '[c' : '<cmd>lua require\"gitsigns\".prev_hunk()<CR>'"},
 
       ['n <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+      ['v <leader>hs'] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
       ['n <leader>hu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
       ['n <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+      ['v <leader>hr'] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
       ['n <leader>hR'] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
       ['n <leader>hp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
       ['n <leader>hb'] = '<cmd>lua require"gitsigns".blame_line(true)<CR>',

--- a/teal/gitsigns/hunks.tl
+++ b/teal/gitsigns/hunks.tl
@@ -117,6 +117,8 @@ function M.create_patch(relpath: string, hunks: {Hunk}, mode_bits: string, inver
     '+++ b/'..relpath,
   }
 
+  local offset = 0
+
   for _, process_hunk in ipairs(hunks) do
     local start, pre_count, now_count =
     process_hunk.removed.start, process_hunk.removed.count, process_hunk.added.count
@@ -140,10 +142,13 @@ function M.create_patch(relpath: string, hunks: {Hunk}, mode_bits: string, inver
       end, lines) as {string}
     end
 
-    table.insert(results, string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start, now_count))
+    table.insert(results, string.format('@@ -%s,%s +%s,%s @@', start, pre_count, start + offset, now_count))
     for _, line in ipairs(lines) do
       table.insert(results, line)
     end
+
+    process_hunk.removed.start = start + offset
+    offset = offset + (now_count - pre_count)
   end
 
   return results

--- a/teal/gitsigns/repeat.tl
+++ b/teal/gitsigns/repeat.tl
@@ -1,4 +1,4 @@
-
+local tbl = require('plenary.tbl')
 local M = {}
 
 local repeat_fn: function()
@@ -8,10 +8,10 @@ function M.repeat_action()
 end
 
 function M.mk_repeatable(fn: function): function
-  return function(...)
-    local args = {...}
+  return function(...: any)
+    local args = tbl.pack(...)
     repeat_fn = function()
-      fn(unpack(args))
+      fn(tbl.unpack(args))
       vim.cmd('silent! call repeat#set("\\<Plug>GitsignsRepeat",-1)')
     end
 

--- a/types/plenary/tbl.d.tl
+++ b/types/plenary/tbl.d.tl
@@ -1,0 +1,6 @@
+local record tbl
+  pack: function(...: any): {any}
+  unpack: function({any}): any...
+end
+
+return tbl

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -157,6 +157,8 @@ global record vim
   api: api
   record fn
     line: function(string): integer
+    join: function({any}, string): string
+    getpos: function(string): {integer}
     expand: function(string): string
     sign_unplace: function(string, {string:any})
     sign_place: function(number, string, string, string | number, {string:any})


### PR DESCRIPTION
Fixes #176.

This changes the `stage_hunk` and `reset_hunk` functions such that they accept a range. When given a range they will stage / reset all hunks that intersect with the given range.

Examples:
 - lua:
 
```lua
require"gitsigns".stage_hunk() -- stage the hunk at the cursor
require"gitsigns".stage_hunk({3, 45}) -- stage all hunks in a specific range
require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")}) -- stage everything in visual selection
```

- vim command:

```
:Gitsigns stage_hunk
:3,45Gitsigns stage_hunk
:'<,'>Gitsigns stage_hunk
```

The `reset_hunk` variants have the same syntax.