### PR TITLE
Rework options for current_line_blame

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -533,6 +533,30 @@ current_line_blame                        *gitsigns-config-current_line_blame*
 
       The highlight group used for the text is `GitSignsCurrentLineBlame`.
 
+current_line_blame_opts              *gitsigns-config-current_line_blame_opts*
+      Type: `table[extended]`
+      Default: >
+        {
+          virt_text = true,
+          virt_text_pos = 'eol',
+          delay = 1000
+        }
+<
+      Options for the current line blame annotation.
+
+      Fields: ~
+        • virt_text: boolean
+          Whether to show a virtual text blame annotation.
+        • virt_text_delat: integer
+          Sets the delay (in milliseconds) before blame virtual text is
+          displayed.
+        • virt_text_pos: string
+          Blame annotation position. Available values:
+            `eol`         Right after eol character.
+            `overlay`     Display over the specified column, without
+                          shifting the underlying text.
+            `right_align` Display right aligned in the window.
+
 current_line_blame_formatter_opts
                            *gitsigns-config-current_line_blame_formatter_opts*
       Type: `table[extended]`
@@ -545,17 +569,6 @@ current_line_blame_formatter_opts
 
       Fields: ~
         • relative_time: boolean
-
-current_line_blame_position      *gitsigns-config-current_line_blame_position*
-      Type: `string`, Default: `"eol"`
-
-        Blame annotation position.
-
-        Available values:
-          `eol`         Right after eol character.
-          `overlay`     Display over the specified column, without shifting
-                      the underlying text.
-          `right_align` Display right aligned in the window.
 
 current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
       Type: `function`
@@ -613,11 +626,6 @@ current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
       Return: ~
         The result of this function is passed directly to the `opts.virt_text`
         field of |nvim_buf_set_extmark|.
-
-current_line_blame_delay            *gitsigns-config-current_line_blame_delay*
-      Type: `number`, Default: `1000`
-
-      Sets the delay before blame virtual text is displayed in milliseconds.
 
 yadm                                                    *gitsigns-config-yadm*
       Type: `table`, Default: `{ enable = false }`
@@ -702,6 +710,11 @@ Example:
                                                              *b:gitsigns_head*
 Use `b:gitsigns_head` to return the name of the current branch. If the current
 HEAD is detached then this will be an empty string.
+
+                                                  *b:gitsigns_blame_line_dict*
+If *gitsigns-config-current_line_blame* is enabled, then contains dictionary
+of the blame object for current line. For complete list of keys, see the
+{blame_info} argument from |gitsigns-config-current_line_blame_formatter|.
 
 ==============================================================================
 TEXT OBJECTS                                             *gitsigns-textobject*

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -6,7 +6,21 @@ local SchemaElem = {}
 
 
 
-local M = {Config = {SignsConfig = {}, watch_index = {}, current_line_blame_formatter_opts = {}, yadm = {}, }, }
+local M = {Config = {SignsConfig = {}, watch_index = {}, current_line_blame_formatter_opts = {}, current_line_blame_opts = {}, yadm = {}, }, }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -363,6 +377,32 @@ M.schema = {
     ]],
    },
 
+   current_line_blame_opts = {
+      type = 'table',
+      deep_extend = true,
+      default = {
+         virt_text = true,
+         virt_text_pos = 'eol',
+         delay = 1000,
+      },
+      description = [[
+      Options for the current line blame annotation.
+
+      Fields: ~
+        • virt_text: boolean
+          Whether to show a virtual text blame annotation.
+        • virt_text_delat: integer
+          Sets the delay (in milliseconds) before blame virtual text is
+          displayed.
+        • virt_text_pos: string
+          Blame annotation position. Available values:
+            `eol`         Right after eol character.
+            `overlay`     Display over the specified column, without
+                          shifting the underlying text.
+            `right_align` Display right aligned in the window.
+    ]],
+   },
+
    current_line_blame_formatter_opts = {
       type = 'table',
       deep_extend = true,
@@ -374,20 +414,6 @@ M.schema = {
 
       Fields: ~
         • relative_time: boolean
-    ]],
-   },
-
-   current_line_blame_position = {
-      type = 'string',
-      default = 'eol',
-      description = [[
-        Blame annotation position.
-
-        Available values:
-          `eol`         Right after eol character.
-          `overlay`     Display over the specified column, without shifting
-                      the underlying text.
-          `right_align` Display right aligned in the window.
     ]],
    },
 
@@ -471,14 +497,6 @@ M.schema = {
     ]],
    },
 
