### PR TITLE
fix(update): issue speculative signs persisting

### DIFF
--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -159,7 +159,7 @@ end
 function M.get_summary(hunks)
    local status = { added = 0, changed = 0, removed = 0 }
 
-   for _, hunk in ipairs(hunks) do
+   for _, hunk in ipairs(hunks or {}) do
       if hunk.type == 'add' then
          status.added = status.added + hunk.added.count
       elseif hunk.type == 'delete' then

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -78,6 +78,8 @@ end
 
 
 
+
+
 local function speculate_signs(buf, last_orig, last_new)
    if last_new < last_orig then
 
@@ -99,6 +101,7 @@ local function speculate_signs(buf, last_orig, last_new)
          else
             signs.remove(buf, 1)
          end
+         return true
       else
          local placed = signs.get(buf, last_orig)[last_orig]
 
@@ -108,6 +111,7 @@ local function speculate_signs(buf, last_orig, last_new)
             for i = last_orig + 1, last_new do
                signs.add(config, buf, { [i] = { type = 'add', count = 0 } })
             end
+            return true
          end
       end
    else
@@ -118,18 +122,40 @@ local function speculate_signs(buf, last_orig, last_new)
 
       if not placed then
          signs.add(config, buf, { [last_orig] = { type = 'change', count = 0 } })
+         return true
       end
    end
 end
 
 M.on_lines = function(buf, last_orig, last_new)
-   if not cache[buf] then
+   local bcache = cache[buf]
+   if not bcache then
       dprint('Cache for buffer was nil. Detaching')
       return true
    end
 
-   speculate_signs(buf, last_orig, last_new)
-   M.update_debounced(buf)
+   if speculate_signs(buf, last_orig, last_new) then
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      bcache.hunks = nil
+   end
+   M.update_debounced(buf, cache[buf])
 end
 
 local ns = api.nvim_create_namespace('gitsigns')
@@ -232,7 +258,7 @@ do
       if not running then
          running = true
          while scheduled[bufnr] do
-            scheduled[bufnr] = false
+            scheduled[bufnr] = nil
             update0(bufnr, bcache)
          end
          running = false

--- a/teal/gitsigns/hunks.tl
+++ b/teal/gitsigns/hunks.tl
@@ -159,7 +159,7 @@ end
 function M.get_summary(hunks: {Hunk}): StatusObj
   local status = { added = 0, changed = 0, removed = 0 }
 
-  for _, hunk in ipairs(hunks) do
+  for _, hunk in ipairs(hunks or {}) do
     if hunk.type == 'add' then
       status.added = status.added + hunk.added.count
     elseif hunk.type == 'delete' then

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -78,7 +78,9 @@ end
 -- Speculate on future signs. It's not a big deal if we speculate incorrectly as
 -- update() will overwrite all the signs anyway. This has noticeable effect on
 -- large files and even makes small files feel very snappy.
-local function speculate_signs(buf: integer, last_orig: integer, last_new: integer)
+--
+-- Returns true if signs are added or removed
+local function speculate_signs(buf: integer, last_orig: integer, last_new: integer): boolean
   if last_new < last_orig then
     -- Lines removed
     --
@@ -99,6 +101,7 @@ local function speculate_signs(buf: integer, last_orig: integer, last_new: integ
       else
         signs.remove(buf, 1)
       end
+      return true
     else
       local placed = signs.get(buf, last_orig)[last_orig]
 
@@ -108,6 +111,7 @@ local function speculate_signs(buf: integer, last_orig: integer, last_new: integ
         for i = last_orig+1, last_new do
           signs.add(config, buf, {[i] = {type='add', count=0}})
         end
+        return true
       end
     end
   else
@@ -118,18 +122,40 @@ local function speculate_signs(buf: integer, last_orig: integer, last_new: integ
     -- add a 'change' sign if there are no other signs
     if not placed then
       signs.add(config, buf, {[last_orig] = {type='change', count=0}})
+      return true
     end
   end
 end
 
 M.on_lines = function(buf: integer, last_orig: integer, last_new: integer): boolean
-  if not cache[buf] then
+  local bcache = cache[buf]
+  if not bcache then
     dprint('Cache for buffer was nil. Detaching')
     return true
   end
 
-  speculate_signs(buf, last_orig, last_new)
-  M.update_debounced(buf)
+  if speculate_signs(buf, last_orig, last_new) then
+    -- Speculative signs are added immediately whereas updates are debounced and
+    -- throttled for each buffer. If we perform two quick updates which result
+    -- in a sign begin added then removed, we need to make sure speculative
+    -- signs don't incorrectly persist. Example:
+    --
+    --   -> buffer change
+    --      - speculative signs (#1)
+    --      - update (#1)
+    --   -> undo (quickly after buffer change)
+    --      - speculative signs (#2)
+    --      - update (#2)
+    --
+    -- Update #1 is dropped due to the debounce which results in update #2 not
+    -- updating signs due to the hunks not changing. Since signs are never
+    -- updated, the speculative signs #1 and #2 will persist.
+    --
+    -- To get around this, we just need to invalidate the hunks to force a sign
+    -- refresh.
+    bcache.hunks = nil
+  end
+  M.update_debounced(buf, cache[buf])
 end
 
 local ns = api.nvim_create_namespace('gitsigns')
@@ -232,7 +258,7 @@ do
     if not running then
       running = true
       while scheduled[bufnr] do
-        scheduled[bufnr] = false
+        scheduled[bufnr] = nil
         update0(bufnr, bcache)
       end
       running = false

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -670,4 +670,17 @@ describe('gitsigns', function()
     end)
   end)
 
+  it('handles a quick undo', function()
+    setup_test_repo()
+    setup_gitsigns(config)
+    edit(test_file)
+    -- This test isn't deterministic so run it a few times
+    for _ = 1, 3 do
+      feed("x")
+      check { signs = {changed=1} }
+      feed("u")
+      check { signs = {} }
+    end
+  end)
+
 end)

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -88,9 +88,9 @@ function M.setup_test_repo(no_add)
   end
 end
 
-function M.expectf(cond)
+function M.expectf(cond, interval)
   local duration = 0
-  local interval = 5
+  interval = interval or 5
   while duration < timeout do
     if pcall(cond) then
       return
@@ -225,7 +225,7 @@ M.it = function(it)
   end
 end
 
-function M.check(attrs)
+function M.check(attrs, interval)
   attrs = attrs or {}
   M.expectf(function()
     local status = attrs.status
@@ -283,7 +283,7 @@ function M.check(attrs)
 
       eq(signs, act, M.inspect(buf_signs))
     end
-  end)
+  end, interval)
 end
 
 return M


### PR DESCRIPTION
Speculative signs are added immediately whereas updates are debounced
and throttled for each buffer. If we perform two quick updates which
result in a sign begin added then removed, we need to make sure
speculative signs don't incorrectly persist. Example:

  -> buffer change
     - speculative signs (#1)
     - update (#1)
  -> undo (quickly after buffer change)
     - speculative signs (#2)
     - update (#2)

Update #1 is dropped due to the debounce which results in update #2 not
updating signs due to the hunks not changing. Since signs are never
updated, the speculative signs #1 and #2 will persist.

To get around this, we just need to invalidate the hunks to force a sign
refresh.

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
