### PR TITLE
remove use_decoration_api from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ require('gitsigns').setup {
   update_debounce = 100,
   status_formatter = nil, -- Use default
   word_diff = false,
-  use_decoration_api = true,
   use_internal_diff = true,  -- If luajit is present
 }
 ```

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -70,7 +70,6 @@ of the default settings:
       sign_priority = 6,
       update_debounce = 100,
       status_formatter = nil, -- Use default
-      use_decoration_api = true,
       use_internal_diff = true,  -- If luajit is present
     }
 <


### PR DESCRIPTION
I got this warning that `use_decoration_api` is now removed so I checked here and the option was still on the docs.

Relevant commit on removing the option: https://github.com/lewis6991/gitsigns.nvim/commit/27e1e95e1aa8d4ec0aabbf5148013f58a1bc4b40