-   current_line_blame_delay = {
-      type = 'number',
-      default = 1000,
-      description = [[
-      Sets the delay before blame virtual text is displayed in milliseconds.
-    ]],
-   },
-
    yadm = {
       type = 'table',
       default = { enable = false },
@@ -553,6 +571,22 @@ local function handle_deprecated(cfg)
    if cfg.use_decoration_api then
       print('Gitsigns: use_decoration_api is now removed; ignoring')
       cfg.use_decoration_api = nil
+   end
+
+   if cfg.current_line_blame_delay then
+      local opts = (cfg.current_line_blame_opts or {})
+      opts.delay = cfg.current_line_blame_delay
+      print('Gitsigns: current_line_blame_delay is deprecated, please use current_line_blame_opts.delay')
+      cfg.current_line_blame_opts = opts
+      cfg.current_line_blame_delay = nil
+   end
+
+   if cfg.current_line_blame_position then
+      local opts = (cfg.current_line_blame_opts or {})
+      opts.virt_text_pos = cfg.current_line_blame_position
+      print('Gitsigns: current_line_blame_opts is deprecated, please use current_line_blame_opts.virt_text_pos')
+      cfg.current_line_blame_opts = opts
+      cfg.current_line_blame_post = nil
    end
 end
 

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -25,13 +25,14 @@ local wait_timer = wrap(vim.loop.timer_start, 4)
 M.reset = function(bufnr)
    bufnr = bufnr or current_buf()
    api.nvim_buf_del_extmark(bufnr, namespace, 1)
+   pcall(api.nvim_buf_del_var, bufnr, 'gitsigns_blame_line_dict')
 end
 
 M.update = void(function()
    M.reset()
 
 
-   wait_timer(timer, config.current_line_blame_delay, 0)
+   wait_timer(timer, config.current_line_blame_opts.delay, 0)
    scheduler()
 
    local bufnr = current_buf()
@@ -47,15 +48,19 @@ M.update = void(function()
    scheduler()
 
    M.reset(bufnr)
-   api.nvim_buf_set_extmark(bufnr, namespace, lnum - 1, 0, {
-      id = 1,
-      virt_text = config.current_line_blame_formatter(
-      bcache.git_obj.username,
-      result,
-      config.current_line_blame_formatter_opts),
 
-      virt_text_pos = config.current_line_blame_position,
-   })
+   api.nvim_buf_set_var(bufnr, 'gitsigns_blame_line_dict', result)
+   if config.current_line_blame_opts.virt_text then
+      api.nvim_buf_set_extmark(bufnr, namespace, lnum - 1, 0, {
+         id = 1,
+         virt_text = config.current_line_blame_formatter(
+         bcache.git_obj.username,
+         result,
+         config.current_line_blame_formatter_opts),
+
+         virt_text_pos = config.current_line_blame_opts.virt_text_pos,
+      })
+   end
 end)
 
 M.setup = function()

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -37,12 +37,26 @@ local record M
     status_formatter: function({string:any}): string
 
     current_line_blame: boolean
-    current_line_blame_formatter: function(string, {string:any}, current_line_blame_formatter_opts): string
+
     record current_line_blame_formatter_opts
-        relative_time: boolean
+      relative_time: boolean
     end
-    current_line_blame_position: string
-    current_line_blame_delay: integer
+
+    current_line_blame_formatter: function(string, {string:any}, current_line_blame_formatter_opts): string
+
+    record current_line_blame_opts
+      virt_text: boolean
+
+      enum VirtTextPos
+        'eol'
+        'overlay'
+        'right_align'
+      end
+      virt_text_pos: VirtTextPos
+
+      delay: integer
+    end
+
     preview_config: {string:any}
     attach_to_untracked: boolean
     use_internal_diff: boolean
@@ -363,6 +377,32 @@ M.schema = {
     ]]
   },
 
+  current_line_blame_opts = {
+    type = 'table',
+    deep_extend = true,
+    default = {
+      virt_text = true,
+      virt_text_pos = 'eol',
+      delay = 1000
+    },
+    description = [[
+      Options for the current line blame annotation.
+
+      Fields: ~
+        • virt_text: boolean
+          Whether to show a virtual text blame annotation.
+        • virt_text_delat: integer
+          Sets the delay (in milliseconds) before blame virtual text is
+          displayed.
+        • virt_text_pos: string
+          Blame annotation position. Available values:
+            `eol`         Right after eol character.
+            `overlay`     Display over the specified column, without
+                          shifting the underlying text.
+            `right_align` Display right aligned in the window.
+    ]]
+  },
+
   current_line_blame_formatter_opts = {
     type = 'table',
     deep_extend = true,
@@ -376,20 +416,6 @@ M.schema = {
         • relative_time: boolean
     ]]
   },
