### PR TITLE
feat(command): better processing of command args

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -199,12 +199,25 @@ show({revision})                                             *gitsigns.show()*
                 Attributes: ~
                     {async}
 
-diffthis({base})                                         *gitsigns.diffthis()*
+diffthis({base}, {opts})                                 *gitsigns.diffthis()*
                 Perform a |vimdiff| on the given file with {base} if it is
                 given, or with the currently set base (index by default).
 
                 If {base} is the index, then the opened buffer is editable and
                 any written changes will update the index accordingly.
+
+                Parameters: ~
+                    {base}   (string|nil): Revision to diff against. Defaults
+                             to index.
+                    {opts}   (table|nil):
+                             Additional options:
+                             • {vertical}: {boolean}. Split window vertically. Defaults to
+                             config.diff_opts.vertical. If running via command line, then
+                             this is taken from the command modifiers.
+                             • {split}: {string}. One of: 'aboveleft', 'belowright',
+                             'botright', 'rightbelow', 'leftabove', 'topleft'. Defaults to
+                             'aboveleft'. If running via command line, then this is taken
+                             from the command modifiers.
 
                 Examples: >
                   " Diff against the index
@@ -380,6 +393,8 @@ stage_hunk({range})                                    *gitsigns.stage_hunk()*
                 Parameters:~
                     {range} table|nil List-like table of two integers making
                     up the line range from which you want to stage the hunks.
+                    If running via command line, then this is taken from the
+                    command modifiers.
 
 toggle_deleted({value})                            *gitsigns.toggle_deleted()*
                 Toggle |gitsigns-config-show_deleted|

--- a/lua/gitsigns/diffthis.lua
+++ b/lua/gitsigns/diffthis.lua
@@ -17,7 +17,12 @@ local throttle_by_id = require('gitsigns.debounce').throttle_by_id
 
 local input = awrap(vim.ui.input, 2)
 
-local M = {}
+local M = {DiffthisOpts = {}, }
+
+
+
+
+
 
 
 
@@ -63,12 +68,14 @@ local bufwrite = void(function(bufnr, dbufnr, base, bcache)
    end
 end)
 
-local function run(base, diffthis, vertical)
+local function run(base, diffthis, opts)
    local bufnr = vim.api.nvim_get_current_buf()
    local bcache = cache[bufnr]
    if not bcache then
       return
    end
+
+   opts = opts or {}
 
    local comp_rev = bcache:get_compare_rev(util.calc_base(base))
    local bufname = bcache:get_rev_bufname(comp_rev)
@@ -114,26 +121,21 @@ local function run(base, diffthis, vertical)
    end
 
    if diffthis then
-      local split_mod = vim.o.splitright and 'botright' or 'aboveleft'
       vim.cmd(table.concat({
-         'keepalt', split_mod,
-         vertical and 'vertical' or '',
+         'keepalt', opts.split or 'aboveleft',
+         opts.vertical and 'vertical' or '',
          'diffsplit', bufname,
       }, ' '))
    else
-
-
-      vim.cmd(table.concat({
-         'edit', bufname,
-      }, ' '))
+      vim.cmd('edit ' .. bufname)
    end
 end
 
