### PR TITLE
fix: bsd support

### DIFF
--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -37,7 +37,7 @@ if jit then
 end
 
 M.is_unix = (function()
-   if jit_os == 'linux' or jit_os == 'osx' then
+   if jit_os == 'linux' or jit_os == 'osx' or jit_os == 'bsd' then
       return true
    end
    return false

--- a/teal/gitsigns/util.tl
+++ b/teal/gitsigns/util.tl
@@ -37,7 +37,7 @@ if jit then
 end
 
 M.is_unix = (function(): boolean
-  if jit_os == 'linux' or jit_os == 'osx' then
+  if jit_os == 'linux' or jit_os == 'osx' or jit_os == 'bsd' then
     return true
   end
   return false


### PR DESCRIPTION
When checking for if on a platform that uses unix style path separators
only linux and osx where take into account. This patch and BSD to that
list.

Tested on: FreeBSD