### PR TITLE
fix: don't set default for GitSignsDeleteLn

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -559,7 +559,7 @@ show_deleted                                    *gitsigns-config-show_deleted*
 
       Show the old version of hunks inline in the buffer (via virtual lines).
 
-      Note: Virtual lines currently use the highlight `GitSignsDeleteLn`.
+      Note: Virtual lines currently use the highlight `GitSignsDeleteVirtLn`.
 
 diff_opts                                          *gitsigns-config-diff_opts*
       Type: `table[extended]`, Default: derived from 'diffopt'

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -269,7 +269,7 @@ M.schema = {
       description = [[
       Show the old version of hunks inline in the buffer (via virtual lines).
 
-      Note: Virtual lines currently use the highlight `GitSignsDeleteLn`.
+      Note: Virtual lines currently use the highlight `GitSignsDeleteVirtLn`.
     ]],
    },
 

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -19,7 +19,8 @@ local hls = {
 
    { GitSignsAddLn = { 'GitGutterAddLine', 'SignifyLineAdd', 'DiffAdd' } },
    { GitSignsChangeLn = { 'GitGutterChangeLine', 'SignifyLineChange', 'DiffChange' } },
-   { GitSignsDeleteLn = { 'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete' } },
+
+
 
    { GitSignsCurrentLineBlame = { 'NonText' } },
 
@@ -33,7 +34,7 @@ local hls = {
 
    { GitSignsAddLnVirtLn = { 'GitSignsAddLn' } },
    { GitSignsChangeVirtLn = { 'GitSignsChangeLn' } },
-   { GitSignsDeleteVirtLn = { 'GitSignsDeleteLn' } },
+   { GitSignsDeleteVirtLn = { 'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete' } },
 
    { GitSignsAddLnVirtLnInLine = { 'GitSignsAddLnInline' } },
    { GitSignsChangeVirtLnInLine = { 'GitSignsChangeLnInline' } },

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -187,19 +187,19 @@ local function show_deleted(bufnr)
                if rline > 1 then
                   break
                end
-               vline[#vline + 1] = { line:sub(last_ecol, scol - 1), 'GitsignsDeleteVirtLn' }
-               vline[#vline + 1] = { line:sub(scol, ecol - 1), 'GitsignsDeleteVirtLnInline' }
+               vline[#vline + 1] = { line:sub(last_ecol, scol - 1), 'GitSignsDeleteVirtLn' }
+               vline[#vline + 1] = { line:sub(scol, ecol - 1), 'GitSignsDeleteVirtLnInline' }
                last_ecol = ecol
             end
          end
 
          if #line > 0 then
-            vline[#vline + 1] = { line:sub(last_ecol, -1), 'GitsignsDeleteVirtLn' }
+            vline[#vline + 1] = { line:sub(last_ecol, -1), 'GitSignsDeleteVirtLn' }
          end
 
 
          local padding = string.rep(' ', VIRT_LINE_LEN - #line)
-         vline[#vline + 1] = { padding, 'GitsignsDeleteVirtLn' }
+         vline[#vline + 1] = { padding, 'GitSignsDeleteVirtLn' }
 
          virt_lines[i] = vline
       end

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -269,7 +269,7 @@ M.schema = {
     description = [[
       Show the old version of hunks inline in the buffer (via virtual lines).
 
-      Note: Virtual lines currently use the highlight `GitSignsDeleteLn`.
+      Note: Virtual lines currently use the highlight `GitSignsDeleteVirtLn`.
     ]]
   },
 

--- a/teal/gitsigns/highlight.tl
+++ b/teal/gitsigns/highlight.tl
@@ -19,7 +19,8 @@ local hls: {{string:{string}}} = {
 
   {GitSignsAddLn              = {'GitGutterAddLine'   , 'SignifyLineAdd'   , 'DiffAdd'   }},
   {GitSignsChangeLn           = {'GitGutterChangeLine', 'SignifyLineChange', 'DiffChange'}},
-  {GitSignsDeleteLn           = {'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete'}},
+  -- Don't set GitSignsDeleteLn by default
+  -- {GitSignsDeleteLn           = {}},
 
   {GitSignsCurrentLineBlame   = {'NonText'}},
 
@@ -33,7 +34,7 @@ local hls: {{string:{string}}} = {
 
   {GitSignsAddLnVirtLn        = {'GitSignsAddLn'   }},
   {GitSignsChangeVirtLn       = {'GitSignsChangeLn'}},
-  {GitSignsDeleteVirtLn       = {'GitSignsDeleteLn'}},
+  {GitSignsDeleteVirtLn       = {'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete'}},
 
   {GitSignsAddLnVirtLnInLine  = {'GitSignsAddLnInline'   }},
   {GitSignsChangeVirtLnInLine = {'GitSignsChangeLnInline'}},

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -187,19 +187,19 @@ local function show_deleted(bufnr: integer)
           if rline > 1 then
             break
           end
-          vline[#vline+1] = { line:sub(last_ecol, scol-1), 'GitsignsDeleteVirtLn'}
-          vline[#vline+1] = { line:sub(scol, ecol-1), 'GitsignsDeleteVirtLnInline'}
+          vline[#vline+1] = { line:sub(last_ecol, scol-1), 'GitSignsDeleteVirtLn'}
+          vline[#vline+1] = { line:sub(scol, ecol-1), 'GitSignsDeleteVirtLnInline'}
           last_ecol = ecol
         end
       end
 
       if #line > 0 then
-        vline[#vline+1] = { line:sub(last_ecol, -1), 'GitsignsDeleteVirtLn'}
+        vline[#vline+1] = { line:sub(last_ecol, -1), 'GitSignsDeleteVirtLn'}
       end
 
       -- Add extra padding so the entire line is highlighted
       local padding = string.rep(' ', VIRT_LINE_LEN-#line)
-      vline[#vline+1] = { padding, 'GitsignsDeleteVirtLn'}
+      vline[#vline+1] = { padding, 'GitSignsDeleteVirtLn'}
 
       virt_lines[i] = vline
     end

--- a/test/highlights_spec.lua
+++ b/test/highlights_spec.lua
@@ -69,7 +69,6 @@ describe('highlights', function()
         p'Deriving GitSignsChangeLn from DiffChange',
         p'Deriving GitSignsChangeNr from GitSignsChange',
         p'Deriving GitSignsDelete from DiffDelete',
-        p'Deriving GitSignsDeleteLn from DiffDelete',
         p'Deriving GitSignsDeleteNr from GitSignsDelete',
       })
     end)


### PR DESCRIPTION
Setting GitSignsDeleteLn to anything by default doesn't make much sense
since it ends up highlighting lines not related to the hunk. This is
especially confusing when show_deleted is enabled.

+ Fix incorrect docs.

Fixes #565