-
-   current_line_blame_position = {
-      type = 'string',
-      default = 'eol',
-      description = [[
-        Blame annotation position.
-
-        Available values:
-          `eol`         Right after eol character.
-          `overlay`     Display over the specified column, without shifting
-                      the underlying text.
-          `right_align` Display right aligned in the window.
-    ]],
-   },
 
   current_line_blame_formatter = {
     type = 'function',
@@ -471,14 +497,6 @@ M.schema = {
     ]]
   },
 
-  current_line_blame_delay = {
-    type = 'number',
-    default = 1000,
-    description = [[
-      Sets the delay before blame virtual text is displayed in milliseconds.
-    ]]
-  },
-
   yadm = {
     type = 'table',
     default = { enable = false },
@@ -553,6 +571,22 @@ local function handle_deprecated(cfg: {string:any})
   if cfg.use_decoration_api then
     print('Gitsigns: use_decoration_api is now removed; ignoring')
     cfg.use_decoration_api = nil
+  end
+
+  if cfg.current_line_blame_delay then
+    local opts = (cfg.current_line_blame_opts or {}) as M.Config.current_line_blame_opts
+    opts.delay = cfg.current_line_blame_delay as integer
+    print('Gitsigns: current_line_blame_delay is deprecated, please use current_line_blame_opts.delay')
+    cfg.current_line_blame_opts = opts
+    cfg.current_line_blame_delay = nil
+  end
+
+  if cfg.current_line_blame_position then
+    local opts = (cfg.current_line_blame_opts or {}) as M.Config.current_line_blame_opts
+    opts.virt_text_pos = cfg.current_line_blame_position as M.Config.current_line_blame_opts.VirtTextPos
+    print('Gitsigns: current_line_blame_opts is deprecated, please use current_line_blame_opts.virt_text_pos')
+    cfg.current_line_blame_opts = opts
+    cfg.current_line_blame_post = nil
   end
 end
 

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -25,13 +25,14 @@ local wait_timer = wrap(vim.loop.timer_start, 4)
 M.reset = function(bufnr: integer)
   bufnr = bufnr or current_buf()
   api.nvim_buf_del_extmark(bufnr, namespace, 1)
+  pcall(api.nvim_buf_del_var, bufnr, 'gitsigns_blame_line_dict')
 end
 
 M.update = void(function()
   M.reset()
 
   -- Note because the same timer is re-used, this call has a debouncing effect.
-  wait_timer(timer, config.current_line_blame_delay, 0)
+  wait_timer(timer, config.current_line_blame_opts.delay, 0)
   scheduler()
 
   local bufnr = current_buf()
@@ -47,15 +48,19 @@ M.update = void(function()
   scheduler()
 
   M.reset(bufnr)
-  api.nvim_buf_set_extmark(bufnr, namespace, lnum-1, 0, {
-    id = 1,
-    virt_text = config.current_line_blame_formatter(
-      bcache.git_obj.username,
-      result,
-      config.current_line_blame_formatter_opts
-    ),
-    virt_text_pos = config.current_line_blame_position,
-  })
+
+  api.nvim_buf_set_var(bufnr, 'gitsigns_blame_line_dict', result)
+  if config.current_line_blame_opts.virt_text then
+    api.nvim_buf_set_extmark(bufnr, namespace, lnum-1, 0, {
+      id = 1,
+      virt_text = config.current_line_blame_formatter(
+        bcache.git_obj.username,
+        result,
+        config.current_line_blame_formatter_opts
+      ),
+      virt_text_pos = config.current_line_blame_opts.virt_text_pos,
+    })
+  end
 end)
 
 M.setup = function()


### PR DESCRIPTION
- Provide b:gitsigns_blame_line_dict for blame info for current line.
  Require config.current_line_blame = true.

- Added config.current_line_blame_opts

- Added config.current_line_blame_opts.virt_text. Can be disabled to
  disable virtual text. Useful if you want b:gitsigns_blame_line_dict
  but without the blame annotation.

- Moved config.current_line_blame_delay to
  config.current_line_blame_opts.delay

- Moved config.current_line_blame_pos to
  config.current_line_blame_opts.virt_text_pos

- Added deprecation handling for old options

Resolve #199