### PR TITLE
feat(blame): autodetect .git-blame-ignore-revs

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -411,16 +411,25 @@ Obj.run_blame = function(self, lines, lnum, ignore_whitespace)
          ['committer-mail'] = '<not.committed.yet>',
       }
    end
-   local results = self:command({
+
+   local args = {
       'blame',
       '--contents', '-',
       '-L', lnum .. ',+1',
       '--line-porcelain',
       self.file,
-      ignore_whitespace and '-w' or nil,
-   }, {
-      writer = lines,
-   })
+   }
+
+   if ignore_whitespace then
+      args[#args + 1] = '-w'
+   end
+
+   local ignore_file = self.repo.toplevel .. '/.git-blame-ignore-revs'
+   if uv.fs_stat(ignore_file) then
+      vim.list_extend(args, { '--ignore-revs-file', ignore_file })
+   end
+
+   local results = self:command(args, { writer = lines })
    if #results == 0 then
       return
    end

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -411,16 +411,25 @@ Obj.run_blame = function(self: Obj, lines: {string}, lnum: number, ignore_whites
       ['committer-mail'] = '<not.committed.yet>',
     }
   end
-  local results = self:command({
-      'blame',
-      '--contents', '-',
-      '-L', lnum..',+1',
-      '--line-porcelain',
-      self.file,
-      ignore_whitespace and '-w' or nil,
-    }, {
-    writer = lines,
-  })
+
+  local args = {
+    'blame',
+    '--contents', '-',
+    '-L', lnum..',+1',
+    '--line-porcelain',
+    self.file
+  }
+
+  if ignore_whitespace then
+    args[#args+1] = '-w'
+  end
+
+  local ignore_file = self.repo.toplevel ..'/.git-blame-ignore-revs'
+  if uv.fs_stat(ignore_file) then
+    vim.list_extend(args, {'--ignore-revs-file', ignore_file})
+  end
+
+  local results = self:command(args, { writer = lines })
   if #results == 0 then
     return
   end


### PR DESCRIPTION
Git blame has a --ignore-revs-file option for specifying a list of SHA's
to exclude. The common convention (according to a quick Google) is to
call this file .git-blame-ignore-revs. Gitsigns will now look for this
file at the top level of the repo and use it if found.

Resolves #459