### PR TITLE
Rework testsuite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,6 @@ export PJ_ROOT=$(PWD)
 
 FILTER=.*
 
-BUSTED_ARGS = \
-    --lpath=$(PJ_ROOT)/lua/?.lua \
-    --lpath=$(PJ_ROOT)/plenary.nvim/lua/?.lua \
-    --lpath=$(PJ_ROOT)/plenary.nvim/lua/?/init.lua \
-    --filter=$(FILTER)
-
-TEST_FILE = $(PJ_ROOT)/test/gitsigns_spec.lua
-
 INIT_LUAROCKS := eval $$(luarocks --lua-version=5.1 path) &&
 
 .DEFAULT_GOAL := build
@@ -22,12 +14,24 @@ neovim:
 plenary.nvim:
 	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim
 
+export VIMRUNTIME=$(PWD)/neovim/runtime
+
 .PHONY: test
 test: neovim plenary.nvim
-	make -C neovim functionaltest \
-		CMAKE_BUILD_TYPE=Release \
-		BUSTED_ARGS="$(BUSTED_ARGS)" \
-		TEST_FILE="$(TEST_FILE)"
+	$(INIT_LUAROCKS) neovim/.deps/usr/bin/busted \
+		-v \
+		--lazy \
+		--helper=$(PWD)/test/preload.lua \
+		--output test.busted.outputHandlers.nvim \
+		--lpath=$(PWD)/neovim/?.lua \
+		--lpath=$(PWD)/neovim/build/?.lua \
+		--lpath=$(PWD)/neovim/runtime/lua/?.lua \
+		--lpath=$(PWD)/?.lua \
+		--lpath=$(PWD)/lua/?.lua \
+		--lpath=$(PWD)/plenary.nvim/lua/?.lua \
+		--lpath=$(PWD)/plenary.nvim/lua/?/init.lua \
+		--filter=$(FILTER) \
+		$(PWD)/test
 	-@stty sane
 
 .PHONY: tl-check

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -140,6 +140,7 @@ M.stage_hunk = mk_repeatable(void(function(range)
    for lnum, _ in pairs(hunk_signs) do
       signs.remove(bufnr, lnum)
    end
+   a.void(manager.update)(bufnr)
 end))
 
 M.reset_hunk = mk_repeatable(function(range)
@@ -206,6 +207,7 @@ M.undo_stage_hunk = mk_repeatable(void(function()
    bcache.compare_text = nil
    scheduler()
    signs.add(config, bufnr, gs_hunks.process_hunks({ hunk }))
+   manager.update(bufnr)
 end))
 
 M.stage_buffer = void(function()
@@ -261,6 +263,7 @@ M.reset_buffer_index = void(function()
 
    scheduler()
    signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
+   a.void(manager.update)(bufnr)
 end)
 
 local function nav_hunk(options)

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -391,7 +391,7 @@ end
 Obj.stage_hunks = function(self, hunks, invert)
    self:ensure_file_in_index()
    self:command({
-      'apply', '--cached', '--unidiff-zero', '-',
+      'apply', '--whitespace=nowarn', '--cached', '--unidiff-zero', '-',
    }, {
       writer = gs_hunks.create_patch(self.relpath, hunks, self.mode_bits, invert),
    })

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -140,6 +140,7 @@ M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
   for lnum, _ in pairs(hunk_signs) do
     signs.remove(bufnr, lnum)
   end
+  a.void(manager.update)(bufnr)
 end))
 
 M.reset_hunk = mk_repeatable(function(range: {integer, integer})
@@ -206,6 +207,7 @@ M.undo_stage_hunk = mk_repeatable(void(function()
   bcache.compare_text = nil -- Invalidate
   scheduler()
   signs.add(config, bufnr, gs_hunks.process_hunks({hunk}))
+  manager.update(bufnr)
 end))
 
 M.stage_buffer = void(function()
@@ -261,6 +263,7 @@ M.reset_buffer_index = void(function()
 
   scheduler()
   signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
+  a.void(manager.update)(bufnr)
 end)
 
 local function nav_hunk(options: NavHunkOpts)

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -391,7 +391,7 @@ end
 Obj.stage_hunks = function(self: Obj, hunks: {Hunk}, invert: boolean)
   self:ensure_file_in_index()
   self:command({
-    'apply', '--cached', '--unidiff-zero', '-'
+    'apply', '--whitespace=nowarn', '--cached', '--unidiff-zero', '-'
   }, {
     writer = gs_hunks.create_patch(self.relpath, hunks, self.mode_bits, invert)
   })

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -1,0 +1,218 @@
+local helpers = require('test.functional.helpers')(nil)
+
+local system   = helpers.funcs.system
+local exec_lua = helpers.exec_lua
+local matches  = helpers.matches
+local exec_capture = helpers.exec_capture
+local eq       = helpers.eq
+
+local timeout = 4000
+
+local M = helpers
+
+M.scratch   = os.getenv('PJ_ROOT')..'/scratch'
+M.gitdir    = M.scratch..'/.git'
+M.test_file = M.scratch..'/dummy.txt'
+M.newfile   = M.scratch.."/newfile.txt"
+
+M.test_config = {
+  debug_mode = true,
+  signs = {
+    add          = {hl = 'DiffAdd'   , text = '+'},
+    delete       = {hl = 'DiffDelete', text = '_'},
+    change       = {hl = 'DiffChange', text = '~'},
+    topdelete    = {hl = 'DiffDelete', text = '^'},
+    changedelete = {hl = 'DiffChange', text = '%'},
+  },
+  keymaps = {
+    noremap = true,
+    buffer = true,
+    ['n mhs'] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
+    ['n mhu'] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
+    ['n mhr'] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
+    ['n mhp'] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
+    ['n mhS'] = '<cmd>lua require"gitsigns".stage_buffer()<CR>',
+    ['n mhU'] = '<cmd>lua require"gitsigns".reset_buffer_index()<CR>',
+  },
+  update_debounce = 5,
+}
+
+local test_file_text = {
+  'This', 'is', 'a', 'file', 'used', 'for', 'testing', 'gitsigns.', 'The',
+  'content', 'doesn\'t', 'matter,', 'it', 'just', 'needs', 'to', 'be', 'static.'
+}
+
+function M.git(args)
+  system{"git", "-C", M.scratch, unpack(args)}
+end
+
+function M.cleanup()
+  system{"rm", "-rf", M.scratch}
+end
+
+
+function M.setup_git()
+  M.git{"init"}
+
+  -- Always force color to test settings don't interfere with gitsigns systems
+  -- commands (addresses #23)
+  M.git{'config', 'color.branch'     , 'always'}
+  M.git{'config', 'color.ui'         , 'always'}
+  M.git{'config', 'color.diff'       , 'always'}
+  M.git{'config', 'color.interactive', 'always'}
+  M.git{'config', 'color.status'     , 'always'}
+  M.git{'config', 'color.grep'       , 'always'}
+  M.git{'config', 'color.pager'      , 'true'}
+  M.git{'config', 'color.decorate'   , 'always'}
+  M.git{'config', 'color.showbranch' , 'always'}
+
+  M.git{'config', 'user.email', 'tester@com.com'}
+  M.git{'config', 'user.name' , 'tester'}
+
+  M.git{'config', 'init.defaultBranch', 'master'}
+end
+
+function M.init(no_add)
+  M.cleanup()
+  system{"mkdir", M.scratch}
+  M.setup_git()
+  system{"touch", M.test_file}
+  M.write_to_file(M.test_file, test_file_text)
+  if not no_add then
+    M.git{"add", M.test_file}
+    M.git{"commit", "-m", "init commit"}
+  end
+end
+
+function M.wait(cond)
+  local duration = 0
+  local interval = 5
+  while duration < timeout do
+    if pcall(cond) then
+      return
+    end
+    duration = duration + interval
+    helpers.sleep(interval)
+    interval = interval * 2
+  end
+  cond()
+end
+
+function M.command_fmt(str, ...)
+  helpers.command(str:format(...))
+end
+
+function M.edit(path)
+  M.command_fmt("edit %s", path)
+end
+
+function M.write_to_file(path, text)
+  local f = io.open(path, 'wb')
+  for _, l in ipairs(text) do
+    f:write(l)
+    f:write('\n')
+  end
+  f:close()
+end
+
+function M.match_lines(lines, spec)
+  local i = 1
+  for lid, line in ipairs(lines) do
+    if line ~= '' then
+      local s = spec[i]
+      if s then
+        if s.pattern then
+          matches(s.text, line)
+        else
+          eq(s, line)
+        end
+      else
+        local extra = {}
+        for j=lid,#lines do
+          table.insert(extra, lines[j])
+        end
+        error('Unexpected extra text:\n    '..table.concat(extra, '\n    '))
+      end
+      i = i + 1
+    end
+  end
+  if i < #spec + 1 then
+    -- print('Lines:')
+    -- for _, l in ipairs(lines) do
+    --   print(string.format(   '"%s"', l))
+    -- end
+    error(('Did not match pattern \'%s\''):format(spec[i]))
+  end
+end
+
+local function match_lines2(lines, spec)
+  local i = 1
+  for _, line in ipairs(lines) do
+    if line ~= '' then
+      local s = spec[i]
+      if s then
+        if s.pattern then
+          if string.match(line, s.text) then
+            i = i + 1
+          end
+        elseif s.next then
+          eq(s.text, line)
+          i = i + 1
+        else
+          if s == line then
+            i = i + 1
+          end
+        end
+      end
+    end
+  end
+
+  if i < #spec + 1 then
+    local unmatched = {}
+    for j = i, #spec do
+      table.insert(unmatched, spec[j].text or spec[j])
+    end
+    error(('Did not match patterns:\n    - %s'):format(table.concat(unmatched, '\n    - ')))
+  end
+end
+
+function M.p(str)
+  return {text=str, pattern=true}
+end
+
+function M.n(str)
+  return {text=str, next=true}
+end
+
+function M.debug_messages()
+  return exec_lua("return require'gitsigns'.debug_messages(true)")
+end
+
+function M.match_dag(lines, spec)
+  for _, s in ipairs(spec) do
+    match_lines2(lines, {s})
+  end
+end
+
+function M.match_debug_messages(spec)
+  M.wait(function()
+    M.match_lines(M.debug_messages(), spec)
+  end)
+end
+
+function M.setup(config)
+  exec_lua([[require('gitsigns').setup(...)]], config)
+  M.wait(function()
+    exec_capture('au gitsigns')
+  end)
+end
+
+local id = 0
+M.it = function(it)
+  return function(name, test)
+    id = id+1
+    return it(name..' #'..id, test)
+  end
+end
+
+return M

--- a/test/highlights_spec.lua
+++ b/test/highlights_spec.lua
@@ -1,0 +1,133 @@
+local Screen = require('test.functional.ui.screen')
+local helpers = require('test.gs_helpers')
+
+local clear         = helpers.clear
+local exec_lua      = helpers.exec_lua
+local command       = helpers.command
+local eq            = helpers.eq
+local exec_capture  = helpers.exec_capture
+
+local cleanup       = helpers.cleanup
+local test_config   = helpers.test_config
+local wait          = helpers.wait
+local match_dag     = helpers.match_dag
+local debug_messages = helpers.debug_messages
+local p             = helpers.p
+local setup         = helpers.setup
+
+local it = helpers.it(it)
+
+describe('highlights', function()
+  local screen
+  local config
+
+  before_each(function()
+    clear()
+    screen = Screen.new(20, 17)
+    screen:attach()
+
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray};
+      [2] = {background = Screen.colors.LightMagenta};
+      [3] = {background = Screen.colors.LightBlue};
+      [4] = {background = Screen.colors.LightCyan1, bold = true, foreground = Screen.colors.Blue1};
+      [5] = {foreground = Screen.colors.Brown};
+      [6] = {foreground = Screen.colors.Blue1, bold = true};
+      [7] = {bold = true},
+      [8] = {foreground = Screen.colors.White, background = Screen.colors.Red};
+      [9] = {foreground = Screen.colors.SeaGreen, bold = true};
+    })
+
+    -- Make gitisigns available
+    exec_lua('package.path = ...', package.path)
+    exec_lua('gs = require("gitsigns")')
+    config = helpers.deepcopy(test_config)
+  end)
+
+  after_each(function()
+    cleanup()
+    screen:detach()
+  end)
+  it('get set up correctly', function()
+    command("set termguicolors")
+
+    config.signs.add.hl = nil
+    config.signs.change.hl = nil
+    config.signs.delete.hl = nil
+    config.signs.changedelete.hl = nil
+    config.signs.topdelete.hl = nil
+    config.numhl = true
+    config.linehl = true
+
+    exec_lua('gs.setup(...)', config)
+
+    wait(function()
+      match_dag(debug_messages(), {
+        p'Deriving GitSignsChangeNr from GitSignsChange',
+        p'Deriving GitSignsChangeLn from GitSignsChange',
+        p'Deriving GitSignsDelete from DiffDelete',
+        p'Deriving GitSignsDeleteNr from GitSignsDelete',
+        p'Deriving GitSignsDeleteLn from GitSignsDelete',
+        p'Deriving GitSignsAdd from DiffAdd',
+        p'Deriving GitSignsAddNr from GitSignsAdd',
+        p'Deriving GitSignsAddLn from GitSignsAdd',
+        p'Deriving GitSignsDeleteNr from GitSignsDelete',
+        p'Deriving GitSignsDeleteLn from GitSignsDelete',
+        p'Deriving GitSignsChangeNr from GitSignsChange',
+        p'Deriving GitSignsChangeLn from GitSignsChange'
+      })
+    end)
+
+    eq('GitSignsChange xxx gui=reverse guibg=#ffbbff',
+      exec_capture('hi GitSignsChange'))
+
+    eq('GitSignsDelete xxx gui=reverse guifg=#0000ff guibg=#e0ffff',
+      exec_capture('hi GitSignsDelete'))
+
+    eq('GitSignsAdd    xxx gui=reverse guibg=#add8e6',
+      exec_capture('hi GitSignsAdd'))
+  end)
+
+  it('update when colorscheme changes', function()
+    command("set termguicolors")
+
+    config.signs.add.hl = nil
+    config.signs.change.hl = nil
+    config.signs.delete.hl = nil
+    config.signs.changedelete.hl = nil
+    config.signs.topdelete.hl = nil
+    config.linehl = true
+
+    setup(config)
+
+    wait(function()
+      eq('GitSignsChange xxx gui=reverse guibg=#ffbbff',
+        exec_capture('hi GitSignsChange'))
+
+      eq('GitSignsDelete xxx gui=reverse guifg=#0000ff guibg=#e0ffff',
+        exec_capture('hi GitSignsDelete'))
+
+      eq('GitSignsAdd    xxx gui=reverse guibg=#add8e6',
+        exec_capture('hi GitSignsAdd'))
+
+      eq('GitSignsAddLn  xxx gui=reverse guibg=#add8e6',
+        exec_capture('hi GitSignsAddLn'))
+    end)
+
+    command('colorscheme blue')
+
+    wait(function()
+      eq('GitSignsChange xxx gui=reverse guifg=#000000 guibg=#006400',
+        exec_capture('hi GitSignsChange'))
+
+      eq('GitSignsDelete xxx gui=reverse guifg=#000000 guibg=#ff7f50',
+        exec_capture('hi GitSignsDelete'))
+
+      eq('GitSignsAdd    xxx gui=reverse guifg=#000000 guibg=#6a5acd',
+        exec_capture('hi GitSignsAdd'))
+
+      eq('GitSignsAddLn  xxx gui=reverse guifg=#000000 guibg=#6a5acd',
+        exec_capture('hi GitSignsAddLn'))
+    end)
+  end)
+end)

--- a/test/preload.lua
+++ b/test/preload.lua
@@ -1,0 +1,12 @@
+-- Modules loaded here will not be cleared and reloaded by Busted.
+-- Busted started doing this to help provide more isolation.
+local global_helpers = require('test.helpers')
+
+-- Bypoass CI behaviour logic
+global_helpers.isCI = function(_)
+  return false
+end
+
+local helpers = require('test.functional.helpers')(nil)
+local gs_helpers = require('test.gs_helpers')
+


### PR DESCRIPTION
- Make tests more asyn friendly and remove most of the magic sleeps
- Break up into multiple files
- Bypass cmake and call busted directly
