### PR TITLE
tweaks and cleanup

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -648,11 +648,6 @@ attach_to_untracked                      *gitsigns-config-attach_to_untracked*
 
       Attach to untracked files.
 
-update_debounce                              *gitsigns-config-update_debounce*
-      Type: `number`, Default: `100`
-
-      Debounce time for updates (in milliseconds).
-
 current_line_blame                        *gitsigns-config-current_line_blame*
       Type: `boolean`, Default: `false`
 
@@ -804,6 +799,9 @@ diff_algorithm                                *gitsigns-config-diff_algorithm*
    DEPRECATED
 
    Please instead use the field `algorithm` in |gitsigns-config-diff_opts|.
+
+update_debounce                              *gitsigns-config-update_debounce*
+   DEPRECATED
 
 use_decoration_api                        *gitsigns-config-use_decoration_api*
    DEPRECATED

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -313,7 +313,7 @@ local attach0 = function(cbuf, aucmd)
       on_reload = function(_, bufnr)
          local __FUNC__ = 'on_reload'
          dprint('Reload')
-         manager.update_debounced(bufnr)
+         void(manager.update)(bufnr)
       end,
       on_detach = function(_, buf)
          M.detach(buf, true)
@@ -489,8 +489,6 @@ M.setup = void(function(cfg)
          M0[nm] = f
       end
    end
-
-   manager.setup()
 
    Status.formatter = config.status_formatter
 

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -157,8 +157,6 @@ M.stage_hunk = mk_repeatable(void(function(range)
 
    table.insert(bcache.staged_diffs, hunk)
 
-   bcache.compare_text = nil
-
    local hunk_signs = gs_hunks.process_hunks({ hunk })
 
    scheduler()
@@ -173,7 +171,9 @@ M.stage_hunk = mk_repeatable(void(function(range)
          signs.remove(bufnr, lnum)
       end
    end
-   void(manager.update)(bufnr)
+
+   bcache.compare_text = nil
+   manager.update(bufnr)
 end))
 
 
@@ -326,13 +326,14 @@ M.reset_buffer_index = void(function()
    bcache.staged_diffs = {}
 
    bcache.git_obj:unstage_file()
-   bcache.compare_text = nil
 
    scheduler()
    if not bcache.base then
       signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
    end
-   void(manager.update)(bufnr)
+
+   bcache.compare_text = nil
+   manager.update(bufnr)
 end)
 
 local function process_nav_opts(opts)

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -410,14 +410,6 @@ M.schema = {
     ]],
    },
 
-   update_debounce = {
-      type = 'number',
-      default = 100,
-      description = [[
-      Debounce time for updates (in milliseconds).
-    ]],
-   },
-
    current_line_blame = {
       type = 'boolean',
       default = false,
@@ -633,6 +625,7 @@ M.schema = {
    current_line_blame_delay = { deprecated = { new_field = 'current_line_blame_opts.delay' } },
    current_line_blame_position = { deprecated = { new_field = 'current_line_blame_opts.virt_text_pos' } },
    diff_algorithm = { deprecated = { new_field = 'diff_opts.algorithm' } },
+   update_debounce = { deprecated = true },
    use_decoration_api = { deprecated = true },
    use_internal_diff = { deprecated = { new_field = 'diff_opts.internal' } },
 }

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -313,7 +313,7 @@ local attach0 = function(cbuf: integer, aucmd: string)
     on_reload = function(_, bufnr: integer)
       local __FUNC__ = 'on_reload'
       dprint('Reload')
-      manager.update_debounced(bufnr)
+      void(manager.update)(bufnr)
     end,
     on_detach = function(_, buf: integer)
       M.detach(buf, true)
@@ -489,8 +489,6 @@ M.setup = void(function(cfg: Config)
       M0[nm] = f
     end
   end
-
-  manager.setup()
 
   Status.formatter = config.status_formatter as function(Status.StatusObj): string
 

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -157,8 +157,6 @@ M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
 
   table.insert(bcache.staged_diffs, hunk)
 
-  bcache.compare_text = nil -- Invalidate
-
   local hunk_signs = gs_hunks.process_hunks({hunk})
 
   scheduler()
@@ -173,7 +171,9 @@ M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
       signs.remove(bufnr, lnum)
     end
   end
-  void(manager.update)(bufnr)
+
+  bcache.compare_text = nil -- Invalidate
+  manager.update(bufnr)
 end))
 
 --- Reset the lines of the hunk at the cursor position, or all
@@ -326,13 +326,14 @@ M.reset_buffer_index = void(function()
   bcache.staged_diffs = {}
 
   bcache.git_obj:unstage_file()
-  bcache.compare_text = nil -- Invalidate
 
   scheduler()
   if not bcache.base then
     signs.add(config, bufnr, gs_hunks.process_hunks(hunks))
   end
-  void(manager.update)(bufnr)
+
+  bcache.compare_text = nil -- Invalidate
+  manager.update(bufnr)
 end)
 
 local function process_nav_opts(opts: NavHunkOpts)

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -410,14 +410,6 @@ M.schema = {
     ]]
   },
 
