### PR TITLE
Make preview window follow cursor when scrolling

### DIFF
--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -173,6 +173,14 @@ function popup.create0(lines, opts, id)
       end,
    })
 
+
+   api.nvim_create_autocmd({ 'WinScrolled' }, {
+      group = group,
+      callback = function()
+         api.nvim_win_set_config(winid, opts1)
+      end,
+   })
+
    return winid, bufnr
 end
 

--- a/teal/gitsigns/popup.tl
+++ b/teal/gitsigns/popup.tl
@@ -173,6 +173,14 @@ function popup.create0(lines: {string}, opts: {string:any}, id: string): integer
     end
   })
 
+  -- update window position to follow the cursor when scrolling
+  api.nvim_create_autocmd({'WinScrolled'}, {
+    group = group,
+    callback = function()
+      api.nvim_win_set_config(winid, opts1)
+    end
+  })
+
   return winid, bufnr
 end
 


### PR DESCRIPTION
This commit makes the hunk preview window follow the cursor when scrolling.

To see this behavior, open a preview window using `:Gitsigns preview_hunk`, then use `Ctrl-e` and `Ctrl-y` to scroll the buffer. Without this patch, the window will stay where it was opened. With this patch, the window will change position to be follow the cursor as the buffer scrolls.