### PR TITLE
fix(repeat): support remapped `l` key

### DIFF
--- a/lua/gitsigns/repeat.lua
+++ b/lua/gitsigns/repeat.lua
@@ -22,7 +22,7 @@ function M.mk_repeatable(fn)
          end
       end
 
-      vim.cmd('normal g@l')
+      vim.cmd('normal! g@l')
    end
 end
 

--- a/teal/gitsigns/repeat.tl
+++ b/teal/gitsigns/repeat.tl
@@ -22,7 +22,7 @@ function M.mk_repeatable(fn: function): function
       end
     end
 
-    vim.cmd'normal g@l'
+    vim.cmd'normal! g@l'
   end
 end
 


### PR DESCRIPTION
I use a non-qwerty layout and so `hjkl` keys are not close to home row,
but instead scattered around the keyboard. Consequently, I remap `l` to
something more convenient.

Recently (it turns out, after commit
9787c94178b4062f30d2f06b6d52984217196647), commands like `Gitsigns
stage_hunk` stopped working, i.e. calling them would not stage the given
hook.

The problem is that `mk_repeatable` assumes a default mapping on `l`
when it calls `normal g@l`. Calling `normal!` fixes this, because then
custom mappings are disregarded and `normal g@l` calls the `stage_hunk`
or whatever was made repeatable.

I believe this should fix #651, although I did not test that.

- [X] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)? Yes
