### PR TITLE
Added configurable timeout for blame virtual text

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ require('gitsigns').setup {
     interval = 1000
   },
   current_line_blame = false,
+  current_line_blame_delay = 1000,
   current_line_blame_position = 'eol',
   sign_priority = 6,
   update_debounce = 100,

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -510,6 +510,11 @@ current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
         git blame --line-porcelain
 <
 
+current_line_blame_delay            *gitsigns-config-current_line_blame_delay*
+      Type: `number`, Default: `1000`
+
+      Sets the delay before blame virtual text is displayed in milliseconds.
+
 yadm                                                    *gitsigns-config-yadm*
       Type: `table`, Default: `{ enable = false }`
 

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -57,6 +57,7 @@ local M = {Config = {SignsConfig = {}, watch_index = {}, yadm = {}, }, }
 
 
 
+
 M.config = {}
 
 M.schema = {
@@ -430,6 +431,14 @@ M.schema = {
       Note that the keys map onto the output of: >
         git blame --line-porcelain
 <
+    ]],
+   },
+
+   current_line_blame_delay = {
+      type = 'number',
+      default = 1000,
+      description = [[
+      Sets the delay before blame virtual text is displayed in milliseconds.
     ]],
    },
 

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -12,11 +12,28 @@ local current_buf = api.nvim_get_current_buf
 
 local namespace = api.nvim_create_namespace('gitsigns_blame')
 
+local timer = vim.loop.new_timer()
+
 local M = {}
 
 
 
 
+
+
+M.cursor_moved = function()
+   M.reset()
+
+   timer:start(
+   config.current_line_blame_delay,
+   0,
+   vim.schedule_wrap(
+   function()
+      M.run()
+   end))
+
+
+end
 
 M.reset = function(bufnr)
    bufnr = bufnr or current_buf()
@@ -49,14 +66,8 @@ M.setup = function()
    for k, _ in pairs(cache) do
       M.reset(k)
    end
-   if config.current_line_blame then
-      for func, events in pairs({
-            run = 'CursorHold',
-            reset = 'CursorMoved',
-         }) do
-         vim.cmd('autocmd gitsigns_blame ' .. events .. ' * lua require("gitsigns.current_line_blame").' .. func .. '()')
-      end
-   end
+
+   vim.cmd('autocmd gitsigns_blame CursorMoved,CursorMovedI * lua require("gitsigns.current_line_blame").cursor_moved()')
 end
 
 return M

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -37,7 +37,7 @@ local record M
     current_line_blame: boolean
     current_line_blame_formatter: function(string, {string:any}): string
     current_line_blame_position: string
-    current_line_blame_delay: number
+    current_line_blame_delay: integer
     preview_config: {string:any}
     attach_to_untracked: boolean
     use_internal_diff: boolean

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -37,6 +37,7 @@ local record M
     current_line_blame: boolean
     current_line_blame_formatter: function(string, {string:any}): string
     current_line_blame_position: string
+    current_line_blame_delay: number
     preview_config: {string:any}
     attach_to_untracked: boolean
     use_internal_diff: boolean
@@ -430,6 +431,14 @@ M.schema = {
       Note that the keys map onto the output of: >
         git blame --line-porcelain
 <
+    ]]
+  },
+
+  current_line_blame_delay = {
+    type = 'number',
+    default = 1000,
+    description = [[
+      Sets the delay before blame virtual text is displayed in milliseconds.
     ]]
   },
 

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -12,10 +12,27 @@ local current_buf = api.nvim_get_current_buf
 
 local namespace = api.nvim_create_namespace('gitsigns_blame')
 
+local timer = vim.loop.new_timer()
+
 local record M
   reset: function
   run: function
   setup: function()
+  cursor_moved: function()
+end
+
+M.cursor_moved = function()
+  M.reset()
+
+  timer:start(
+    config.current_line_blame_delay,
+    0,
+    vim.schedule_wrap(
+      function()
+        M.run()
+      end
+    )
+  )
 end
 
 M.reset = function(bufnr: integer)
@@ -49,14 +66,8 @@ M.setup = function()
   for k, _ in pairs(cache as {any:any}) do
     M.reset(k)
   end
-  if config.current_line_blame then
-    for func, events in pairs{
-      run   = 'CursorHold',
-      reset = 'CursorMoved',
-    } do
-      vim.cmd('autocmd gitsigns_blame '..events..' * lua require("gitsigns.current_line_blame").'..func..'()')
-    end
-  end
+
+  vim.cmd('autocmd gitsigns_blame CursorMoved,CursorMovedI * lua require("gitsigns.current_line_blame").cursor_moved()')
 end
 
 return M

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -2,6 +2,7 @@ local a = require('plenary.async_lib.async')
 local await      = a.await
 local async_void = a.async_void
 local scheduler  = a.scheduler
+local wrap       = a.wrap
 
 local cache  = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
@@ -16,31 +17,24 @@ local timer = vim.loop.new_timer()
 
 local record M
   reset: function
-  run: function
+  update: function
   setup: function()
-  cursor_moved: function()
 end
 
-M.cursor_moved = function()
-  M.reset()
-
-  timer:start(
-    config.current_line_blame_delay,
-    0,
-    vim.schedule_wrap(
-      function()
-        M.run()
-      end
-    )
-  )
-end
+local wait_timer = wrap(vim.loop.timer_start, 4)
 
 M.reset = function(bufnr: integer)
   bufnr = bufnr or current_buf()
   api.nvim_buf_del_extmark(bufnr, namespace, 1)
 end
 
-M.run = async_void(function()
+M.update = async_void(function()
+  M.reset()
+
+  -- Note because the same timer is re-used, this call has a debouncing effect.
+  await(wait_timer(timer, config.current_line_blame_delay, 0))
+  await(scheduler())
+
   local bufnr = current_buf()
   local bcache = cache[bufnr]
   if not bcache or not bcache.git_obj.object_name then
@@ -63,11 +57,12 @@ end)
 
 M.setup = function()
   vim.cmd('augroup gitsigns_blame | autocmd! | augroup END')
-  for k, _ in pairs(cache as {any:any}) do
+  for k, _ in pairs(cache as {integer:any}) do
     M.reset(k)
   end
 
-  vim.cmd('autocmd gitsigns_blame CursorMoved,CursorMovedI * lua require("gitsigns.current_line_blame").cursor_moved()')
+  vim.cmd('autocmd gitsigns_blame CursorMoved,CursorMovedI * lua require("gitsigns.current_line_blame").update()')
+  M.update()
 end
 
 return M

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -213,6 +213,7 @@ global record vim
       get_due_in: function(Timer): number
     end
     new_timer: function(): Timer
+    timer_start: function(Timer, integer, integer, function()): integer | string
 
     new_fs_event: function()
 


### PR DESCRIPTION
Use a custom timer instead of relying on CursorHold to detach the blame virtial text from `updatetime`.