### PR TITLE
Fix missing commit description if there's no empty line after title

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -382,25 +382,21 @@ M.blame_line = void(function(full)
 
    local is_committed = tonumber('0x' .. result.sha) ~= 0
    if is_committed then
-      local body = {}
+      local commit_message = {}
       if full then
-         body = bcache.git_obj:command({ 'show', '-s', '--format=%b', result.sha })
-
-         while body[#body] == '' do
-            body[#body] = nil
+         commit_message = bcache.git_obj:command({ 'show', '-s', '--format=%B', result.sha })
+         while commit_message[#commit_message] == '' do
+            commit_message[#commit_message] = nil
          end
-
-         if #body > 0 then
-            body = { '', unpack(body) }
-         end
+      else
+         commit_message = { result.summary }
       end
 
       local date = os.date('%Y-%m-%d %H:%M', tonumber(result['author_time']))
 
       local lines = {
          ('%s %s (%s):'):format(result.abbrev_sha, result.author, date),
-         result.summary,
-         unpack(body),
+         unpack(commit_message),
       }
 
       scheduler()

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -382,25 +382,21 @@ M.blame_line = void(function(full: boolean)
 
   local is_committed = tonumber('0x'..result.sha) ~= 0
   if is_committed then
-    local body = {}
+    local commit_message = {}
     if full then
-      body = bcache.git_obj:command({'show', '-s', '--format=%b', result.sha})
-
-      while body[#body] == '' do
-        body[#body] = nil
-      end
-
-      if #body > 0 then
-        body = {'', unpack(body)}
-      end
+       commit_message = bcache.git_obj:command({ 'show', '-s', '--format=%B', result.sha })
+       while commit_message[#commit_message] == '' do
+          commit_message[#commit_message] = nil
+       end
+    else
+       commit_message = {result.summary}
     end
 
     local date = os.date('%Y-%m-%d %H:%M', tonumber(result['author_time']))
 
     local lines = {
       ('%s %s (%s):'):format(result.abbrev_sha, result.author, date),
-      result.summary,
-      unpack(body)
+      unpack(commit_message)
     }
 
     scheduler()


### PR DESCRIPTION
All the lines in the beginning of a commit message with no gaps between them are treated by git as a multiline title.

For example:
```
Title
Also title

Description
```

Currently, if you call `lua require('gitsigns').blame_line(true)` it will show you
```
Title

Description
```
because [`result.summary`](https://github.com/lewis6991/gitsigns.nvim/blob/9940d8bef15e2050fbe27e6cfdfdd8dc64e3593c/lua/gitsigns/actions.lua#L402) stores only the first line of a title.

My solution is to get the whole commit message, rather than concatenating commit's description with its summary.