### PR TITLE
fix(hl): use NormalFloat instead of Normal

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -634,7 +634,7 @@ M.preview_hunk = noautocmd(function()
 
    local lines_fmt = {
       { { 'Hunk <hunk_no> of <num_hunks>', 'Title' } },
-      { { '<hunk>', 'Normal' } },
+      { { '<hunk>', 'NormalFloat' } },
    }
 
    insert_hunk_hlmarks(lines_fmt, hunk)
@@ -715,21 +715,21 @@ local function create_blame_fmt(is_committed, full)
       { '<abbrev_sha> ', 'Directory' },
       { '<author> ', 'MoreMsg' },
       { '(<author_time:%Y-%m-%d %H:%M>)', 'Label' },
-      { ':', 'Normal' },
+      { ':', 'NormalFloat' },
    }
 
    if full then
       return {
          header,
-         { { '<body>', 'Normal' } },
+         { { '<body>', 'NormalFloat' } },
          { { 'Hunk <hunk_no> of <num_hunks>', 'Title' }, { ' <hunk_head>', 'LineNr' } },
-         { { '<hunk>', 'Normal' } },
+         { { '<hunk>', 'NormalFloat' } },
       }
    end
 
    return {
       header,
-      { { '<summary>', 'Normal' } },
+      { { '<summary>', 'NormalFloat' } },
    }
 end
 

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -634,7 +634,7 @@ M.preview_hunk = noautocmd(function()
 
   local lines_fmt = {
     {{'Hunk <hunk_no> of <num_hunks>', 'Title'}},
-    {{'<hunk>', 'Normal' }}
+    {{'<hunk>', 'NormalFloat' }}
   }
 
   insert_hunk_hlmarks(lines_fmt, hunk)
@@ -715,21 +715,21 @@ local function create_blame_fmt(is_committed: boolean, full: boolean): popup.Lin
     {'<abbrev_sha> ', 'Directory'},
     {'<author> ', 'MoreMsg'},
     {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'},
-    {':', 'Normal'}
+    {':', 'NormalFloat'}
   }
 
   if full then
     return {
       header,
-      {{'<body>', 'Normal'}},
+      {{'<body>', 'NormalFloat'}},
       {{'Hunk <hunk_no> of <num_hunks>', 'Title'}, {' <hunk_head>', 'LineNr'}},
-      {{'<hunk>', 'Normal'}}
+      {{'<hunk>', 'NormalFloat'}}
     }
   end
 
   return {
     header,
-    {{'<summary>', 'Normal'}}
+    {{'<summary>', 'NormalFloat'}}
   }
 end
 


### PR DESCRIPTION
- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?

I think `NormalFloat` is the one to highlight with since it's highlight inside a popup window. I have different backgrounds for a floating window and using `Normal` looks a bit weird.

Before: 
<img width="471" alt="image" src="https://user-images.githubusercontent.com/5160701/179045237-597d35a8-147b-487d-9006-2e5ff2b9b5b4.png">


After: 
<img width="460" alt="image" src="https://user-images.githubusercontent.com/5160701/179045155-24677270-4b99-445d-a118-f0b4a33c15b5.png">
