### PR TITLE
Fixed crash when trying to use blame_line on a staged file

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -463,7 +463,7 @@ M.blame_line = void(function(full)
       highlights[#highlights + 1] = { hlgroup, #lines - 1, start or 0, length or -1 }
    end
 
-   local is_committed = bcache.git_obj.object_name and tonumber('0x' .. result.sha) ~= 0
+   local is_committed = bcache.git_obj.object_name and result.sha ~= nil and tonumber('0x' .. result.sha) ~= 0
    if is_committed then
       local commit_message = {}
       if full then
@@ -492,6 +492,7 @@ M.blame_line = void(function(full)
          hunk, ihunk, nhunk = get_blame_hunk(bcache.git_obj, result)
       end
    else
+      result = { author = 'Me' }
       lines[#lines + 1] = result.author
       add_highlight('ErrorMsg')
       if full then

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -463,7 +463,7 @@ M.blame_line = void(function(full: boolean)
     highlights[#highlights+1] = {hlgroup, #lines-1, start or 0, length or -1}
   end
 
-  local is_committed = bcache.git_obj.object_name and tonumber('0x'..result.sha) ~= 0
+  local is_committed = bcache.git_obj.object_name and result.sha ~= nil and tonumber('0x'..result.sha) ~= 0
   if is_committed then
     local commit_message = {}
     if full then
@@ -492,6 +492,7 @@ M.blame_line = void(function(full: boolean)
       hunk, ihunk, nhunk = get_blame_hunk(bcache.git_obj, result)
     end
   else
+    result = {author = 'Me'}
     lines[#lines+1] = result.author
     add_highlight('ErrorMsg')
     if full then


### PR DESCRIPTION
Closes #355

![Screenshot_2021-09-11_09-50-59](https://user-images.githubusercontent.com/15123086/132940845-36383d8a-25d9-4be1-ba17-938614d511fd.png)

@lewis6991 is something like this the desired behavior?