### PR TITLE
fix(): support filepaths with unicode characters

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -336,6 +336,7 @@ end
 
 Obj.file_info = function(self, file)
    local results, stderr = self:command({
+      '-c', 'core.quotepath=off',
       'ls-files',
       '--stage',
       '--others',

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -336,6 +336,7 @@ end
 
 Obj.file_info = function(self: Obj, file: string): M.FileProps
   local results, stderr = self:command({
+    '-c', 'core.quotepath=off',
     'ls-files',
     '--stage',
     '--others',

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -702,4 +702,29 @@ describe('gitsigns', function()
     end
   end)
 
+  it('handles filenames with unicode characters', function()
+    screen:try_resize(20,2)
+    setup_test_repo()
+    setup_gitsigns(config)
+    local uni_filename = scratch..'/föobær'
+
+    write_to_file(uni_filename, {'Lorem ipsum'})
+    git{"add", uni_filename}
+    git{"commit", "-m", "another commit"}
+
+    edit(uni_filename)
+
+    screen:expect{grid=[[
+      ^Lorem ipsum         |
+      {6:~                   }|
+    ]]}
+
+    feed 'x'
+
+    screen:expect{grid=[[
+      {2:~ }^orem ipsum        |
+      {6:~                   }|
+    ]]}
+  end)
+
 end)


### PR DESCRIPTION
Fixes #447

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
