### PR TITLE
Fix `indent_heuristic` data type in the documentation

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -534,7 +534,7 @@ diff_opts                                          *gitsigns-config-diff_opts*
 
             Note Neovim v0.5 uses LuaJIT's FFI interface, whereas v0.5+ uses
             `vim.diff`.
-        • indent_heuristic: string
+        • indent_heuristic: boolean
             Use the indent heuristic for the internal
             diff library.
         • vertical: boolean


### PR DESCRIPTION
The documentation states `indent_heuristic` is a string when it should be `boolean`.
