### PR TITLE
fix(setup_command): Fix error when redefining Gitsigns

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -453,7 +453,7 @@ local function setup_command()
          local fargs = vim.split(params.args, '%s+')
          M._run_func({ params.range, params.line1, params.line2 }, unpack(fargs))
       end, {
-         bang = true,
+         force = true,
          nargs = '+',
          range = true,
          complete = M._complete,

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -453,7 +453,7 @@ local function setup_command()
       local fargs = vim.split(params.args, '%s+')
       M._run_func({params.range, params.line1, params.line2}, unpack(fargs))
     end, {
-      bang = true,
+      force = true,
       nargs = '+',
       range = true,
       complete = M._complete


### PR DESCRIPTION
Replace bang with force in the command-attributes, since the latter
is equivalent to "command! Gitsigns" when using nvim_add_user_command.
Using bang without force is equivalent to "command -bang Gitsigns".

This closes #433

Signed-off-by: Joshua Wong <joshua99wong@gmail.com>

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