-M.diffthis = void(function(base, vertical)
+M.diffthis = void(function(base, opts)
    if vim.wo.diff then
       return
    end
-   run(base, true, vertical)
+   run(base, true, opts)
 end)
 
 M.show = void(function(base)

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -304,49 +304,52 @@ end
 --   'nil'      -> nil
 --   '100'      -> 100
 --   'HEAD~300' -> 'HEAD~300'
-local function parse_args_to_lua(...: string): {any}
-  local args: {any} = {}
-  for i, a in ipairs({...}) do
-    if tonumber(a) then
-      args[i] = tonumber(a)
-    elseif a == 'false' or a == 'true' then
-      args[i] = a == 'true'
-    elseif a == 'nil' then
-      args[i] = nil
-    else
-      args[i] = a
-    end
+local function parse_to_lua(a: string): any
+  if tonumber(a) then
+    return tonumber(a)
+  elseif a == 'false' or a == 'true' then
+    return a == 'true'
+  elseif a == 'nil' then
+    return nil
   end
-  return args
+  return a
 end
 
-local function run_func(range: {integer, integer, integer}, func: string, ...: string)
+local function run_cmd_func(params: api.UserCmdParams)
+  local pos_args_raw, named_args_raw = require('gitsigns.argparse').parse_args(params.args)
+
+  local func = pos_args_raw[1]
+  local pos_args = vim.tbl_map(parse_to_lua, vim.list_slice(pos_args_raw, 2)) as {any}
+  local named_args = vim.tbl_map(parse_to_lua, named_args_raw) as {string:any}
+
   local actions = require('gitsigns.actions')
   local actions0 = actions as {string:function}
 
-  local args = parse_args_to_lua(...)
+  local cmd_func = actions.get_cmd_func(func)
+  if cmd_func then
+    -- Action has a specialised mapping function from command form to lua
+    -- function
+    cmd_func(pos_args, named_args, params)
+    return
+  end
 
   if type(actions0[func]) == 'function' then
-    if range and range[1] > 0 then
-      actions.user_range = {range[2], range[3]}
-    else
-      actions.user_range = nil
-    end
-    actions0[func](unpack(args))
-    actions.user_range = nil
+    actions0[func](unpack(pos_args), named_args)
     return
   end
+
   if type(M0[func]) == 'function' then
-    M0[func](unpack(args))
+    -- Note functions here do not have named arguments
+    M0[func](unpack(pos_args))
     return
   end
+
+  error(string.format('%s is not a valid function or action', func))
 end
 
 local function setup_command()
-  nvim.command('Gitsigns', function(params: api.UserCmdParams)
-    local fargs = require('gitsigns.argparse').parse_args(params.args)
-    run_func({params.range, params.line1, params.line2}, unpack(fargs))
-  end, { force = true, nargs = '+', range = true, complete = complete })
+  nvim.command('Gitsigns', run_cmd_func,
+  { force = true, nargs = '+', range = true, complete = complete })
 end
 
 local function wrap_func(fn: function, ...: any): function()

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -20,6 +20,11 @@ local Hunk_Public = gs_hunks.Hunk_Public
 local api = vim.api
 local current_buf = api.nvim_get_current_buf
 
+local record DiffthisOpts
+  vertical: boolean
+  split: string
+end
+
 local record NavHunkOpts
   forwards: boolean
   wrap: boolean
@@ -51,8 +56,10 @@ local record M
   blame_line         : function(BlameOpts)
   change_base        : function(base: string, global: boolean)
   reset_base         : function(global: boolean)
-  diffthis           : function(base: string)
+  diffthis           : function(base: string, opts: DiffthisOpts)
   show               : function(base: string)
+
+  test: function(base: string, opts: {string:any})
 
   record QFListOpts
     use_location_list: boolean
@@ -63,8 +70,6 @@ local record M
   setqflist          : function(target:integer|string, opts: QFListOpts, callback: function)
   setloclist         : function(nr: integer, target:integer|string)
 
-  user_range         : {integer, integer}
-
   get_actions        : function(bufnr: integer, lnum: integer)
 
   refresh            : function()
@@ -74,7 +79,14 @@ local record M
   toggle_word_diff   : function(boolean): boolean
   toggle_current_line_blame : function(boolean): boolean
   toggle_deleted     : function(boolean): boolean
+
+  arg_spec: {string:{integer,boolean,boolean}}
 end
+
+local type CmdFunc = function(pos_args: {any}, named_args: {string:any}, params: api.UserCmdParams)
+
+-- Variations of functions from M which are used for the Gitsigns command
+local C: {string:CmdFunc} = {}
 
 --- Toggle |gitsigns-config-signbooleancolumn|
 ---
@@ -200,6 +212,14 @@ local function update(bufnr: integer)
   end
 end
 
+local function get_range(params: api.UserCmdParams): {integer, integer}
+  local range: {integer, integer}
+  if params.range > 0 then
+    range = {params.line1, params.line2}
+  end
+  return range
+end
+
 --- Stage the hunk at the cursor position, or all lines in the
 --- given range. If {range} is provided, all lines in the given
 --- range are staged. This supports partial-hunks, meaning if a
@@ -212,8 +232,9 @@ end
 --- Parameters:~
 ---     {range} table|nil List-like table of two integers making
 ---     up the line range from which you want to stage the hunks.
+---     If running via command line, then this is taken from the
+---     command modifiers.
 M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
-  range = range or M.user_range
   local bufnr = current_buf()
   local bcache = cache[bufnr]
   if not bcache then
@@ -253,6 +274,10 @@ M.stage_hunk = mk_repeatable(void(function(range: {integer, integer})
   update(bufnr)
 end))
 
+C.stage_hunk = function(_pos_args: {any}, _named_args: {string:any}, params: api.UserCmdParams)
+  M.stage_hunk(get_range(params))
+end
+
 --- Reset the lines of the hunk at the cursor position, or all
 --- lines in the given range. If {range} is provided, all lines in
 --- the given range are reset. This supports partial-hunks,
@@ -263,7 +288,6 @@ end))
 ---     {range} table|nil List-like table of two integers making
 ---     up the line range from which you want to reset the hunks.
 M.reset_hunk = mk_repeatable(function(range: {integer, integer})
-  range = range or M.user_range
   local bufnr = current_buf()
   local bcache = cache[bufnr]
   if not bcache then
@@ -300,6 +324,10 @@ M.reset_hunk = mk_repeatable(function(range: {integer, integer})
   end
   util.set_lines(bufnr, lstart, lend, hunk.removed.lines)
 end)
+
+C.reset_hunk = function(_pos_args: {any}, _named_args: {string:any}, params: api.UserCmdParams)
+  M.reset_hunk(get_range(params))
+end
 
 --- Reset the lines of all hunks in the buffer.
 M.reset_buffer = function()
@@ -832,6 +860,19 @@ end
 --- If {base} is the index, then the opened buffer is editable and
 --- any written changes will update the index accordingly.
 ---
+--- Parameters: ~
+---     {base}   (string|nil): Revision to diff against. Defaults
+---              to index.
+---     {opts}   (table|nil):
+---              Additional options:
+---              • {vertical}: {boolean}. Split window vertically. Defaults to
+---              config.diff_opts.vertical. If running via command line, then
+---              this is taken from the command modifiers.
+---              • {split}: {string}. One of: 'aboveleft', 'belowright',
+---              'botright', 'rightbelow', 'leftabove', 'topleft'. Defaults to
+---              'aboveleft'. If running via command line, then this is taken
+---              from the command modifiers.
+---
 --- Examples: >
 ---   " Diff against the index
 ---   :Gitsigns diffthis
@@ -845,10 +886,38 @@ end
 ---
 --- Attributes: ~
 ---     {async}
-M.diffthis = function(base: string)
+M.diffthis = function(base: string, opts: DiffthisOpts)
+  opts = opts or {}
   local diffthis = require('gitsigns.diffthis')
-  diffthis.diffthis(base, config.diff_opts.vertical)
+  if not opts.vertical then
+    opts.vertical = config.diff_opts.vertical
+  end
+  diffthis.diffthis(base, opts as diffthis.DiffthisOpts)
 end
+
+C.diffthis = function(pos_args: {any}, named_args: {string:any}, params: api.UserCmdParams)
+  local opts: DiffthisOpts = {
+    vertical = named_args.vertical as boolean,
+    split    = named_args.split as string
+  }
+
+  if params.mods then
+    if opts.split == nil then
+      opts.split = params.smods.split
+    end
+    if opts.vertical == nil then
+      opts.vertical = params.smods.vertical
+    end
+  end
+
+  M.diffthis(pos_args[1] as string, opts)
+end
+
+-- C.test = function(pos_args: {any}, named_args: {string:any}, params: api.UserCmdParams)
+--   print('POS ARGS:', vim.inspect(pos_args))
+--   print('NAMED ARGS:', vim.inspect(named_args))
+--   print('PARAMS:', vim.inspect(params))
+-- end
 
 --- Show revision {base} of the current file, if it is given, or
 --- with the currently set base (index by default).
@@ -1063,5 +1132,9 @@ M.refresh = void(function()
     manager.update(k, v)
   end
 end)
+
+function M.get_cmd_func(name: string): CmdFunc
+  return C[name]
+end
 
 return M

--- a/teal/gitsigns/diffthis.tl
+++ b/teal/gitsigns/diffthis.tl
@@ -18,7 +18,12 @@ local throttle_by_id = require('gitsigns.debounce').throttle_by_id
 local input = awrap(vim.ui.input, 2)
 
 local record M
-  diffthis: function(base: string, vertical: boolean)
+  record DiffthisOpts
+    vertical: boolean
+    split: string
+  end
+
+  diffthis: function(base: string, opts: DiffthisOpts)
   show: function(base: string)
   update: function(bufnr: integer)
 end
@@ -63,12 +68,14 @@ local bufwrite = void(function(bufnr: integer, dbufnr: integer, base: string, bc
   end
 end)
 
-local function run(base: string, diffthis: boolean, vertical: boolean)
+local function run(base: string, diffthis: boolean, opts: M.DiffthisOpts)
   local bufnr = vim.api.nvim_get_current_buf()
   local bcache = cache[bufnr]
   if not bcache then
     return
   end
+
+  opts = opts or {}
 
   local comp_rev = bcache:get_compare_rev(util.calc_base(base))
   local bufname = bcache:get_rev_bufname(comp_rev)
@@ -114,26 +121,21 @@ local function run(base: string, diffthis: boolean, vertical: boolean)
   end
 
   if diffthis then
-    local split_mod = vim.o.splitright and 'botright' or 'aboveleft'
     vim.cmd(table.concat({
-      'keepalt', split_mod,
-      vertical and 'vertical' or '',
+      'keepalt', opts.split or 'aboveleft',
+      opts.vertical and 'vertical' or '',
       'diffsplit', bufname
     }, ' '))
   else
-    -- TODO(lewis6991): Pull in mods from the :Gitsigns command (split, vsplit,
-    -- etc)
-    vim.cmd(table.concat({
-      'edit', bufname
-    }, ' '))
+    vim.cmd('edit '..bufname)
   end
 end
 
-M.diffthis = void(function(base: string, vertical: boolean)
+M.diffthis = void(function(base: string, opts: M.DiffthisOpts)
   if vim.wo.diff then
     return
   end
-  run(base, true, vertical)
+  run(base, true, opts)
 end)
 
 M.show = void(function(base: string)

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -29,7 +29,37 @@ local record api
     count: number
     reg: string
     mods: string
+
+    record Mods
+      browse       : boolean
+      confirm      : boolean
+      emsg_silent  : boolean
+      hide         : boolean
+      keepalt      : boolean
+      keepjumps    : boolean
+      keepmarks    : boolean
+      keeppatterns : boolean
+      lockmarks    : boolean
+      noautocmd    : boolean
+      noswapfile   : boolean
+      sandbox      : boolean
+      silent       : boolean
+      tab          : integer
+      verbose      : integer
+      vertical     : boolean
+
+      enum Split ''
+        'aboveleft'
+        'belowright'
+        'topleft'
+        'botright'
+      end
+
+      split : Split
+    end
+    smods: Mods
   end
+
   record UserCmdOpts
     nargs: string|integer
     range: boolean|string|integer


### PR DESCRIPTION
When running an action via the :Gitsigns command, the internal plumbing
can now pass the entire command context/options directly to a
specialised action command (per action) that knows how to translate
command parameters to the specific action parameters.

Example 1: `:belowright Gitsigns diffthis` now translates to
`diffthis(nil, {split='belowright'}`.

Example 2: `:6,10Gitsigns stage_hunk` now translates to
`stage_hunk({6,10})`.

Note this change reverts the behaviour of the previous commit that
respects 'splitright'

Fixes #585
