### PR TITLE
show abbrev_sha in current_line_blame

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -591,7 +591,7 @@ current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
               date_time = os.date('%Y-%m-%d', tonumber(blame_info['author_time']))
             end
 
-            text = string.format('%s, %s - %s', blame_info.author, date_time, blame_info.summary)
+            text = string.format('%s, %s, %s - %s', blame_info.author, blame_info.abbrev_sha, date_time, blame_info.summary)
           end
 
           return {{' '..text, 'GitSignsCurrentLineBlame'}}

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -440,7 +440,7 @@ M.schema = {
                date_time = os.date('%Y-%m-%d', tonumber(blame_info['author_time']))
             end
 
-            text = string.format('%s, %s - %s', blame_info.author, date_time, blame_info.summary)
+            text = string.format('%s, %s, %s - %s', blame_info.author, blame_info.abbrev_sha, date_time, blame_info.summary)
          end
 
          return { { ' ' .. text, 'GitSignsCurrentLineBlame' } }
@@ -462,7 +462,7 @@ M.schema = {
           date_time = os.date('%Y-%m-%d', tonumber(blame_info['author_time']))
         end
 
-        text = string.format('%s, %s - %s', blame_info.author, date_time, blame_info.summary)
+        text = string.format('%s, %s, %s - %s', blame_info.author, blame_info.abbrev_sha, date_time, blame_info.summary)
       end
 
       return {{' '..text, 'GitSignsCurrentLineBlame'}}

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -440,7 +440,7 @@ M.schema = {
           date_time = os.date('%Y-%m-%d', tonumber(blame_info['author_time']))
         end
 
-        text = string.format('%s, %s - %s', blame_info.author, date_time, blame_info.summary)
+        text = string.format('%s, %s, %s - %s', blame_info.author, blame_info.abbrev_sha, date_time, blame_info.summary)
       end
 
       return {{' '..text, 'GitSignsCurrentLineBlame'}}
@@ -462,7 +462,7 @@ M.schema = {
           date_time = os.date('%Y-%m-%d', tonumber(blame_info['author_time']))
         end
 
-        text = string.format('%s, %s - %s', blame_info.author, date_time, blame_info.summary)
+        text = string.format('%s, %s, %s - %s', blame_info.author, blame_info.abbrev_sha, date_time, blame_info.summary)
       end
 
       return {{' '..text, 'GitSignsCurrentLineBlame'}}


### PR DESCRIPTION
I don't know if this is the sort of change you want, but I find it useful so here is a PR. 😊

 - A use case for this is selection copy the `abbrev_sha` to the secondary X11 clipboard using a mouse. ik ik, not a great workflow.
 - Another use case might be two people working next to each other. Person A wants to look at the diff at point on Person B's computer, showing the `abbrev_sha` makes it easier for Person A to look up the diff on their system.

I'm sure there are better approaches for both use cases, but meh. 🤷

*I haven't ran the test suite as my computer is a laptop form 2008 and I don't feel like waiting for Neovim to compile.*

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
