### PR TITLE
Fixed race condition in git rev-parse

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -2,6 +2,7 @@ local a = require('plenary.async_lib.async')
 local JobSpec = require('plenary.job').JobSpec
 local await = a.await
 local async = a.async
+local scheduler = a.scheduler
 
 local gsd = require("gitsigns.debug")
 local util = require('gitsigns.util')
@@ -163,6 +164,10 @@ local get_repo_info = async(function(path, cmd)
 
    local has_abs_gd = check_version({ 2, 13 })
    local git_dir_opt = has_abs_gd and '--absolute-git-dir' or '--git-dir'
+
+
+
+   await(scheduler())
 
    local results = await(command({
       'rev-parse', '--show-toplevel', git_dir_opt, '--abbrev-ref', 'HEAD',

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -2,6 +2,7 @@ local a = require('plenary.async_lib.async')
 local JobSpec = require('plenary.job').JobSpec
 local await = a.await
 local async = a.async
+local scheduler = a.scheduler
 
 local gsd = require("gitsigns.debug")
 local util = require('gitsigns.util')
@@ -163,6 +164,10 @@ local get_repo_info = async(function(path: string, cmd: string): string,string,s
   --   https://public-inbox.org/git/20170203024829.8071-16-szeder.dev@gmail.com/
   local has_abs_gd = check_version{2,13}
   local git_dir_opt = has_abs_gd and '--absolute-git-dir' or '--git-dir'
+
+  -- Wait for internal scheduler to settle before running command
+  --   https://github.com/lewis6991/gitsigns.nvim/pull/215
+  await(scheduler())
 
   local results = await(command({
     'rev-parse', '--show-toplevel', git_dir_opt, '--abbrev-ref', 'HEAD',


### PR DESCRIPTION
In #212 I was having some issues with getting line blame working, and from some discussions there you pointed me to #205.

And @benatouba is on to something there. This is definitely something to do with the async of things.

After lots of frustration trying to get to the bottom of this I decided to apply this small change, and now it just seems to work, somewhat to my amazement.

I'm not 100% sure why this fixes things, but it does seem to be a race condition that maybe cancels out the job capture ? Because the problem was that stdout was not being captured (the exit code was 0 so technically everything ran fine).

*PS* Also, I'm very new to the neovim (Lua) API, ecosystem and plenary as well as this plugin so this might work, but maybe not the right solution :D