### PR TITLE
feat(preview): add separate highlights for hunks

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -563,13 +563,13 @@ local function hlmarks_for_hunk(hunk, hl)
    end
 
    hls[#hls + 1] = {
-      hl_group = 'GitSignsDeleteLn',
+      hl_group = 'GitSignsDeletePreview',
       start_row = 0,
       end_row = removed.count,
    }
 
    hls[#hls + 1] = {
-      hl_group = 'GitSignsAddLn',
+      hl_group = 'GitSignsAddPreview',
       start_row = removed.count,
       end_row = removed.count + added.count,
    }

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -22,6 +22,9 @@ local hls = {
 
 
 
+   { GitSignsAddPreview = { 'GitGutterAddLine', 'SignifyLineAdd', 'DiffAdd' } },
+   { GitSignsDeletePreview = { 'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete' } },
+
    { GitSignsCurrentLineBlame = { 'NonText' } },
 
    { GitSignsAddInline = { 'TermCursor' } },

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -563,13 +563,13 @@ local function hlmarks_for_hunk(hunk: Hunk, hl: string): {HlMark}
   end
 
   hls[#hls+1] = {
-    hl_group  = 'GitSignsDeleteLn',
+    hl_group  = 'GitSignsDeletePreview',
     start_row = 0,
     end_row   = removed.count,
   }
 
   hls[#hls+1] = {
-    hl_group  = 'GitSignsAddLn',
+    hl_group  = 'GitSignsAddPreview',
     start_row = removed.count,
     end_row   = removed.count + added.count,
   }

--- a/teal/gitsigns/highlight.tl
+++ b/teal/gitsigns/highlight.tl
@@ -22,6 +22,9 @@ local hls: {{string:{string}}} = {
   -- Don't set GitSignsDeleteLn by default
   -- {GitSignsDeleteLn           = {}},
 
+  {GitSignsAddPreview         = {'GitGutterAddLine'   , 'SignifyLineAdd'   , 'DiffAdd'   }},
+  {GitSignsDeletePreview      = {'GitGutterDeleteLine', 'SignifyLineDelete', 'DiffDelete'}},
+
   {GitSignsCurrentLineBlame   = {'NonText'}},
 
   {GitSignsAddInline          = {'TermCursor'}},


### PR DESCRIPTION
Previously the hunks in the preview windows used GitSigns*Ln highlights.
These are really intended for signs when linehl is enabled and
GitSignsDeleteLn is unset by default.

This change add the highlights GitSignsAddPreview and
GitSignsDeletePreview.

- [ ] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
