### PR TITLE
chore(config)!: hard deprecate fields

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -762,30 +762,30 @@ debug_mode                                        *gitsigns-config-debug_mode*
       available: `dump_cache`, `debug_messages`, `clear_debug`.
 
 watch_index                                      *gitsigns-config-watch_index*
-   DEPRECATED
+   HARD-DEPRECATED
 
    Please instead use |gitsigns-config-watch_gitdir|.
 
 current_line_blame_delay            *gitsigns-config-current_line_blame_delay*
-   DEPRECATED
+   HARD-DEPRECATED
 
    Please instead use the field `delay` in |gitsigns-config-current_line_blame_opts|.
 
 current_line_blame_position      *gitsigns-config-current_line_blame_position*
-   DEPRECATED
+   HARD-DEPRECATED
 
    Please instead use the field `virt_text_pos` in |gitsigns-config-current_line_blame_opts|.
 
 diff_algorithm                                *gitsigns-config-diff_algorithm*
-   DEPRECATED
+   HARD-DEPRECATED
 
    Please instead use the field `algorithm` in |gitsigns-config-diff_opts|.
 
 use_decoration_api                        *gitsigns-config-use_decoration_api*
-   DEPRECATED
+   HARD-DEPRECATED
 
 use_internal_diff                          *gitsigns-config-use_internal_diff*
-   DEPRECATED
+   HARD-DEPRECATED
 
    Please instead use the field `internal` in |gitsigns-config-diff_opts|.
 

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -631,12 +631,12 @@ M.schema = {
     ]],
    },
 
-   watch_index = { deprecated = { new_field = 'watch_gitdir' } },
-   current_line_blame_delay = { deprecated = { new_field = 'current_line_blame_opts.delay' } },
-   current_line_blame_position = { deprecated = { new_field = 'current_line_blame_opts.virt_text_pos' } },
-   diff_algorithm = { deprecated = { new_field = 'diff_opts.algorithm' } },
-   use_decoration_api = { deprecated = true },
-   use_internal_diff = { deprecated = { new_field = 'diff_opts.internal' } },
+   watch_index = { deprecated = { hard = true, new_field = 'watch_gitdir' } },
+   current_line_blame_delay = { deprecated = { hard = true, new_field = 'current_line_blame_opts.delay' } },
+   current_line_blame_position = { deprecated = { hard = true, new_field = 'current_line_blame_opts.virt_text_pos' } },
+   diff_algorithm = { deprecated = { hard = true, new_field = 'diff_opts.algorithm' } },
+   use_decoration_api = { deprecated = { hard = true } },
+   use_internal_diff = { deprecated = { hard = true, new_field = 'diff_opts.internal' } },
 }
 
 warn = function(s, ...)

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -631,12 +631,12 @@ M.schema = {
     ]]
   },
 
-  watch_index                 = { deprecated = {new_field = 'watch_gitdir' } },
-  current_line_blame_delay    = { deprecated = {new_field = 'current_line_blame_opts.delay'} },
-  current_line_blame_position = { deprecated = {new_field = 'current_line_blame_opts.virt_text_pos'} },
-  diff_algorithm              = { deprecated = {new_field = 'diff_opts.algorithm'} },
-  use_decoration_api          = { deprecated = true },
-  use_internal_diff           = { deprecated = {new_field = 'diff_opts.internal'} },
+  watch_index                 = { deprecated = {hard = true, new_field = 'watch_gitdir' } },
+  current_line_blame_delay    = { deprecated = {hard = true, new_field = 'current_line_blame_opts.delay'} },
+  current_line_blame_position = { deprecated = {hard = true, new_field = 'current_line_blame_opts.virt_text_pos'} },
+  diff_algorithm              = { deprecated = {hard = true, new_field = 'diff_opts.algorithm'} },
+  use_decoration_api          = { deprecated = {hard = true}},
+  use_internal_diff           = { deprecated = {hard = true, new_field = 'diff_opts.internal'} },
 }
 
 warn = function(s: string, ...: any)


### PR DESCRIPTION
Any fields that were deprecated during v0.4 cycle are now
hard-deprecated. They can still be used, but now a warning will appear
on startup.

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
