### PR TITLE
fix(unix): properly clean `util.tmpname` leftovers

### DIFF
--- a/teal/gitsigns/diff_ext.tl
+++ b/teal/gitsigns/diff_ext.tl
@@ -35,8 +35,8 @@ M.run_diff = function(
     scheduler()
   end
 
-  local file_buf = util.tmpname()..'_buf'
-  local file_cmp = util.tmpname()..'_cmp'
+  local file_buf = util.tmpname()
+  local file_cmp = util.tmpname()
 
   write_to_file(file_buf, text_buf)
   write_to_file(file_cmp, text_cmp)


### PR DESCRIPTION
- [x] Have you read [CONTRIBUTING.md](https://github.com/lewis6991/gitsigns.nvim/blob/HEAD/CONTRIBUTING.md)?

Issue:

* Since os.tmpname doesn't just display temp filenames but creates them, the current logic of adding '_cmp'/'_buf' to the names ends up losing track of the original file, thus creating leftovers.

```bash
[11/01/22 22:46:32]
qosmio@macbook-pro-wlan ~
❯ ll /tmp/lua*
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_C6e7Pi
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_CEPath
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_E55gdE
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_IFqsAT
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_KUryRh
-rw-------  1 qosmio  wheel     0B Nov  1 22:46 /tmp/lua_MbawBP
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_NAx48o
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_PiLRrx
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_S39x4N
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_TXHemY
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_ZQgEvO
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_ZfgpqF
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_cUBYai
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_keNz7S
-rw-------  1 qosmio  wheel     0B Nov  1 22:44 /tmp/lua_lIVloi
-rw-------  1 qosmio  wheel     0B Nov  1 22:46 /tmp/lua_lYPr1x
-rw-------  1 qosmio  wheel     0B Nov  1 22:45 /tmp/lua_miUvEt
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_rjgOc8
-rw-------  1 qosmio  wheel     0B Nov  1 22:46 /tmp/lua_soIAKT
-rw-------  1 qosmio  wheel     0B Nov  1 22:45 /tmp/lua_sy7NNH
-rw-------  1 qosmio  wheel     0B Nov  1 22:42 /tmp/lua_zgDH0y
-rw-------  1 qosmio  wheel     0B Nov  1 22:46 /tmp/lua_zoAjJW
```

Proposal:

* Remove unecessary '_cmp'/'_buf' suffixes as the filenames are already referenced using descriptive variables `file_buf` and	`file_cmp`.