### PR TITLE
Incorporate `cursorline` highlighting in sign column

### DIFF
--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -122,11 +122,11 @@ M.schema = {
       type = 'table',
       deep_extend = true,
       default = {
-         add = { hl = 'GitSignsAdd', text = '┃', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn' },
-         change = { hl = 'GitSignsChange', text = '┃', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
-         delete = { hl = 'GitSignsDelete', text = '▁', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
-         topdelete = { hl = 'GitSignsDelete', text = '▔', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
-         changedelete = { hl = 'GitSignsChange', text = '~', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
+         add = { hl = 'GitSignsAdd', text = '┃', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn', culhl = 'GitSignsAddCul' },
+         change = { hl = 'GitSignsChange', text = '┃', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn', culhl = 'GitSignsChangeCul' },
+         delete = { hl = 'GitSignsDelete', text = '▁', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn', culhl = 'GitSignsDeleteCul' },
+         topdelete = { hl = 'GitSignsDelete', text = '▔', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn', culhl = 'GitSignsDeleteCul' },
+         changedelete = { hl = 'GitSignsChange', text = '~', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn', culhl = 'GitSignsChangeCul' },
       },
       description = [[
       Configuration for signs:
@@ -135,6 +135,8 @@ M.schema = {
         • `numhl` specifies the highlight group to use for the number column
           (see |gitsigns-config.numhl|).
         • `linehl` specifies the highlight group to use for the line
+          (see |gitsigns-config.linehl|).
+        • `culhl` specifies the highlight group to use for the signs on the cursor line
           (see |gitsigns-config.linehl|).
         • `show_count` to enable showing count of hunk, e.g. number of deleted
           lines.
@@ -258,6 +260,18 @@ M.schema = {
       Enable/disable line highlights.
 
       When enabled the highlights defined in `signs.*.linehl` are used. If
+      the highlight group does not exist, then it is automatically defined
+      and linked to the corresponding highlight group in `signs.*.hl`.
+    ]],
+   },
+
+   culhl = {
+      type = 'boolean',
+      default = false,
+      description = [[
+      Enable/disable cursor line symbol highlights.
+
+      When enabled the highlights defined in `signs.*.culhl` are used. If
       the highlight group does not exist, then it is automatically defined
       and linked to the corresponding highlight group in `signs.*.hl`.
     ]],

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -41,6 +41,12 @@ local hls = {
    { GitSignsDeleteVirtLnInLine = { 'GitSignsDeleteLnInline' } },
 }
 
+local culhls = {
+   GitSignsAddCul = { 'GitSignsAdd' },
+   GitSignsChangeCul = { 'GitSignsChange' },
+   GitSignsDeleteCul = { 'GitSignsDelete' },
+}
+
 local function is_hl_set(hl_name)
 
    local exists, hl = pcall(api.nvim_get_hl_by_name, hl_name, true)
@@ -63,6 +69,22 @@ M.setup_highlights = function()
                   nvim.highlight(hl, { default = true, link = d })
                   break
                end
+            end
+         end
+      end
+   end
+   local cursorline_background = vim.api.nvim_get_hl_by_name("CursorLine", true).background
+   for hl, candidates in ipairs(culhls) do
+      if is_hl_set(hl) then
+
+         dprintf('Highlight %s is already defined', hl)
+      else
+         for _, d in ipairs(candidates) do
+            if is_hl_set(d) then
+               dprintf('Deriving %s from %s', hl, d)
+               d.background = cursorline_background
+               nvim.highlight(hl, d)
+               break
             end
          end
       end

--- a/lua/gitsigns/signs/vimfn.lua
+++ b/lua/gitsigns/signs/vimfn.lua
@@ -61,6 +61,7 @@ local function define_signs(obj, redefine)
          text = config.signcolumn and cs.text or nil,
          numhl = config.numhl and cs.numhl,
          linehl = config.linehl and cs.linehl,
+         culhl = config.culhl and cs.culhl,
       }, redefine)
    end
 end
@@ -119,6 +120,7 @@ function M:add(bufnr, signs)
             text = config.signcolumn and cs.text .. count_char or '',
             numhl = config.numhl and cs.numhl,
             linehl = config.linehl and cs.linehl,
+            culhl = config.culhl and cs.culhl,
          })
       end
 


### PR DESCRIPTION
Fixes #563

WIP as I'm not sure what is required for extmarks and I haven't had a chance to see what needs adding to tests and documentation.

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?