### PR TITLE
Update status to return short commit hash in detached HEAD

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -691,7 +691,7 @@ provided. `b:gitsigns_status` is formatted using `config.status_formatter`
         • `added` - Number of added lines.
         • `changed` - Number of changed lines.
         • `removed` - Number of removed lines.
-        • `head` - Name of current branch.
+        • `head` - Name of current HEAD (branch or short commit hash).
         • `root` - Top level directory of the working tree.
         • `gitdir` - .git directory.
 
@@ -700,8 +700,8 @@ Example:
     set statusline+=%{get(b:,'gitsigns_status','')}
 <
                                                              *b:gitsigns_head*
-Use `b:gitsigns_head` to return the name of the current branch. If the current
-HEAD is detached then this will be an empty string.
+Use `b:gitsigns_head` to return the name of the current HEAD (usually branch
+name). If the current HEAD is detached then this will be a short commit hash.
 
 ==============================================================================
 TEXT OBJECTS                                             *gitsigns-textobject*

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -155,19 +155,21 @@ local function process_abbrev_head(gitdir, head_str, path, cmd)
       return head_str
    end
    if head_str == 'HEAD' then
-      if util.path_exists(gitdir .. '/rebase-merge') or
-         util.path_exists(gitdir .. '/rebase-apply') then
-         return '(rebasing)'
-      elseif gsd.debug_mode then
-         return head_str
-      else
-         local hash_tbl = M.command({ 'rev-parse', '--short', 'HEAD' }, {
+      local short_sha
+      if not gsd.debug_mode then
+         short_sha = M.command({ 'rev-parse', '--short', 'HEAD' }, {
             command = cmd or 'git',
             supress_stderr = true,
             cwd = path,
-         })
-         return hash_tbl[1] or ''
+         })[1] or ''
+      else
+         short_sha = 'HEAD'
       end
+      if util.path_exists(gitdir .. '/rebase-merge') or
+         util.path_exists(gitdir .. '/rebase-apply') then
+         return short_sha .. '(rebasing)'
+      end
+      return short_sha
    end
    return head_str
 end

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -150,7 +150,7 @@ M.command = wrap(function(args, spec, callback)
    util.run_job(spec)
 end, 3)
 
-local function process_abbrev_head(gitdir, head_str)
+local function process_abbrev_head(gitdir, head_str, path, cmd)
    if not gitdir then
       return head_str
    end
@@ -161,7 +161,12 @@ local function process_abbrev_head(gitdir, head_str)
       elseif gsd.debug_mode then
          return head_str
       else
-         return ''
+         local hash_tbl = M.command({ 'rev-parse', '--short', 'HEAD' }, {
+            command = cmd or 'git',
+            supress_stderr = true,
+            cwd = path,
+         })
+         return hash_tbl[1] or ''
       end
    end
    return head_str
@@ -190,7 +195,7 @@ local get_repo_info = function(path, cmd)
    if not has_abs_gd then
       gitdir = uv.fs_realpath(gitdir)
    end
-   local abbrev_head = process_abbrev_head(gitdir, results[3])
+   local abbrev_head = process_abbrev_head(gitdir, results[3], path, cmd)
    return toplevel, gitdir, abbrev_head
 end
 

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -150,7 +150,7 @@ M.command = wrap(function(args: {string}, spec: GJobSpec, callback: function({st
   util.run_job(spec as JobSpec)
 end, 3)
 
-local function process_abbrev_head(gitdir: string, head_str: string): string
+local function process_abbrev_head(gitdir: string, head_str: string, path: string, cmd: string): string
   if not gitdir then
     return head_str
   end
@@ -161,7 +161,12 @@ local function process_abbrev_head(gitdir: string, head_str: string): string
     elseif gsd.debug_mode then
       return head_str
     else
-      return ''
+      local hash_tbl = M.command({'rev-parse', '--short', 'HEAD'}, {
+        command = cmd or 'git',
+        supress_stderr = true,
+        cwd = path,
+      })
+      return hash_tbl[1] or ''
     end
   end
   return head_str
@@ -190,7 +195,7 @@ local get_repo_info = function(path: string, cmd: string): string,string,string
   if not has_abs_gd then
     gitdir = uv.fs_realpath(gitdir)
   end
-  local abbrev_head = process_abbrev_head(gitdir, results[3])
+  local abbrev_head = process_abbrev_head(gitdir, results[3], path, cmd)
   return toplevel, gitdir, abbrev_head
 end
 

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -155,19 +155,21 @@ local function process_abbrev_head(gitdir: string, head_str: string, path: strin
     return head_str
   end
   if head_str == 'HEAD' then
-    if util.path_exists(gitdir..'/rebase-merge')
-      or util.path_exists(gitdir..'/rebase-apply') then
-      return '(rebasing)'
-    elseif gsd.debug_mode then
-      return head_str
-    else
-      local hash_tbl = M.command({'rev-parse', '--short', 'HEAD'}, {
+    local short_sha: string
+    if not gsd.debug_mode then
+      short_sha = M.command({'rev-parse', '--short', 'HEAD'}, {
         command = cmd or 'git',
         supress_stderr = true,
         cwd = path,
-      })
-      return hash_tbl[1] or ''
+      })[1] or ''
+    else
+      short_sha = 'HEAD'
     end
+    if util.path_exists(gitdir..'/rebase-merge')
+      or util.path_exists(gitdir..'/rebase-apply') then
+      return short_sha..'(rebasing)'
+    end
+    return short_sha
   end
   return head_str
 end

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -582,14 +582,14 @@ describe('gitsigns', function()
         -- test_file should have a conflict
         edit(test_file)
         check {
-          status = {head='(rebasing)', added=4, changed=1, removed=0},
+          status = {head='HEAD(rebasing)', added=4, changed=1, removed=0},
           signs = {changed=1, added=4}
         }
 
         exec_lua('require("gitsigns.actions").stage_hunk()')
 
         check {
-          status = {head='(rebasing)', added=0, changed=0, removed=0},
+          status = {head='HEAD(rebasing)', added=0, changed=0, removed=0},
           signs = {}
         }
 
@@ -653,6 +653,21 @@ describe('gitsigns', function()
       'attach(5): attaching is disabled',
     }, exec_lua[[return require'gitsigns'.debug_messages(true)]])
 
+  end)
+
+  it('show short SHA when detached head', function()
+    setup_test_repo()
+    git{"checkout", "--detach"}
+
+    -- Disable debug_mode so the sha is calculated
+    config.debug_mode = false
+    setup_gitsigns(config)
+    edit(test_file)
+
+    -- SHA is not deterministic so just check it can be cast as a hex value
+    expectf(function()
+      helpers.neq(nil, tonumber('0x'..get_buf_var('gitsigns_head')))
+    end)
   end)
 
 end)


### PR DESCRIPTION
Fixes #292.

Also slightly updated wording in documentation to be precise, but didn't touch README.

I believe some test should be updated but I have problem there. Running `make test` on current 'main' branch gives 20 errors (they seem to be related to branch name being 'HEAD' instead of 'master'). I also see 20 errors with this branch. Maybe it is something with my local setup, I am not sure.
And also didn't find any test dedicated to detached HEAD.