### PR TITLE
fix(blame_line): Do not omit carriage return

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 export PJ_ROOT=$(PWD)
 
-FILTER=.*
+FILTER ?= .*
 
 INIT_LUAROCKS := eval $$(luarocks --lua-version=5.1 path) &&
 
@@ -35,7 +35,7 @@ test: deps/neovim deps/plenary.nvim
 		--lpath=$(PWD)/lua/?.lua \
 		--lpath=$(PWD)/deps/plenary.nvim/lua/?.lua \
 		--lpath=$(PWD)/deps/plenary.nvim/lua/?/init.lua \
-		--filter=$(FILTER) \
+		--filter="$(FILTER)" \
 		$(PWD)/test
 
 	-@stty sane

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -618,7 +618,7 @@ M.blame_line = void(function(opts)
    end)
 
    scheduler()
-   local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+   local buftext = util.buf_lines(bufnr)
    local lnum = api.nvim_win_get_cursor(0)[1]
    local result = bcache.git_obj:run_blame(buftext, lnum, ignore_whitespace)
    pcall(function()

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -6,6 +6,7 @@ local scheduler = require('plenary.async.util').scheduler
 local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
 local BlameInfo = require('gitsigns.git').BlameInfo
+local util = require('gitsigns.util')
 
 local api = vim.api
 
@@ -85,7 +86,7 @@ M.update = void(function()
    BlameCache:init_or_invalidate(bufnr)
    local result = BlameCache:get(bufnr, lnum)
    if not result then
-      local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local buftext = util.buf_lines(bufnr)
       result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
       BlameCache:add(bufnr, lnum, result)
    end

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -17,6 +17,7 @@ local dprint = gs_debug.dprint
 local dprintf = gs_debug.dprintf
 local eprint = gs_debug.eprint
 local subprocess = require('gitsigns.subprocess')
+local util = require('gitsigns.util')
 
 local gs_hunks = require("gitsigns.hunks")
 local Hunk = gs_hunks.Hunk
@@ -211,17 +212,6 @@ M.apply_word_diff = function(bufnr, row)
    end
 end
 
-local function get_lines(bufnr)
-
-   local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-   if api.nvim_buf_get_option(bufnr, 'fileformat') == 'dos' then
-      for i = 1, #buftext do
-         buftext[i] = buftext[i] .. '\r'
-      end
-   end
-   return buftext
-end
-
 local update_cnt = 0
 
 local update0 = function(bufnr, bcache)
@@ -235,7 +225,7 @@ local update0 = function(bufnr, bcache)
    bcache.hunks = nil
 
    scheduler_if_buf_valid(bufnr)
-   local buftext = get_lines(bufnr)
+   local buftext = util.buf_lines(bufnr)
    local git_obj = bcache.git_obj
 
 

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -34,6 +34,17 @@ end
 
 M.path_sep = package.config:sub(1, 1)
 
+function M.buf_lines(bufnr)
+
+   local buftext = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+   if vim.bo[bufnr].fileformat == 'dos' then
+      for i = 1, #buftext do
+         buftext[i] = buftext[i] .. '\r'
+      end
+   end
+   return buftext
+end
+
 function M.tmpname()
    if is_unix then
       return os.tmpname()

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -618,7 +618,7 @@ M.blame_line = void(function(opts: boolean | BlameOpts)
   end)
 
   scheduler()
-  local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local buftext = util.buf_lines(bufnr)
   local lnum = api.nvim_win_get_cursor(0)[1]
   local result = bcache.git_obj:run_blame(buftext, lnum, ignore_whitespace)
   pcall(function()

--- a/teal/gitsigns/current_line_blame.tl
+++ b/teal/gitsigns/current_line_blame.tl
@@ -6,6 +6,7 @@ local scheduler = require('plenary.async.util').scheduler
 local cache  = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
 local BlameInfo = require('gitsigns.git').BlameInfo
+local util = require('gitsigns.util')
 
 local api = vim.api
 
@@ -85,7 +86,7 @@ M.update = void(function()
   BlameCache:init_or_invalidate(bufnr)
   local result = BlameCache:get(bufnr, lnum)
   if not result then
-    local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    local buftext = util.buf_lines(bufnr)
     result = bcache.git_obj:run_blame(buftext, lnum, opts.ignore_whitespace)
     BlameCache:add(bufnr, lnum, result)
   end

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -17,6 +17,7 @@ local dprint            = gs_debug.dprint
 local dprintf           = gs_debug.dprintf
 local eprint            = gs_debug.eprint
 local subprocess        = require('gitsigns.subprocess')
+local util              = require('gitsigns.util')
 
 local gs_hunks          = require("gitsigns.hunks")
 local Hunk              = gs_hunks.Hunk
@@ -211,17 +212,6 @@ M.apply_word_diff = function(bufnr: integer, row: integer)
   end
 end
 
-local function get_lines(bufnr: integer): {string}
-  -- nvim_buf_get_lines strips carriage returns if fileformat==dos
-  local buftext = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  if api.nvim_buf_get_option(bufnr, 'fileformat') == 'dos' then
-    for i = 1, #buftext do
-      buftext[i] = buftext[i]..'\r'
-    end
-  end
-  return buftext
-end
-
 local update_cnt = 0
 
 local update0 = function(bufnr: integer, bcache: CacheEntry)
@@ -235,7 +225,7 @@ local update0 = function(bufnr: integer, bcache: CacheEntry)
   bcache.hunks = nil
 
   scheduler_if_buf_valid(bufnr)
-  local buftext = get_lines(bufnr)
+  local buftext = util.buf_lines(bufnr)
   local git_obj = bcache.git_obj
 
   -- Make sure these requires are done in the main event.

--- a/teal/gitsigns/util.tl
+++ b/teal/gitsigns/util.tl
@@ -34,6 +34,17 @@ end
 
 M.path_sep = package.config:sub(1, 1)
 
+function M.buf_lines(bufnr: integer): {string}
+  -- nvim_buf_get_lines strips carriage returns if fileformat==dos
+  local buftext: {string} = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  if vim.bo[bufnr].fileformat == 'dos' then
+    for i = 1, #buftext do
+      buftext[i] = buftext[i]..'\r'
+    end
+  end
+  return buftext
+end
+
 function M.tmpname(): string
   if is_unix then
     return os.tmpname()


### PR DESCRIPTION
When blaming a line on a file, which as the "dos" fileformat
which is also checked in as a "dos" format including the
carriage returns, gitsigns.nvim currently reports
"Not yet commited" caused by an unsucessfull blame call
to git.

This commit fixes that behavior by appending the carriage
return lines again

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?

Fixes #410 

Starting as a draft, because the tests do not really make sense. Do you have a suggestion, which test helper function to use, to actually test the content of `blame_line()` @lewis6991? 
