### PR TITLE
fix(compat): support PUC Lua

### DIFF
--- a/lua/gitsigns/nvim/autocmds_compat.lua
+++ b/lua/gitsigns/nvim/autocmds_compat.lua
@@ -9,7 +9,14 @@ function M._exec(id)
 end
 
 local function set_callback(fn)
-   local id = string.format("%p", fn)
+   local id
+
+   if jit then
+      id = string.format("%p", fn)
+   else
+      id = tostring(fn):match('function: (.*)')
+   end
+
    callbacks[id] = function() fn() end
    return string.format('lua require("gitsigns.nvim.autocmds_compat")._exec("%s")', id)
 end

--- a/teal/gitsigns/nvim/autocmds_compat.tl
+++ b/teal/gitsigns/nvim/autocmds_compat.tl
@@ -9,7 +9,14 @@ function M._exec(id: string)
 end
 
 local function set_callback(fn: function): string
-  local id = string.format("%p", fn)
+  local id: string
+
+  if jit then
+    id = string.format("%p", fn)
+  else
+    id = tostring(fn):match('function: (.*)')
+  end
+
   callbacks[id] = function() fn() end
   return string.format('lua require("gitsigns.nvim.autocmds_compat")._exec("%s")', id)
 end


### PR DESCRIPTION
LuaJIT supports the '%p' format string however PUC Lua does not
(see http://www.lua.org/manual/5.1/manual.html#pdf-string.format).

The autocmd compat module used '%p' to generate id's for Lua callbacks.

This change uses the jit module to detect LuaJIT. If LuaJIT is not
present then '%p' will not be used and instead tostring of the function
with a simple pattern match is used instead.

Fixes: #485
