### PR TITLE
fix(setup): don't defer setting up signs

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -7,6 +7,7 @@ local manager = require('gitsigns.manager')
 local nvim = require('gitsigns.nvim')
 local signs = require('gitsigns.signs')
 local util = require('gitsigns.util')
+local hl = require('gitsigns.highlight')
 
 local gs_cache = require('gitsigns.cache')
 local cache = gs_cache.cache
@@ -532,7 +533,8 @@ M.setup = void(function(cfg)
 
 
 
-   on_or_after_vimenter(manager.setup_signs_and_highlights)
+   on_or_after_vimenter(hl.setup_highlights)
+   manager.setup_signs()
 
    setup_command()
 
@@ -570,7 +572,7 @@ M.setup = void(function(cfg)
    nvim.augroup('gitsigns')
 
    autocmd('VimLeavePre', M.detach_all)
-   autocmd('ColorScheme', manager.setup_signs_and_highlights)
+   autocmd('ColorScheme', hl.setup_highlights)
    autocmd('BufRead', wrap_func(M.attach, nil, 'BufRead'))
    autocmd('BufNewFile', wrap_func(M.attach, nil, 'BufNewFile'))
    autocmd('BufWritePost', wrap_func(M.attach, nil, 'BufWritePost'))

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -991,7 +991,8 @@ end
 
 
 M.refresh = void(function()
-   manager.setup_signs_and_highlights(true)
+   manager.setup_signs(true)
+   require('gitsigns.highlight').setup_highlights()
    require('gitsigns.current_line_blame').setup()
    for k, v in pairs(cache) do
 

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -21,7 +21,6 @@ local util = require('gitsigns.util')
 local gs_hunks = require("gitsigns.hunks")
 local Hunk = gs_hunks.Hunk
 
-local setup_highlights = require('gitsigns.highlight').setup_highlights
 local config = require('gitsigns.config').config
 
 local api = vim.api
@@ -335,7 +334,7 @@ M.setup = function()
    M.update_debounced = debounce_trailing(config.update_debounce, void(M.update))
 end
 
-M.setup_signs_and_highlights = function(redefine)
+M.setup_signs = function(redefine)
 
    for t, sign_name in pairs(signs.sign_map) do
       local cs = config.signs[t]
@@ -348,8 +347,6 @@ M.setup_signs_and_highlights = function(redefine)
       }, redefine)
 
    end
-
-   setup_highlights()
 end
 
 return M

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -7,6 +7,7 @@ local manager    = require('gitsigns.manager')
 local nvim       = require('gitsigns.nvim')
 local signs      = require('gitsigns.signs')
 local util       = require('gitsigns.util')
+local hl         = require('gitsigns.highlight')
 
 local gs_cache   = require('gitsigns.cache')
 local cache      = gs_cache.cache
@@ -532,7 +533,8 @@ M.setup = void(function(cfg: Config)
   -- Make sure highlights are setup on or after VimEnter so the colorscheme is
   -- loaded. Do not set them up with vim.schedule as this removes the intro
   -- message.
-  on_or_after_vimenter(manager.setup_signs_and_highlights)
+  on_or_after_vimenter(hl.setup_highlights)
+  manager.setup_signs()
 
   setup_command()
 
@@ -570,7 +572,7 @@ M.setup = void(function(cfg: Config)
   nvim.augroup('gitsigns')
 
   autocmd('VimLeavePre' , M.detach_all)
-  autocmd('ColorScheme' , manager.setup_signs_and_highlights)
+  autocmd('ColorScheme' , hl.setup_highlights)
   autocmd('BufRead'     , wrap_func(M.attach, nil, 'BufRead'))
   autocmd('BufNewFile'  , wrap_func(M.attach, nil, 'BufNewFile'))
   autocmd('BufWritePost', wrap_func(M.attach, nil, 'BufWritePost'))

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -991,7 +991,8 @@ end
 --- Attributes: ~
 ---     {async}
 M.refresh = void(function()
-  manager.setup_signs_and_highlights(true)
+  manager.setup_signs(true)
+  require('gitsigns.highlight').setup_highlights()
   require('gitsigns.current_line_blame').setup()
   for k, v in pairs(cache as {integer:CacheEntry}) do
     -- Invalidate cache fields

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -21,7 +21,6 @@ local util              = require('gitsigns.util')
 local gs_hunks          = require("gitsigns.hunks")
 local Hunk              = gs_hunks.Hunk
 
-local setup_highlights  = require('gitsigns.highlight').setup_highlights
 local config            = require('gitsigns.config').config
 
 local api = vim.api
@@ -35,7 +34,7 @@ local record M
   apply_word_diff: function(buf: integer, row: integer)
 
   setup: function()
-  setup_signs_and_highlights: function(redefine: boolean)
+  setup_signs: function(redefine: boolean)
 end
 
 local schedule_if_buf_valid = function(buf: integer, cb: function)
@@ -335,7 +334,7 @@ M.setup = function()
   M.update_debounced = debounce_trailing(config.update_debounce, void(M.update)) as function(integer)
 end
 
-M.setup_signs_and_highlights = function(redefine: boolean)
+M.setup_signs = function(redefine: boolean)
   -- Define signs
   for t, sign_name in pairs(signs.sign_map) do
     local cs = config.signs[t]
@@ -348,8 +347,6 @@ M.setup_signs_and_highlights = function(redefine: boolean)
     }, redefine)
 
   end
-
-  setup_highlights()
 end
 
 return M


### PR DESCRIPTION
Sign must be defined before running any updates.

Fixes #490
