### PR TITLE
fix: #521

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -304,7 +304,7 @@ local attach0 = function(cbuf, aucmd)
 
             return
          end
-         return manager.on_lines(buf, last_orig, last_new)
+         return manager.on_lines(buf, first, last_orig, last_new)
       end,
       on_reload = function(_, bufnr)
          local __FUNC__ = 'on_reload'

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -70,11 +70,18 @@ function M.apply_win_signs(bufnr, hunks, top, bot, clear)
    signs.draw(bufnr, top, bot)
 end
 
-M.on_lines = function(buf, _, _)
+M.on_lines = function(buf, first, _, last_new)
    local bcache = cache[buf]
    if not bcache then
       dprint('Cache for buffer was nil. Detaching')
       return true
+   end
+
+
+
+   if bcache.hunks and signs.need_redraw(buf, first, last_new) then
+
+      bcache.hunks = nil
    end
 
    M.update_debounced(buf, cache[buf])

--- a/lua/gitsigns/signs/base.lua
+++ b/lua/gitsigns/signs/base.lua
@@ -22,4 +22,5 @@ local M = {Sign = {}, }
 
 
 
+
 return M

--- a/lua/gitsigns/signs/extmarks.lua
+++ b/lua/gitsigns/signs/extmarks.lua
@@ -112,4 +112,10 @@ function M.add(cfg, bufnr, signs)
    end
 end
 
+function M.need_redraw(bufnr, start, last)
+
+   local marks = api.nvim_buf_get_extmarks(bufnr, ns_em, { start, 0 }, { last + 1, 0 }, { limit = 1 })
+   return #marks > 0
+end
+
 return M

--- a/lua/gitsigns/signs/vimfn.lua
+++ b/lua/gitsigns/signs/vimfn.lua
@@ -147,4 +147,13 @@ function M.add(cfg, bufnr, signs)
    end
 end
 
+function M.need_redraw(bufnr, start, last)
+   for i = start + 1, last + 1 do
+      if placed[bufnr][i] then
+         return true
+      end
+   end
+   return false
+end
+
 return M

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -304,7 +304,7 @@ local attach0 = function(cbuf: integer, aucmd: string)
         -- call which indicates no changes.
         return
       end
-      return manager.on_lines(buf, last_orig, last_new)
+      return manager.on_lines(buf, first, last_orig, last_new)
     end,
     on_reload = function(_, bufnr: integer)
       local __FUNC__ = 'on_reload'

--- a/teal/gitsigns/debounce.tl
+++ b/teal/gitsigns/debounce.tl
@@ -2,9 +2,9 @@ local M = {}
 
 --- Debounces a function on the trailing edge.
 ---
---@param ms (number) Timeout in ms
---@param fn (function) Function to debounce
---@returns (function) Debounced function.
+---@param ms (number) Timeout in ms
+---@param fn (function) Function to debounce
+---@returns (function) Debounced function.
 function M.debounce_trailing(ms: number, fn: function): function
   local timer = vim.loop.new_timer()
   return function(...)

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -27,10 +27,10 @@ local config            = require('gitsigns.config').config
 local api = vim.api
 
 local record M
-  update           : function(integer, CacheEntry)
-  update_debounced : function(integer, CacheEntry)
+  update           : function(integer, CacheEntry, boolean)
+  update_debounced : function( bufnr: integer, CacheEntry)
   apply_win_signs  : function(bufnr: integer, {Hunk}, top: integer, bot: integer)
-  on_lines         : function(buf: integer, last_orig: integer, last_new: integer): boolean
+  on_lines         : function(buf: integer, first: integer, last_orig: integer, last_new: integer): boolean
 
   apply_word_diff: function(buf: integer, row: integer)
 
@@ -70,11 +70,18 @@ function M.apply_win_signs(bufnr: integer, hunks: {Hunk}, top: integer, bot: int
   signs.draw(bufnr, top, bot)
 end
 
-M.on_lines = function(buf: integer, _: integer, _: integer): boolean
+M.on_lines = function(buf: integer, first: integer, _: integer, last_new: integer): boolean
   local bcache = cache[buf]
   if not bcache then
     dprint('Cache for buffer was nil. Detaching')
     return true
+  end
+
+  -- Signs in changed regions get invalidated so we need to force a redraw if
+  -- any signs get removed.
+  if bcache.hunks and signs.need_redraw(buf, first, last_new) then
+    -- invalidate hunks to force a sign redraw
+    bcache.hunks = nil
   end
 
   M.update_debounced(buf, cache[buf])
@@ -245,7 +252,7 @@ end
 M.update = throttle_by_id(update0, true) as function(integer, CacheEntry)
 
 M.setup = function()
-  M.update_debounced = debounce_trailing(config.update_debounce, void(M.update)) as function(integer)
+  M.update_debounced = debounce_trailing(config.update_debounce, void(M.update)) as function(integer, CacheEntry)
 end
 
 return M

--- a/teal/gitsigns/signs/base.tl
+++ b/teal/gitsigns/signs/base.tl
@@ -20,6 +20,7 @@ local record M
   remove  : function(bufnr: integer, lnum: integer)
   schedule: function(cfg: Config, bufnr: integer, signs: {M.Sign})
   add     : function(cfg: Config, bufnr: integer, signs: {M.Sign})
+  need_redraw: function(bufnr: integer, start: integer, last: integer): boolean
 end
 
 return M

--- a/teal/gitsigns/signs/extmarks.tl
+++ b/teal/gitsigns/signs/extmarks.tl
@@ -112,4 +112,10 @@ function M.add(cfg: Config, bufnr: integer, signs: {M.Sign})
   end
 end
 
+function M.need_redraw(bufnr: integer, start: integer, last: integer): boolean
+  -- Use nvim_buf_get_extmarks as that should be quicker than scanning 'placed'
+  local marks = api.nvim_buf_get_extmarks(bufnr, ns_em, {start, 0}, {last+1, 0}, {limit=1})
+  return #marks > 0
+end
+
 return M

--- a/teal/gitsigns/signs/vimfn.tl
+++ b/teal/gitsigns/signs/vimfn.tl
@@ -147,4 +147,13 @@ function M.add(cfg: Config, bufnr: integer, signs: {M.Sign})
   end
 end
 
+function M.need_redraw(bufnr: integer, start: integer, last: integer): boolean
+  for i = start+1, last+1 do
+    if placed[bufnr][i] then
+      return true
+    end
+  end
+  return false
+end
+
 return M

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -54,7 +54,20 @@ local record api
   nvim_buf_get_changedtick: function(number): number
   nvim_buf_get_commands: function(number, {string:any}): {string:any}
   nvim_buf_get_extmark_by_id: function(number, number, number, table): {number}
-  nvim_buf_get_extmarks: function(number, number, any, any, {string:any}): any
+
+  record GetExtmarOpts
+    limit: integer
+    details: boolean
+  end
+
+  nvim_buf_get_extmarks: function(
+    buf: integer,
+    ns: integer,
+    start: integer | {integer, integer},
+    eend: integer | {integer, integer},
+    GetExtmarOpts
+  ): {{integer, integer, integer}}
+
   nvim_buf_get_keymap: function(number, string): {{string:any}}
   nvim_buf_get_lines: function(number, number, number, boolean): {string}
   nvim_buf_get_mark: function(number, string): {number}


### PR DESCRIPTION
Any lines changed by nvim_buf_set_text lose their signs so we need to
force a sign redraw when this happens.setup

In particular `vim.lsp.buf.formatting_sync` causes the whole buffer to be
rewritten which removes all the signs.
