### PR TITLE
fix: be more graceful with binary files

### DIFF
--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -19,9 +19,11 @@ local function bufnr_calc_width(bufnr, lines)
    return api.nvim_buf_call(bufnr, function()
       local width = 0
       for _, l in ipairs(lines) do
-         local len = vim.fn.strdisplaywidth(l)
-         if len > width then
-            width = len
+         if vim.fn.type(l) == vim.v.t_string then
+            local len = vim.fn.strdisplaywidth(l)
+            if len > width then
+               width = len
+            end
          end
       end
       return width + 1

--- a/teal/gitsigns/git.tl
+++ b/teal/gitsigns/git.tl
@@ -69,7 +69,7 @@ local record M
 
     command            : function(Repo, {string}, GJobSpec): {string}, string
     files_changed      : function(Repo): {string}
-    get_show_text      : function(Repo, string): {string}, string
+    get_show_text      : function(Repo, string, string): {string}, string
     update_abbrev_head : function(Repo)
     new                : function(string): Repo
   end
@@ -286,8 +286,20 @@ Repo.files_changed = function(self: Repo): {string}
 end
 
 --- Get version of file in the index, return array lines
-Repo.get_show_text = function(self: Repo, object: string): {string}, string
-  return self:command({'show', object}, {supress_stderr = true})
+Repo.get_show_text = function(self: Repo, object: string, encoding: string): {string}, string
+  local stdout, stderr = self:command({'show', object}, {supress_stderr = true})
+
+  if encoding ~= 'utf-8' then
+    scheduler()
+    for i, l in ipairs(stdout) do
+      -- TODO(lewis6991): How should we handle blob types?
+      if vim.fn.type(l) == vim.v.t_string then
+        stdout[i] = vim.fn.iconv(l, encoding, 'utf-8')
+      end
+    end
+  end
+
+  return stdout, stderr
 end
 
 Repo.update_abbrev_head = function(self: Repo)
@@ -384,19 +396,12 @@ Obj.get_show_text = function(self: Obj, revision: string): {string}, string
     return {}
   end
 
-  local stdout, stderr =  self.repo:get_show_text(revision..':'..self.relpath)
+  local stdout, stderr =  self.repo:get_show_text(revision..':'..self.relpath, self.encoding)
 
   if not self.i_crlf and self.w_crlf then
     -- Add cr
     for i = 1, #stdout do
       stdout[i] = stdout[i]..'\r'
-    end
-  end
-
-  if self.encoding ~= 'utf-8' then
-    scheduler()
-    for i, l in ipairs(stdout) do
-      stdout[i] = vim.fn.iconv(l, self.encoding, 'utf-8')
     end
   end
 

--- a/teal/gitsigns/popup.tl
+++ b/teal/gitsigns/popup.tl
@@ -19,9 +19,11 @@ local function bufnr_calc_width(bufnr: integer, lines: {string}): integer
   return api.nvim_buf_call(bufnr, function(): integer
     local width = 0
     for _, l in ipairs(lines) do
-      local len = vim.fn.strdisplaywidth(l)
-      if len > width then
-        width = len
+      if vim.fn.type(l) == vim.v.t_string then
+        local len = vim.fn.strdisplaywidth(l)
+        if len > width then
+          width = len
+        end
       end
     end
     return width + 1 -- Add 1 for some miinor padding

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -280,7 +280,9 @@ global record vim
     sign_undefine: function(string): number
     strdisplaywidth: function(string, integer): integer
     stridx: function(haystack: string, needle: string, start: integer): integer
+    string: function(any): string
     tempname: function(): string
+    type: function(any): integer
   end
 
   cmd: function(string): any
@@ -336,6 +338,7 @@ global record vim
 
   record v
     vim_did_enter: integer
+    t_string: integer
   end
 
 


### PR DESCRIPTION
Diffs will still be wrong as we can't detect if the file is binary or
not without using .gitattributes

Fixes: #549

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
