### PR TITLE
Configurable blame virtual text position

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ require('gitsigns').setup {
     interval = 1000
   },
   current_line_blame = false,
+  current_line_blame_position = 'eol',
   sign_priority = 6,
   update_debounce = 100,
   status_formatter = nil, -- Use default

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -454,6 +454,14 @@ current_line_blame                        *gitsigns-config-current_line_blame*
 
       The highlight group used for the text is `GitSignsCurrentLineBlame`.
 
+current_line_blame_position      *gitsigns-config-current_line_blame_position*
+      Type: `string`, Default: `"eol"`
+
+        Blame annotation position. Available options:
+        - eol: right after eol character (default).
+        - overlay: display over the specified column, without shifting the underlying text.
+        - right_align: display right aligned in the window.
+
 current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
       Type: `function`
       Default: >

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -55,6 +55,7 @@ local M = {Config = {SignsConfig = {}, watch_index = {}, yadm = {}, }, }
 
 
 
+
 M.config = {}
 
 M.schema = {
@@ -349,6 +350,17 @@ M.schema = {
       the current line.
 
       The highlight group used for the text is `GitSignsCurrentLineBlame`.
+    ]],
+   },
+
+   current_line_blame_position = {
+      type = 'string',
+      default = 'eol',
+      description = [[
+        Blame annotation position. Available options:
+        - eol: right after eol character (default).
+        - overlay: display over the specified column, without shifting the underlying text.
+        - right_align: display right aligned in the window.
     ]],
    },
 

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -40,6 +40,7 @@ M.run = async_void(function()
    api.nvim_buf_set_extmark(bufnr, namespace, lnum - 1, 0, {
       id = 1,
       virt_text = config.current_line_blame_formatter(bcache.git_obj.username, result),
+      virt_text_pos = config.current_line_blame_position,
    })
 end)
 

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -36,6 +36,7 @@ local record M
     status_formatter: function({string:any}): string
     current_line_blame: boolean
     current_line_blame_formatter: function(string, {string:any}): string
+    current_line_blame_position: string
     preview_config: {string:any}
     attach_to_untracked: boolean
     use_internal_diff: boolean
@@ -351,6 +352,17 @@ M.schema = {
       The highlight group used for the text is `GitSignsCurrentLineBlame`.
     ]]
   },
+
+   current_line_blame_position = {
+      type = 'string',
+      default = 'eol',
+      description = [[
+        Blame annotation position. Available options:
+        - eol: right after eol character (default).
+        - overlay: display over the specified column, without shifting the underlying text.
+        - right_align: display right aligned in the window.
+    ]],
+   },
 
   current_line_blame_formatter = {
     type = 'function',

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -40,6 +40,7 @@ M.run = async_void(function()
   api.nvim_buf_set_extmark(bufnr, namespace, lnum-1, 0, {
     id = 1,
     virt_text = config.current_line_blame_formatter(bcache.git_obj.username, result),
+    virt_text_pos = config.current_line_blame_position,
   })
 end)
 


### PR DESCRIPTION
This PR adds a configuration option to adjust the `virt_text_pos` for the git blame virtual text.