### PR TITLE
feat: add filetype for diff and blame window

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -645,7 +645,8 @@ M.preview_hunk = noautocmd(function()
       hunk = gs_hunks.patch_lines(hunk, vim.bo[bufnr].fileformat),
    })
 
-   popup.create(lines_spec, config.preview_config)
+   _, bufnr = popup.create(lines_spec, config.preview_config)
+   api.nvim_buf_set_option(bufnr, 'ft', 'gitsigns_diff')
 end)
 
 
@@ -786,7 +787,8 @@ M.blame_line = void(function(opts)
 
    scheduler()
 
-   popup.create(lines_format(blame_fmt, info), config.preview_config)
+   _, bufnr = popup.create(lines_format(blame_fmt, info), config.preview_config)
+   api.nvim_buf_set_option(bufnr, 'ft', 'gitsigns_blame')
 end)
 
 local function update_buf_base(buf, bcache, base)

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -645,7 +645,8 @@ M.preview_hunk = noautocmd(function()
     hunk = gs_hunks.patch_lines(hunk, vim.bo[bufnr].fileformat),
   })
 
-  popup.create(lines_spec, config.preview_config)
+  _, bufnr = popup.create(lines_spec, config.preview_config)
+  api.nvim_buf_set_option(bufnr, 'ft', 'gitsigns_diff')
 end)
 
 --- Select the hunk under the cursor.
@@ -786,7 +787,8 @@ M.blame_line = void(function(opts: BlameOpts)
 
   scheduler()
 
-  popup.create(lines_format(blame_fmt, info), config.preview_config)
+  _, bufnr = popup.create(lines_format(blame_fmt, info), config.preview_config)
+  api.nvim_buf_set_option(bufnr, 'ft', 'gitsigns_blame')
 end)
 
 local function update_buf_base(buf: integer, bcache: CacheEntry, base: string)


### PR DESCRIPTION
- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?

I want to run some code to substitute a gitmoji code for the actual emoji in the git-blame window (for example `%s/:sparkles:/✨`, and I need the filetype to do this. I figured I could add a filetype to the diff-window as well.

Not 100% sure of the naming of filetype though, so open for other suggestions here