### PR TITLE
Fix: check if the buffer is still loaded before calling nvim_buf_attach

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -289,6 +289,11 @@ local attach_throttled = throttle_by_id(function(cbuf, aucmd)
       git_obj = git_obj,
    })
 
+   if not api.nvim_buf_is_loaded(cbuf) then
+      dprint('Un-loaded buffer')
+      return
+   end
+
 
 
    api.nvim_buf_attach(cbuf, false, {

--- a/teal/gitsigns.tl
+++ b/teal/gitsigns.tl
@@ -289,6 +289,11 @@ local attach_throttled = throttle_by_id(function(cbuf: integer, aucmd: string)
     git_obj        = git_obj
   }
 
+  if not api.nvim_buf_is_loaded(cbuf) then
+    dprint('Un-loaded buffer')
+    return
+  end
+
   -- Make sure to attach before the first update (which is async) so we pick up
   -- changes from BufReadCmd.
   api.nvim_buf_attach(cbuf, false, {


### PR DESCRIPTION
I'm getting the following error when calling `bwipeout` on a buffer, so this PR fixes it.

Not sure if this's the best solution since we already have another check [gitsigns.tl#L209-L212](https://github.com/lewis6991/gitsigns.nvim/blob/main/teal/gitsigns.tl#L209-L212) in the same function.

```
Error executing vim.schedule lua callback: ...e/pack/packer/start/gitsigns.nvim/lua/gitsigns/async.lua:62: The coroutine failed with this message: ...im/site/pack/packer/start/gitsigns.nvim/lua/gitsigns.lua:294: Invalid buffer id: 5
stack traceback:
        [C]: in function 'nvim_buf_attach'
        ...im/site/pack/packer/start/gitsigns.nvim/lua/gitsigns.lua:294: in function 'fn'
        ...ack/packer/start/gitsigns.nvim/lua/gitsigns/debounce.lua:78: in function 'attach_throttled'
        ...im/site/pack/packer/start/gitsigns.nvim/lua/gitsigns.lua:316: in function <...im/site/pack/packer/start/gitsigns.nvim/lua/gitsigns.lua:315>
stack traceback:
        [C]: in function 'error'
        ...e/pack/packer/start/gitsigns.nvim/lua/gitsigns/async.lua:62: in function <...e/pack/packer/start/gitsigns.nvim/lua/gitsigns/async.lua:57>
```

- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?
