### PR TITLE
async: require plenary.async -> plenary.async.async

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -1,6 +1,5 @@
-local a = require('plenary.async')
-local void = a.void
-local scheduler = a.util.scheduler
+local void = require('plenary.async.async').void
+local scheduler = require('plenary.async.util').scheduler
 
 local Status = require("gitsigns.status")
 local git = require('gitsigns.git')

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -1,6 +1,5 @@
-local a = require('plenary.async')
-local void = a.void
-local scheduler = a.util.scheduler
+local void = require('plenary.async.async').void
+local scheduler = require('plenary.async.util').scheduler
 
 local Status = require("gitsigns.status")
 local config = require('gitsigns.config').config
@@ -145,7 +144,7 @@ M.stage_hunk = mk_repeatable(void(function(range)
    for lnum, _ in pairs(hunk_signs) do
       signs.remove(bufnr, lnum)
    end
-   a.void(manager.update)(bufnr)
+   void(manager.update)(bufnr)
 end))
 
 M.reset_hunk = mk_repeatable(function(range)
@@ -268,7 +267,7 @@ M.reset_buffer_index = void(function()
 
    scheduler()
    signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
-   a.void(manager.update)(bufnr)
+   void(manager.update)(bufnr)
 end)
 
 local function nav_hunk(options)
@@ -457,7 +456,7 @@ M.change_base = function(base)
    base = calc_base(base)
    bcache.base = base
    bcache.compare_text = nil
-   a.void(manager.update)(buf, bcache)
+   void(manager.update)(buf, bcache)
 end
 
 M.diffthis = void(function(base)

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -1,7 +1,7 @@
-local a = require('plenary.async')
+local a = require('plenary.async.async')
 local wrap = a.wrap
 local void = a.void
-local scheduler = a.util.scheduler
+local scheduler = require('plenary.async.util').scheduler
 
 local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config

--- a/lua/gitsigns/diff_ext.lua
+++ b/lua/gitsigns/diff_ext.lua
@@ -3,7 +3,7 @@ local git = require('gitsigns.git')
 local gs_hunks = require("gitsigns.hunks")
 local Hunk = gs_hunks.Hunk
 local util = require('gitsigns.util')
-local a = require('plenary.async')
+local scheduler = require('plenary.async.util').scheduler
 
 local M = {}
 
@@ -31,7 +31,7 @@ M.run_diff = function(
 
    if not util.is_unix then
 
-      a.util.scheduler()
+      scheduler()
    end
 
    local file_buf = util.tmpname() .. '_buf'

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -1,4 +1,5 @@
-local a = require('plenary.async')
+local wrap = require('plenary.async.async').wrap
+local scheduler = require('plenary.async.util').scheduler
 local JobSpec = require('plenary.job').JobSpec
 
 local gsd = require("gitsigns.debug")
@@ -117,7 +118,7 @@ local function check_version(version)
    return true
 end
 
-M.command = a.wrap(function(args, spec, callback)
+M.command = wrap(function(args, spec, callback)
    local result = {}
    local reserr
    spec = spec or {}
@@ -174,7 +175,7 @@ local get_repo_info = function(path, cmd)
 
 
 
-   a.util.scheduler()
+   scheduler()
 
    local results = M.command({
       'rev-parse', '--show-toplevel', git_dir_opt, '--abbrev-ref', 'HEAD',

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -1,7 +1,6 @@
-local a = require('plenary.async')
-local void = a.void
-local scheduler = a.util.scheduler
-local sleep = a.util.sleep
+local void = require('plenary.async.async').void
+local async_util = require('plenary.async.util')
+local scheduler = async_util.scheduler
 
 local gs_cache = require('gitsigns.cache')
 local CacheEntry = gs_cache.CacheEntry
@@ -244,7 +243,7 @@ do
       else
 
          while running do
-            sleep(100)
+            async_util.sleep(100)
          end
       end
    end

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -1,6 +1,5 @@
-local a = require('plenary.async')
-local void      = a.void
-local scheduler = a.util.scheduler
+local void = require('plenary.async.async').void
+local scheduler = require('plenary.async.util').scheduler
 
 local Status     = require("gitsigns.status")
 local git        = require('gitsigns.git')

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -1,6 +1,5 @@
-local a = require('plenary.async')
-local void      = a.void
-local scheduler = a.util.scheduler
+local void      = require('plenary.async.async').void
+local scheduler = require('plenary.async.util').scheduler
 
 local Status        = require("gitsigns.status")
 local config        = require('gitsigns.config').config
@@ -145,7 +144,7 @@ M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
   for lnum, _ in pairs(hunk_signs) do
     signs.remove(bufnr, lnum)
   end
-  a.void(manager.update)(bufnr)
+  void(manager.update)(bufnr)
 end))
 
 M.reset_hunk = mk_repeatable(function(range: {integer, integer})
@@ -268,7 +267,7 @@ M.reset_buffer_index = void(function()
 
   scheduler()
   signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
-  a.void(manager.update)(bufnr)
+  void(manager.update)(bufnr)
 end)
 
 local function nav_hunk(options: NavHunkOpts)
@@ -457,7 +456,7 @@ M.change_base = function(base: string)
   base = calc_base(base)
   bcache.base = base
   bcache.compare_text = nil
-  a.void(manager.update)(buf, bcache)
+  void(manager.update)(buf, bcache)
 end
 
 M.diffthis = void(function(base: string)

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -1,7 +1,7 @@
-local a = require('plenary.async')
+local a = require('plenary.async.async')
 local wrap      = a.wrap
 local void      = a.void
-local scheduler = a.util.scheduler
+local scheduler = require('plenary.async.util').scheduler
 
 local cache  = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config

--- a/teal/gitsigns/diff_ext.tl
+++ b/teal/gitsigns/diff_ext.tl
@@ -3,7 +3,7 @@ local git = require('gitsigns.git')
 local gs_hunks = require("gitsigns.hunks")
 local Hunk = gs_hunks.Hunk
 local util = require('gitsigns.util')
-local a = require('plenary.async')
+local scheduler = require('plenary.async.util').scheduler
 
 local record M
   -- Async function
@@ -31,7 +31,7 @@ M.run_diff = function(
 
   if not util.is_unix then
     -- tmpname must not be called in a callback on windows
-    a.util.scheduler()
+    scheduler()
   end
 
   local file_buf = util.tmpname()..'_buf'

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -1,4 +1,5 @@
-local a = require('plenary.async')
+local wrap = require('plenary.async.async').wrap
+local scheduler = require('plenary.async.util').scheduler
 local JobSpec = require('plenary.job').JobSpec
 
 local gsd = require("gitsigns.debug")
@@ -117,7 +118,7 @@ local function check_version(version: {number,number,number}): boolean
   return true
 end
 
-M.command = a.wrap(function(args: {string}, spec: GJobSpec, callback: function({string}, string))
+M.command = wrap(function(args: {string}, spec: GJobSpec, callback: function({string}, string))
   local result: {string} = {}
   local reserr: string
   spec = spec or {}
@@ -174,7 +175,7 @@ local get_repo_info = function(path: string, cmd: string): string,string,string
 
   -- Wait for internal scheduler to settle before running command
   --   https://github.com/lewis6991/gitsigns.nvim/pull/215
-  a.util.scheduler()
+  scheduler()
 
   local results = M.command({
     'rev-parse', '--show-toplevel', git_dir_opt, '--abbrev-ref', 'HEAD',

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -1,7 +1,6 @@
-local a = require('plenary.async')
-local void      = a.void
-local scheduler = a.util.scheduler
-local sleep     = a.util.sleep
+local void = require('plenary.async.async').void
+local async_util = require('plenary.async.util')
+local scheduler = async_util.scheduler
 
 local gs_cache = require('gitsigns.cache')
 local CacheEntry = gs_cache.CacheEntry
@@ -244,7 +243,7 @@ do
     else
       -- Wait until all updates have finished
       while running do
-        sleep(100)
+        async_util.sleep(100)
       end
     end
   end

--- a/types/plenary/async/async.d.tl
+++ b/types/plenary/async/async.d.tl
@@ -86,11 +86,6 @@ local record Async
 
   void: function(function): function
   run: function(function, function)
-
-  record util
-    sleep: function(integer)
-    scheduler: function()
-  end
 end
 
 return Async

--- a/types/plenary/async/util.d.tl
+++ b/types/plenary/async/util.d.tl
@@ -1,0 +1,7 @@
+
+local record util
+  sleep: function(integer)
+  scheduler: function()
+end
+
+return util


### PR DESCRIPTION
plenary.async requires several modules not used by gitsigns which is
inflating the startup time. Instead just require plenary.async.async.

On an M1 Macbook this appears to half the startup time of gitsigns.