-  update_debounce = {
-    type = 'number',
-    default = 100,
-    description = [[
-      Debounce time for updates (in milliseconds).
-    ]]
-  },
-
   current_line_blame = {
     type = 'boolean',
     default = false,
@@ -633,6 +625,7 @@ M.schema = {
   current_line_blame_delay    = { deprecated = {new_field = 'current_line_blame_opts.delay'} },
   current_line_blame_position = { deprecated = {new_field = 'current_line_blame_opts.virt_text_pos'} },
   diff_algorithm              = { deprecated = {new_field = 'diff_opts.algorithm'} },
+  update_debounce             = { deprecated = true },
   use_decoration_api          = { deprecated = true },
   use_internal_diff           = { deprecated = {new_field = 'diff_opts.internal'} },
 }

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -10,7 +10,6 @@ local Sign              = signs.Sign
 
 local Status            = require("gitsigns.status")
 
-local debounce_trailing = require('gitsigns.debounce').debounce_trailing
 local throttle_by_id    = require('gitsigns.debounce').throttle_by_id
 local gs_debug          = require("gitsigns.debug")
 local dprint            = gs_debug.dprint
@@ -28,14 +27,10 @@ local config         = require('gitsigns.config').config
 local api = vim.api
 
 local record M
-  update           : function(integer, CacheEntry)
-  update_debounced : function(integer, CacheEntry)
-  apply_win_signs  : function(bufnr: integer, pending: {integer:Sign}, top: integer, bot: integer)
-  on_lines         : function(buf: integer, last_orig: integer, last_new: integer): boolean
-
-  apply_word_diff: function(buf: integer, row: integer)
-
-  setup: function()
+  update          : function(integer, CacheEntry)
+  apply_win_signs : function(bufnr: integer, pending: {integer:Sign}, top: integer, bot: integer)
+  on_lines        : function(buf: integer, last_orig: integer, last_new: integer): boolean
+  apply_word_diff : function(buf: integer, row: integer)
   setup_signs_and_highlights: function(redefine: boolean)
 end
 
@@ -159,7 +154,7 @@ M.on_lines = function(buf: integer, last_orig: integer, last_new: integer): bool
       bcache.hunks = nil
     end
   end)
-  M.update_debounced(buf, cache[buf])
+  void(M.update)(buf, cache[buf])
 end
 
 local ns = api.nvim_create_namespace('gitsigns')
@@ -214,7 +209,9 @@ end
 
 local update_cnt = 0
 
-local update0 = function(bufnr: integer, bcache: CacheEntry)
+local run_diff: function({string}, {string}, string, boolean): {Hunk}
+
+local update = function(bufnr: integer, bcache: CacheEntry)
   local __FUNC__ = 'update'
   bcache = bcache or cache[bufnr]
   if not bcache then
@@ -232,11 +229,12 @@ local update0 = function(bufnr: integer, bcache: CacheEntry)
 
   -- Make sure these requires are done in the main event.
   -- See https://github.com/neovim/neovim/issues/15147
-  local run_diff: function({string}, {string}, string, boolean): {Hunk}
-  if config.diff_opts.internal then
-    run_diff = require('gitsigns.diff_int').run_diff
-  else
-    run_diff = require('gitsigns.diff_ext').run_diff
+  if not run_diff then
+    if config.diff_opts.internal then
+      run_diff = require('gitsigns.diff_int').run_diff
+    else
+      run_diff = require('gitsigns.diff_ext').run_diff
+    end
   end
 
   if not bcache.compare_text or config._refresh_staged_on_update then
@@ -268,11 +266,7 @@ end
 -- Since updates are asynchronous we need to make sure an update isn't performed
 -- whilst another one is in progress. If this happens then schedule another
 -- update after the current one has completed.
-M.update = throttle_by_id(update0) as function(integer, CacheEntry)
-
-M.setup = function()
-  M.update_debounced = debounce_trailing(config.update_debounce, void(M.update)) as function(integer)
-end
+M.update = throttle_by_id(update) as function(integer, CacheEntry)
 
 M.setup_signs_and_highlights = function(redefine: boolean)
   -- Define signs


### PR DESCRIPTION
Deprecate config.update_debounce. Updates were recently throttled;
debouncing them has little benefit, especially given how quick vim.diff
is.

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
