### PR TITLE
fix(watcher): watch gitdir instead if index

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -458,7 +458,7 @@ on_attach                                          *gitsigns-config-on_attach*
         end
 <
 
-watch_index                                      *gitsigns-config-watch_index*
+watch_gitdir                                    *gitsigns-config-watch_gitdir*
       Type: `table`
       Default: >
         {

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -73,17 +73,16 @@ local handle_moved = function(bufnr, bcache, old_relpath)
    end
 end
 
-local watch_index = function(bufnr, gitdir)
-   dprintf('Watching index')
-   local index = gitdir .. util.path_sep .. 'index'
+local watch_gitdir = function(bufnr, gitdir)
+   dprintf('Watching git dir')
    local w = uv.new_fs_poll()
-   w:start(index, config.watch_index.interval, void(function(err)
+   w:start(gitdir, config.watch_gitdir.interval, void(function(err)
       local __FUNC__ = 'watcher_cb'
       if err then
-         dprintf('Index update error: %s', err)
+         dprintf('Git dir update error: %s', err)
          return
       end
-      dprint('Index update')
+      dprint('Git dir update')
 
       local bcache = cache[bufnr]
 
@@ -110,7 +109,7 @@ local watch_index = function(bufnr, gitdir)
          return
       end
 
-      if config.watch_index.follow_files and was_tracked and not git_obj.object_name then
+      if config.watch_gitdir.follow_files and was_tracked and not git_obj.object_name then
 
 
          handle_moved(bufnr, bcache, old_relpath)
@@ -287,7 +286,7 @@ local attach0 = function(cbuf, aucmd)
       base = config.base,
       file = file,
       commit = commit,
-      index_watcher = watch_index(cbuf, repo.gitdir),
+      index_watcher = watch_gitdir(cbuf, repo.gitdir),
       git_obj = git_obj,
    })
 

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -7,7 +7,7 @@ local SchemaElem = {}
 
 
 
-local M = {Config = {DiffOpts = {}, SignsConfig = {}, watch_index = {}, current_line_blame_formatter_opts = {}, current_line_blame_opts = {}, yadm = {}, }, }
+local M = {Config = {DiffOpts = {}, SignsConfig = {}, watch_gitdir = {}, current_line_blame_formatter_opts = {}, current_line_blame_opts = {}, yadm = {}, }, }
 
 
 
@@ -189,7 +189,7 @@ M.schema = {
     ]],
    },
 
-   watch_index = {
+   watch_gitdir = {
       type = 'table',
       default = {
          interval = 1000,
@@ -586,6 +586,7 @@ M.schema = {
     ]],
    },
 
+   watch_index = { deprecated = 'watch_gitdir' },
    current_line_blame_delay = { deprecated = 'current_line_blame_opts.delay' },
    current_line_blame_position = { deprecated = 'current_line_blame_opts.virt_text_pos' },
    diff_algorithm = { deprecated = 'diff_opts.algorithm' },

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -73,23 +73,22 @@ local handle_moved = function(bufnr: integer, bcache: CacheEntry, old_relpath: s
   end
 end
 
-local watch_index = function(bufnr: integer, gitdir: string): uv.FSPollObj
-  dprintf('Watching index')
-  local index = gitdir..util.path_sep..'index'
+local watch_gitdir = function(bufnr: integer, gitdir: string): uv.FSPollObj
+  dprintf('Watching git dir')
   local w = uv.new_fs_poll()
-  w:start(index, config.watch_index.interval, void(function(err: string)
+  w:start(gitdir, config.watch_gitdir.interval, void(function(err: string)
     local __FUNC__ = 'watcher_cb'
     if err then
-      dprintf('Index update error: %s', err)
+      dprintf('Git dir update error: %s', err)
       return
     end
-    dprint('Index update')
+    dprint('Git dir update')
 
     local bcache = cache[bufnr]
 
     if not bcache then
       -- Very occasionally an external git operation may cause the buffer to
-      -- detach and update the index simultaneously. When this happens this
+      -- detach and update the git dir simultaneously. When this happens this
       -- handler will trigger but there will be no cache.
       dprint('Has detached, aborting')
       return
@@ -110,7 +109,7 @@ local watch_index = function(bufnr: integer, gitdir: string): uv.FSPollObj
       return
     end
 
-    if config.watch_index.follow_files and was_tracked and not git_obj.object_name then
+    if config.watch_gitdir.follow_files and was_tracked and not git_obj.object_name then
       -- File was tracked but is no longer tracked. Must of been removed or
       -- moved. Check if it was moved and switch to it.
       handle_moved(bufnr, bcache, old_relpath)
@@ -287,7 +286,7 @@ local attach0 = function(cbuf: integer, aucmd: string)
     base          = config.base,
     file          = file,
     commit        = commit,
-    index_watcher = watch_index(cbuf, repo.gitdir),
+    index_watcher = watch_gitdir(cbuf, repo.gitdir),
     git_obj       = git_obj
   }
 

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -37,7 +37,7 @@ local record M
     sign_priority: integer
     keymaps: {string:any}
     on_attach: function(bufnr: integer)
-    record watch_index
+    record watch_gitdir
       interval: integer
       follow_files: boolean
     end
@@ -189,7 +189,7 @@ M.schema = {
     ]]
   },
 
-  watch_index = {
+  watch_gitdir = {
     type = 'table',
     default = {
       interval = 1000,
@@ -586,6 +586,7 @@ M.schema = {
     ]]
   },
 
+  watch_index                 = { deprecated = 'watch_gitdir' },
   current_line_blame_delay    = { deprecated = 'current_line_blame_opts.delay' },
   current_line_blame_position = { deprecated = 'current_line_blame_opts.virt_text_pos' },
   diff_algorithm              = { deprecated = 'diff_opts.algorithm' },

--- a/test/gitdir_watcher_spec.lua
+++ b/test/gitdir_watcher_spec.lua
@@ -17,7 +17,7 @@ local get_buf_name    = helpers.curbufmeths.get_name
 
 local it = helpers.it(it)
 
-describe('index_watcher', function()
+describe('gitdir_watcher', function()
   before_each(function()
     clear()
 
@@ -42,7 +42,7 @@ describe('index_watcher', function()
       p"run_job: git .* config user.name",
       "run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD",
       p('run_job: git .* ls%-files .* '..test_file),
-      'watch_index(1): Watching index',
+      'watch_gitdir(1): Watching git dir',
       p'run_job: git .* show :0:dummy.txt',
       'update(1): updates: 1, jobs: 6',
     }
@@ -52,7 +52,7 @@ describe('index_watcher', function()
     git{'mv', test_file, test_file..'2'}
 
     match_debug_messages {
-      'watcher_cb(1): Index update',
+      'watcher_cb(1): Git dir update',
       'run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD',
       p('run_job: git .* ls%-files .* '..test_file),
       p'run_job: git .* diff %-%-name%-status %-C %-%-cached',
@@ -69,7 +69,7 @@ describe('index_watcher', function()
     git{'mv', test_file..'2', test_file..'3'}
 
     match_debug_messages {
-      'watcher_cb(1): Index update',
+      'watcher_cb(1): Git dir update',
       'run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD',
       p('run_job: git .* ls%-files .* '..test_file..'2'),
       p'run_job: git .* diff %-%-name%-status %-C %-%-cached',
@@ -86,7 +86,7 @@ describe('index_watcher', function()
     git{'mv', test_file..'3', test_file}
 
     match_debug_messages {
-      'watcher_cb(1): Index update',
+      'watcher_cb(1): Git dir update',
       'run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD',
       p('run_job: git .* ls%-files .* '..test_file..'3'),
       p'run_job: git .* diff %-%-name%-status %-C %-%-cached',

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -72,10 +72,10 @@ describe('gitsigns', function()
     check { status = {}, signs = {} }
   end)
 
-  it('index watcher works on a fresh repo', function()
+  it('gitdir watcher works on a fresh repo', function()
     screen:try_resize(20,6)
     setup_test_repo(true)
-    config.watch_index = {interval = 5}
+    config.watch_gitdir = {interval = 5}
     setup_gitsigns(config)
     edit(test_file)
 
@@ -86,8 +86,7 @@ describe('gitsigns', function()
         p'run_job: git .* config user.name',
         'run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD',
         p('run_job: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard '..test_file),
-        'watch_index(1): Watching index',
-        'watcher_cb(1): Index update error: ENOENT',
+        'watch_gitdir(1): Watching git dir',
         p'run_job: git .* show :0:dummy.txt',
         'update(1): updates: 1, jobs: 7'
       })
@@ -480,7 +479,7 @@ describe('gitsigns', function()
           p"run_job: git .* config user.name",
           'run_job: git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD',
           p'run_job: git .* ls%-files .*',
-          'watch_index(1): Watching index',
+          'watch_gitdir(1): Watching git dir',
           p'run_job: git .* show :0:newfile.txt'
         }
 


### PR DESCRIPTION
Some git command likes `git checkout -b` do no update .git/index.
Instead watch the git dir itself to capture all git operations.

Renamed config.watch_index -> config.watch_gitdir

Fixes #377

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
