### PR TITLE
fix: don't move preview window while it's focused

### DIFF
--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -181,6 +181,15 @@ function popup.create0(lines, opts, id)
       end,
    })
 
+
+   api.nvim_create_autocmd({ 'WinScrolled' }, {
+      buffer = api.nvim_get_current_buf(),
+      group = group,
+      callback = function()
+         api.nvim_win_set_config(winid, opts1)
+      end,
+   })
+
    return winid, bufnr
 end
 

--- a/teal/gitsigns/popup.tl
+++ b/teal/gitsigns/popup.tl
@@ -181,6 +181,15 @@ function popup.create0(lines: {string}, opts: {string:any}, id: string): integer
     end
   })
 
+  -- update window position to follow the cursor when scrolling
+  api.nvim_create_autocmd({'WinScrolled'}, {
+    buffer = api.nvim_get_current_buf(),
+    group = group,
+    callback = function()
+      api.nvim_win_set_config(winid, opts1)
+    end
+  })
+
   return winid, bufnr
 end
 


### PR DESCRIPTION
Fixes a bug introduced by #705 

Currently, if the hunk preview window is focused and the user moves their cursor inside the preview window, the preview window will gradually move down and too the right by on column and row per move. This is because the floating preview window is incorrectly being adjusted to have its position be relative to the cursor which is offset by the floating window boarder.

This commit updates the `WinScrolled` autocommand introduced by #705 to be scoped to buffer of the file so that this doesn't happen.