### PR TITLE
fix: gitsigns in fugitive buffer not visible

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -159,6 +159,23 @@ M.detach = function(bufnr, _keep_signs)
    cache:destroy(bufnr)
 end
 
+local function parse_fugitive_uri(name)
+   local _, _, root_path, sub_module_path, commit, real_path = 
+   name:find([[^fugitive://(.*)/%.git(.*/)/(%x-)/(.*)]])
+   if root_path then
+      sub_module_path = sub_module_path:gsub("^/modules", "")
+      name = root_path .. sub_module_path .. real_path
+   end
+   return name, commit
+end
+
+if _TEST then
+   local path, commit = parse_fugitive_uri(
+   'fugitive:///home/path/to/project/.git//1b441b947c4bc9a59db428f229456619051dd133/subfolder/to/a/file.txt')
+   assert(path == '/home/path/to/project/subfolder/to/a/file.txt', string.format('GOT %s', path))
+   assert(commit == '1b441b947c4bc9a59db428f229456619051dd133', string.format('GOT %s', commit))
+end
+
 local function get_buf_path(bufnr)
    local file = 
    uv.fs_realpath(api.nvim_buf_get_name(bufnr)) or
@@ -168,19 +185,11 @@ local function get_buf_path(bufnr)
    end)
 
    if vim.startswith(file, 'fugitive://') and vim.wo.diff == false then
-      local orig_path = file
-      local _, _, root_path, sub_module_path, commit, real_path = 
-      file:find([[^fugitive://(.*)/%.git(.*)/(%x-)/(.*)]])
-      if root_path then
-         sub_module_path = sub_module_path:gsub("^/modules", "")
-         file = root_path .. sub_module_path .. real_path
-         file = uv.fs_realpath(file)
-         dprintf("Fugitive buffer for file '%s' from path '%s'", file, orig_path)
-         if file then
-            return file, commit
-         else
-            file = orig_path
-         end
+      local path, commit = parse_fugitive_uri(file)
+      dprintf("Fugitive buffer for file '%s' from path '%s'", path, file)
+      path = uv.fs_realpath(path)
+      if path then
+         return path, commit
       end
    end
 

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -159,6 +159,23 @@ M.detach = function(bufnr: integer, _keep_signs: boolean)
   cache:destroy(bufnr)
 end
 
+local function parse_fugitive_uri(name: string): string, string
+  local _, _, root_path, sub_module_path, commit, real_path =
+    name:find([[^fugitive://(.*)/%.git(.*/)/(%x-)/(.*)]])
+  if root_path then
+    sub_module_path = sub_module_path:gsub("^/modules", "")
+    name = root_path .. sub_module_path .. real_path
+  end
+  return name, commit
+end
+
+if _TEST then
+  local path, commit = parse_fugitive_uri(
+    'fugitive:///home/path/to/project/.git//1b441b947c4bc9a59db428f229456619051dd133/subfolder/to/a/file.txt')
+  assert(path == '/home/path/to/project/subfolder/to/a/file.txt', string.format('GOT %s', path))
+  assert(commit == '1b441b947c4bc9a59db428f229456619051dd133', string.format('GOT %s', commit))
+end
+
 local function get_buf_path(bufnr: integer): string, string
   local file =
     uv.fs_realpath(api.nvim_buf_get_name(bufnr))
@@ -168,19 +185,11 @@ local function get_buf_path(bufnr: integer): string, string
     end)
 
   if vim.startswith(file, 'fugitive://') and vim.wo.diff == false then
-    local orig_path = file
-    local _,_, root_path, sub_module_path, commit, real_path =
-      file:find([[^fugitive://(.*)/%.git(.*)/(%x-)/(.*)]])
-    if root_path then
-      sub_module_path = sub_module_path:gsub("^/modules", "")
-      file = root_path .. sub_module_path .. real_path
-      file = uv.fs_realpath(file)
-      dprintf("Fugitive buffer for file '%s' from path '%s'", file, orig_path)
-      if file then
-        return file, commit
-      else
-        file = orig_path
-      end
+    local path, commit = parse_fugitive_uri(file)
+    dprintf("Fugitive buffer for file '%s' from path '%s'", path, file)
+    path = uv.fs_realpath(path)
+    if path then
+      return path, commit
     end
   end
 

--- a/test/unit_spec.lua
+++ b/test/unit_spec.lua
@@ -1,0 +1,13 @@
+local helpers = require('test.gs_helpers')
+local exec_lua = helpers.exec_lua
+local setup_gitsigns  = helpers.setup_gitsigns
+local clear           = helpers.clear
+
+describe('unit', function()
+  it('passes all _TEST blocks', function()
+    clear()
+    exec_lua('package.path = ...', package.path)
+    exec_lua('_TEST = true')
+    setup_gitsigns()
+  end)
+end)

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -1,5 +1,7 @@
 global _: any
 
+global _TEST: boolean
+
 global loadstring: function(string): (function(): any)
 
 global unpack: function<T>({T}, number, number): T...


### PR DESCRIPTION
The regular expression in gitsigns.lua did not recognize a path like:
`fugitive:///home/path/to/project/.git//1b441b947c4bc9a59db428f229456619051dd133/subfolder/to/a/file.txt`

Fixed it by adding a missing "/".  This is compatible with PR #152 and still works with git submodules.

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
