### PR TITLE
feat(blame): Allow to ignore whitespace

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -179,10 +179,17 @@ preview_hunk()                                       *gitsigns.preview_hunk()*
                 Preview the hunk at the cursor position in a floating
                 window.
 
-blame_line({full})                                     *gitsigns.blame_line()*
+blame_line({opts})                                     *gitsigns.blame_line()*
                 Run git blame on the current line and show the results in a
-                floating window. If {full} is true then the full commit
-                message is displayed along with the corresponding hunk.
+                floating window.
+
+                Parameters: ~
+                    {opts}   (table|nil):
+                             Additional options:
+                             • {full}: (boolean)
+                               Display full commit message
+                             • {ignore_whitespace}: (boolean)
+                               Ignore whitespace when running blame.
 
                 Attributes: ~
                     {async}
@@ -637,6 +644,8 @@ current_line_blame_opts              *gitsigns-config-current_line_blame_opts*
         • delay: integer
           Sets the delay (in milliseconds) before blame virtual text is
           displayed.
+        • ignore_whitespace: boolean
+          Ignore whitespace when running blame.
 
 current_line_blame_formatter_opts
                            *gitsigns-config-current_line_blame_formatter_opts*

--- a/gitsigns.nvim-scm-1.rockspec
+++ b/gitsigns.nvim-scm-1.rockspec
@@ -48,6 +48,7 @@ build = {
     ['gitsigns.hunks']                 = 'lua/gitsigns/hunks.lua',
     ['gitsigns.manager']               = 'lua/gitsigns/manager.lua',
     ['gitsigns.mappings']              = 'lua/gitsigns/mappings.lua',
+    ['gitsigns.message']               = 'lua/gitsigns/message.lua',
     ['gitsigns.popup']                 = 'lua/gitsigns/popup.lua',
     ['gitsigns.repeat']                = 'lua/gitsigns/repeat.lua',
     ['gitsigns.signs']                 = 'lua/gitsigns/signs.lua',

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -9,6 +9,7 @@ local signs = require('gitsigns.signs')
 local util = require('gitsigns.util')
 local manager = require('gitsigns.manager')
 local git = require('gitsigns.git')
+local warn = require('gitsigns.message').warn
 
 local gs_cache = require('gitsigns.cache')
 local cache = gs_cache.cache
@@ -474,10 +475,25 @@ local function get_blame_hunk(repo, info)
    return hunk, i, #hunks
 end
 
-M.blame_line = void(function(full)
+local BlameOpts = {}
+
+
+
+
+M.blame_line = void(function(opts0)
    local bufnr = current_buf()
    local bcache = cache[bufnr]
    if not bcache then return end
+
+   local full
+   local opts
+   if type(opts0) == "boolean" then
+      warn('Passing boolean as first argument to blame_line is now deprecated; please pass an options table')
+      full = opts0
+   else
+      full = opts0.full
+      opts = opts0
+   end
 
    local loading = defer(1000, function()
       popup.create({ 'Loading...' }, config.preview_config)
@@ -486,7 +502,7 @@ M.blame_line = void(function(full)
    scheduler()
    local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
    local lnum = api.nvim_win_get_cursor(0)[1]
-   local result = bcache.git_obj:run_blame(buftext, lnum)
+   local result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
    pcall(function()
       loading:close()
    end)

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -1,3 +1,12 @@
+local warn
+do
+
+   local ok, ret = pcall(require, 'gitsigns.message')
+   if ok then
+      warn = ret.warn
+   end
+end
+
 local SchemaElem = {Deprecated = {}, }
 
 
@@ -15,6 +24,7 @@ local SchemaElem = {Deprecated = {}, }
 
 
 local M = {Config = {DiffOpts = {}, SignsConfig = {}, watch_gitdir = {}, current_line_blame_formatter_opts = {}, current_line_blame_opts = {}, yadm = {}, }, }
+
 
 
 
@@ -441,6 +451,8 @@ M.schema = {
         • delay: integer
           Sets the delay (in milliseconds) before blame virtual text is
           displayed.
+        • ignore_whitespace: boolean
+          Ignore whitespace when running blame.
     ]],
    },
 

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -31,9 +31,10 @@ end
 
 M.update = void(function()
    M.reset()
+   local opts = config.current_line_blame_opts
 
 
-   wait_timer(timer, config.current_line_blame_opts.delay, 0)
+   wait_timer(timer, opts.delay, 0)
    scheduler()
 
    local bufnr = current_buf()
@@ -44,7 +45,7 @@ M.update = void(function()
 
    local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
    local lnum = api.nvim_win_get_cursor(0)[1]
-   local result = bcache.git_obj:run_blame(buftext, lnum)
+   local result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
 
    scheduler()
 
@@ -62,7 +63,7 @@ M.update = void(function()
    end
 
    api.nvim_buf_set_var(bufnr, 'gitsigns_blame_line_dict', result)
-   if config.current_line_blame_opts.virt_text then
+   if opts.virt_text then
       api.nvim_buf_set_extmark(bufnr, namespace, lnum - 1, 0, {
          id = 1,
          virt_text = config.current_line_blame_formatter(
@@ -70,7 +71,7 @@ M.update = void(function()
          result,
          config.current_line_blame_formatter_opts),
 
-         virt_text_pos = config.current_line_blame_opts.virt_text_pos,
+         virt_text_pos = opts.virt_text_pos,
          hl_mode = 'combine',
       })
    end

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -322,7 +322,7 @@ Obj.unstage_file = function(self)
    self:command({ 'reset', self.file })
 end
 
-Obj.run_blame = function(self, lines, lnum)
+Obj.run_blame = function(self, lines, lnum, ignore_whitespace)
    if not self.object_name or self.repo.abbrev_head == '' then
 
 
@@ -340,6 +340,7 @@ Obj.run_blame = function(self, lines, lnum)
       '-L', lnum .. ',+1',
       '--line-porcelain',
       self.file,
+      ignore_whitespace and '-w' or nil,
    }, {
       writer = lines,
    })

--- a/lua/gitsigns/message.lua
+++ b/lua/gitsigns/message.lua
@@ -1,0 +1,8 @@
+
+local M = {}
+
+function M.warn(s, ...)
+   vim.notify(s:format(...), vim.log.levels.WARN, { title = 'gitsigns' })
+end
+
+return M

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -9,6 +9,7 @@ local signs         = require('gitsigns.signs')
 local util          = require('gitsigns.util')
 local manager       = require('gitsigns.manager')
 local git           = require('gitsigns.git')
+local warn          = require('gitsigns.message').warn
 
 local gs_cache       = require('gitsigns.cache')
 local cache          = gs_cache.cache
@@ -474,10 +475,25 @@ local function get_blame_hunk(repo: git.Repo, info: git.BlameInfo): Hunk, intege
   return hunk, i, #hunks
 end
 
-M.blame_line = void(function(full: boolean)
+local record BlameOpts
+  full: boolean
+  ignore_whitespace: boolean
+end
+
+M.blame_line = void(function(opts0: boolean | BlameOpts)
   local bufnr = current_buf()
   local bcache = cache[bufnr]
   if not bcache then return end
+
+  local full: boolean
+  local opts: BlameOpts
+  if opts0 is boolean then
+    warn('Passing boolean as first argument to blame_line is now deprecated; please pass an options table')
+    full = opts0
+  else
+    full = opts0.full
+    opts = opts0
+  end
 
   local loading = defer(1000, function()
     popup.create({'Loading...'}, config.preview_config)
@@ -486,7 +502,7 @@ M.blame_line = void(function(full: boolean)
   scheduler()
   local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local lnum = api.nvim_win_get_cursor(0)[1]
-  local result = bcache.git_obj:run_blame(buftext, lnum)
+  local result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
   pcall(function()
     loading:close()
   end)

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -1,3 +1,12 @@
+local warn: function(string)
+do
+  -- this is included in gen_help.lua so don't error if requires fail
+  local ok, ret = pcall(require, 'gitsigns.message')
+  if ok then
+    warn = ret.warn as function(string)
+  end
+end
+
 local record SchemaElem
   type: string
   deep_extend: boolean
@@ -71,6 +80,7 @@ local record M
       virt_text_pos: VirtTextPos
 
       delay: integer
+      ignore_whitespace: boolean
     end
 
     preview_config: {string:any}
@@ -441,6 +451,8 @@ M.schema = {
         • delay: integer
           Sets the delay (in milliseconds) before blame virtual text is
           displayed.
+        • ignore_whitespace: boolean
+          Ignore whitespace when running blame.
     ]]
   },
 

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -31,9 +31,10 @@ end
 -- Update function, must be called in async context
 M.update = void(function()
   M.reset()
+  local opts = config.current_line_blame_opts
 
   -- Note because the same timer is re-used, this call has a debouncing effect.
-  wait_timer(timer, config.current_line_blame_opts.delay, 0)
+  wait_timer(timer, opts.delay, 0)
   scheduler()
 
   local bufnr = current_buf()
@@ -44,7 +45,7 @@ M.update = void(function()
 
   local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local lnum = api.nvim_win_get_cursor(0)[1]
-  local result = bcache.git_obj:run_blame(buftext, lnum)
+  local result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
 
   scheduler()
 
@@ -62,7 +63,7 @@ M.update = void(function()
   end
 
   api.nvim_buf_set_var(bufnr, 'gitsigns_blame_line_dict', result)
-  if config.current_line_blame_opts.virt_text then
+  if opts.virt_text then
     api.nvim_buf_set_extmark(bufnr, namespace, lnum-1, 0, {
       id = 1,
       virt_text = config.current_line_blame_formatter(
@@ -70,7 +71,7 @@ M.update = void(function()
         result,
         config.current_line_blame_formatter_opts
       ),
-      virt_text_pos = config.current_line_blame_opts.virt_text_pos,
+      virt_text_pos = opts.virt_text_pos,
       hl_mode = 'combine',
     })
   end

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -83,7 +83,7 @@ local record M
     command              : function(Obj, {string}, GJobSpec): {string}, string
     update_file_info     : function(Obj): boolean
     unstage_file         : function(Obj, string, string)
-    run_blame            : function(Obj, {string}, number): BlameInfo
+    run_blame            : function(Obj, {string}, number, boolean): BlameInfo
     file_info            : function(Obj, string): string, string, string, boolean
     ensure_file_in_index : function(Obj)
     stage_hunks          : function(Obj, {Hunk}, boolean)
@@ -322,7 +322,7 @@ Obj.unstage_file = function(self: Obj)
   self:command{'reset', self.file }
 end
 
-Obj.run_blame = function(self: Obj, lines: {string}, lnum: number): M.BlameInfo
+Obj.run_blame = function(self: Obj, lines: {string}, lnum: number, ignore_whitespace: boolean): M.BlameInfo
   if not self.object_name or self.repo.abbrev_head == '' then
     -- As we support attaching to untracked files we need to return something if
     -- the file isn't isn't tracked in git.
@@ -339,7 +339,8 @@ Obj.run_blame = function(self: Obj, lines: {string}, lnum: number): M.BlameInfo
       '--contents', '-',
       '-L', lnum..',+1',
       '--line-porcelain',
-      self.file
+      self.file,
+      ignore_whitespace and '-w' or nil,
     }, {
     writer = lines,
   })

--- a/teal/gitsigns/message.tl
+++ b/teal/gitsigns/message.tl
@@ -1,0 +1,8 @@
+
+local M = {}
+
+function M.warn(s: string, ...:any)
+  vim.notify(s:format(...), vim.log.levels.WARN, {title = 'gitsigns'})
+end
+
+return M


### PR DESCRIPTION
- blame_line() now takes a table as it's first argument (instead of a
boolean) with the fields "full" and "ignore_whitespace"

- Added config.current_line_blame_opts.ignore_whitespace

Resolves #400

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
