### PR TITLE
fix(highlight): use `:highlight default link`

### DIFF
--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -66,7 +66,7 @@ M.setup_highlight = function(hl_name)
    for _, d in ipairs(hls[hl_name]) do
       if is_hl_set(d) then
          dprint(('Deriving %s from %s'):format(hl_name, d))
-         local hl_cmd = ('highlight link %s %s'):format(hl_name, d)
+         local hl_cmd = ('highlight default link %s %s'):format(hl_name, d)
 
 
          if vim.v.vim_did_enter == 1 then

--- a/teal/gitsigns/highlight.tl
+++ b/teal/gitsigns/highlight.tl
@@ -66,7 +66,7 @@ M.setup_highlight = function(hl_name: string)
   for _, d in ipairs(hls[hl_name as GitSignHl]) do
     if is_hl_set(d) then
       dprint(('Deriving %s from %s'):format(hl_name, d))
-      local hl_cmd = ('highlight link %s %s'):format(hl_name, d)
+      local hl_cmd = ('highlight default link %s %s'):format(hl_name, d)
       -- Run highlight commands in an autocmd so they are run after any `syntax
       -- clear` commands triggered by colorschemes.
       if vim.v.vim_did_enter == 1 then


### PR DESCRIPTION
Before this commit, the `:highlight link` commands would override
highlight links applied by colorschemes on startup. Now that the
`default` argument is given, the command will respect existing settings,
even if they are links.

See |:hi-default| for more.