### PR TITLE
fix(signs): hunks can be nil

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -58,6 +58,9 @@ local function apply_win_signs(bufnr, hunks, top, bot, clear)
    end
 
 
+   hunks = hunks or {}
+
+
 
 
 
@@ -65,7 +68,7 @@ local function apply_win_signs(bufnr, hunks, top, bot, clear)
       signs:add(bufnr, gs_hunks.calc_signs(hunks[1], hunks[1].added.start, hunks[1].added.start))
    end
 
-   for _, hunk in ipairs(hunks or {}) do
+   for _, hunk in ipairs(hunks) do
       if top <= hunk.vend and bot >= hunk.added.start then
          signs:add(bufnr, gs_hunks.calc_signs(hunk, top, bot))
       end

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -57,6 +57,9 @@ local function apply_win_signs(bufnr: integer, hunks: {Hunk}, top: integer, bot:
     signs:remove(bufnr)  -- Remove all signs
   end
 
+  -- hunks can be nil
+  hunks = hunks or {}
+
   -- To stop the sign column width changing too much, if there are signs to be
   -- added but none of them are visible in the window, then make sure to add at
   -- least one sign. Only do this on the first call after an update when we all
@@ -65,7 +68,7 @@ local function apply_win_signs(bufnr: integer, hunks: {Hunk}, top: integer, bot:
     signs:add(bufnr, gs_hunks.calc_signs(hunks[1], hunks[1].added.start, hunks[1].added.start))
   end
 
-  for _, hunk in ipairs(hunks or {}) do
+  for _, hunk in ipairs(hunks) do
     if top <= hunk.vend and bot >= hunk.added.start then
       signs:add(bufnr, gs_hunks.calc_signs(hunk, top, bot))
     end


### PR DESCRIPTION
Sometimes apply_win_signs is called with hunks as nil which throws an error in the second if statement of the function.
I'm unsure if this is expected to happen.
In my case it seemed to occur sometimes when using hydra.nvim with a configuration similar to the one on their [wiki page](https://github.com/anuvyklack/hydra.nvim/wiki/Git#pink-hydra) and opening Neogit's status command.

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?