### PR TITLE
doc: telescope no longer supports `lsp_code_actions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,6 @@ null_ls.setup {
 ```
 
 Will enable `:lua vim.lsp.buf.code_action()` to retrieve code actions from Gitsigns.
-Alternatively if you have [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) installed, you can use `:Telescope lsp_code_actions`.
 
 ### [trouble.nvim](https://github.com/folke/trouble.nvim)
 


### PR DESCRIPTION
Telescope removed support for `code_actions`.
See: `help telescope.changelog-1866`

Ref: https://github.com/nvim-telescope/telescope.nvim/pull/1866

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?