### PR TITLE
Don't require in a luv callback

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -194,9 +194,7 @@ local update0 = function(bufnr, bcache)
 
    local compare_object = bcache.get_compare_obj(bcache)
 
-   if not bcache.compare_text or config._refresh_staged_on_update then
-      bcache.compare_text = git_obj:get_show_text(compare_object)
-   end
+
 
    local run_diff
    if config.use_internal_diff then
@@ -204,6 +202,11 @@ local update0 = function(bufnr, bcache)
    else
       run_diff = require('gitsigns.diff_ext').run_diff
    end
+
+   if not bcache.compare_text or config._refresh_staged_on_update then
+      bcache.compare_text = git_obj:get_show_text(compare_object)
+   end
+
    bcache.hunks = run_diff(bcache.compare_text, buftext, config.diff_algorithm)
    bcache.pending_signs = gs_hunks.process_hunks(bcache.hunks)
 

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -194,16 +194,19 @@ local update0 = function(bufnr: integer, bcache: CacheEntry)
 
   local compare_object = bcache.get_compare_obj(bcache)
 
-  if not bcache.compare_text or config._refresh_staged_on_update then
-    bcache.compare_text = git_obj:get_show_text(compare_object)
-  end
-
+  -- Make sure these requires are done in the main event.
+  -- See https://github.com/neovim/neovim/issues/15147
   local run_diff: function({string}, {string}, string): {Hunk}
   if config.use_internal_diff then
     run_diff = require('gitsigns.diff_ffi').run_diff
   else
     run_diff = require('gitsigns.diff_ext').run_diff
   end
+
+  if not bcache.compare_text or config._refresh_staged_on_update then
+    bcache.compare_text = git_obj:get_show_text(compare_object)
+  end
+
   bcache.hunks = run_diff(bcache.compare_text, buftext, config.diff_algorithm)
   bcache.pending_signs = gs_hunks.process_hunks(bcache.hunks)
 


### PR DESCRIPTION
See: https://github.com/neovim/neovim/issues/15147

> require invokes nvim_get_runtime_file which is marked as FAST. however
> as part as its implementation it uses regexes which can invoke
> os_breakcheck which must not be done in FAST functions.

Fixes #272
