### PR TITLE
Update keymaps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,29 +141,29 @@ require('gitsigns').setup{
       if vim.wo.diff then return ']c' end
       vim.schedule(function() gs.next_hunk() end)
       return '<Ignore>'
-    end, {expr=true})
+    end, {expr=true, buffer=bufnr})
 
     vim.keymap.set('n', '[c', function()
       if vim.wo.diff then return '[c' end
       vim.schedule(function() gs.prev_hunk() end)
       return '<Ignore>'
-    end, {expr=true})
+    end, {expr=true, buffer=bufnr})
 
     -- Actions
-    vim.keymap.set({'n', 'v'}, '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    vim.keymap.set({'n', 'v'}, '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    vim.keymap.set('n', '<leader>hS', gs.stage_buffer)
-    vim.keymap.set('n', '<leader>hu', gs.undo_stage_hunk)
-    vim.keymap.set('n', '<leader>hR', gs.reset_buffer)
-    vim.keymap.set('n', '<leader>hp', gs.preview_hunk)
-    vim.keymap.set('n', '<leader>hb', function() gs.blame_line{full=true} end)
-    vim.keymap.set('n', '<leader>tb', gs.toggle_current_line_blame)
-    vim.keymap.set('n', '<leader>hd', gs.diffthis)
-    vim.keymap.set('n', '<leader>hD', function() gs.diffthis('~') end)
-    vim.keymap.set('n', '<leader>td', gs.toggle_deleted)
+    vim.keymap.set({'n', 'v'}, '<leader>hs', ':Gitsigns stage_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set({'n', 'v'}, '<leader>hr', ':Gitsigns reset_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hS', gs.stage_buffer, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hu', gs.undo_stage_hunk, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hR', gs.reset_buffer, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hp', gs.preview_hunk, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hb', function() gs.blame_line{full=true} end, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>tb', gs.toggle_current_line_blame, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hd', gs.diffthis, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hD', function() gs.diffthis('~') end, {buffer=bufnr})
+    vim.keymap.set('n', '<leader>td', gs.toggle_deleted, {buffer=bufnr})
 
     -- Text object
-    vim.keymap.set({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    vim.keymap.set({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>', {buffer=bufnr})
   end
 }
 ```
@@ -177,27 +177,27 @@ require('gitsigns').setup {
   ...
   on_attach = function(bufnr)
     -- Navigation
-    vim.keymap.set('n', ']c', "&diff ? ']c' : '<cmd>Gitsigns next_hunk<CR>'", {expr=true})
-    vim.keymap.set('n', '[c', "&diff ? '[c' : '<cmd>Gitsigns prev_hunk<CR>'", {expr=true})
+    vim.keymap.set('n', ']c', "&diff ? ']c' : '<cmd>Gitsigns next_hunk<CR>'", {expr=true, buffer=bufnr})
+    vim.keymap.set('n', '[c', "&diff ? '[c' : '<cmd>Gitsigns prev_hunk<CR>'", {expr=true, buffer=bufnr})
 
     -- Actions
-    vim.keymap.set('n', '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    vim.keymap.set('v', '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    vim.keymap.set('n', '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    vim.keymap.set('v', '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    vim.keymap.set('n', '<leader>hS', '<cmd>Gitsigns stage_buffer<CR>')
-    vim.keymap.set('n', '<leader>hu', '<cmd>Gitsigns undo_stage_hunk<CR>')
-    vim.keymap.set('n', '<leader>hR', '<cmd>Gitsigns reset_buffer<CR>')
-    vim.keymap.set('n', '<leader>hp', '<cmd>Gitsigns preview_hunk<CR>')
-    vim.keymap.set('n', '<leader>hb', '<cmd>lua require"gitsigns".blame_line{full=true}<CR>')
-    vim.keymap.set('n', '<leader>tb', '<cmd>Gitsigns toggle_current_line_blame<CR>')
-    vim.keymap.set('n', '<leader>hd', '<cmd>Gitsigns diffthis<CR>')
-    vim.keymap.set('n', '<leader>hD', '<cmd>lua require"gitsigns".diffthis("~")<CR>')
-    vim.keymap.set('n', '<leader>td', '<cmd>Gitsigns toggle_deleted<CR>')
+    vim.keymap.set('n', '<leader>hs', ':Gitsigns stage_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('v', '<leader>hs', ':Gitsigns stage_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hr', ':Gitsigns reset_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('v', '<leader>hr', ':Gitsigns reset_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hS', '<cmd>Gitsigns stage_buffer<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hu', '<cmd>Gitsigns undo_stage_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hR', '<cmd>Gitsigns reset_buffer<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hp', '<cmd>Gitsigns preview_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hb', '<cmd>lua require"gitsigns".blame_line{full=true}<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>tb', '<cmd>Gitsigns toggle_current_line_blame<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hd', '<cmd>Gitsigns diffthis<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>hD', '<cmd>lua require"gitsigns".diffthis("~")<CR>', {buffer=bufnr})
+    vim.keymap.set('n', '<leader>td', '<cmd>Gitsigns toggle_deleted<CR>', {buffer=bufnr})
 
     -- Text object
-    vim.keymap.set('o', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
-    vim.keymap.set('x', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    vim.keymap.set('o', 'ih', ':<C-U>Gitsigns select_hunk<CR>', {buffer=bufnr})
+    vim.keymap.set('x', 'ih', ':<C-U>Gitsigns select_hunk<CR>', {buffer=bufnr})
   end
 }
 ```

--- a/README.md
+++ b/README.md
@@ -136,40 +136,34 @@ require('gitsigns').setup{
   on_attach = function(bufnr)
     local gs = package.loaded.gitsigns
 
-    local function map(mode, l, r, opts)
-      opts = opts or {}
-      opts.buffer = bufnr
-      vim.keymap.set(mode, l, r, opts)
-    end
-
     -- Navigation
-    map('n', ']c', function()
+    vim.keymap.set('n', ']c', function()
       if vim.wo.diff then return ']c' end
       vim.schedule(function() gs.next_hunk() end)
       return '<Ignore>'
     end, {expr=true})
 
-    map('n', '[c', function()
+    vim.keymap.set('n', '[c', function()
       if vim.wo.diff then return '[c' end
       vim.schedule(function() gs.prev_hunk() end)
       return '<Ignore>'
     end, {expr=true})
 
     -- Actions
-    map({'n', 'v'}, '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    map({'n', 'v'}, '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    map('n', '<leader>hS', gs.stage_buffer)
-    map('n', '<leader>hu', gs.undo_stage_hunk)
-    map('n', '<leader>hR', gs.reset_buffer)
-    map('n', '<leader>hp', gs.preview_hunk)
-    map('n', '<leader>hb', function() gs.blame_line{full=true} end)
-    map('n', '<leader>tb', gs.toggle_current_line_blame)
-    map('n', '<leader>hd', gs.diffthis)
-    map('n', '<leader>hD', function() gs.diffthis('~') end)
-    map('n', '<leader>td', gs.toggle_deleted)
+    vim.keymap.set({'n', 'v'}, '<leader>hs', ':Gitsigns stage_hunk<CR>')
+    vim.keymap.set({'n', 'v'}, '<leader>hr', ':Gitsigns reset_hunk<CR>')
+    vim.keymap.set('n', '<leader>hS', gs.stage_buffer)
+    vim.keymap.set('n', '<leader>hu', gs.undo_stage_hunk)
+    vim.keymap.set('n', '<leader>hR', gs.reset_buffer)
+    vim.keymap.set('n', '<leader>hp', gs.preview_hunk)
+    vim.keymap.set('n', '<leader>hb', function() gs.blame_line{full=true} end)
+    vim.keymap.set('n', '<leader>tb', gs.toggle_current_line_blame)
+    vim.keymap.set('n', '<leader>hd', gs.diffthis)
+    vim.keymap.set('n', '<leader>hD', function() gs.diffthis('~') end)
+    vim.keymap.set('n', '<leader>td', gs.toggle_deleted)
 
     -- Text object
-    map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    vim.keymap.set({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
   end
 }
 ```
@@ -182,33 +176,28 @@ Note this requires Neovim v0.7 which introduces `vim.keymap.set`. If you are usi
 require('gitsigns').setup {
   ...
   on_attach = function(bufnr)
-    local function map(mode, lhs, rhs, opts)
-        opts = vim.tbl_extend('force', {noremap = true, silent = true}, opts or {})
-        vim.api.nvim_buf_set_keymap(bufnr, mode, lhs, rhs, opts)
-    end
-
     -- Navigation
-    map('n', ']c', "&diff ? ']c' : '<cmd>Gitsigns next_hunk<CR>'", {expr=true})
-    map('n', '[c', "&diff ? '[c' : '<cmd>Gitsigns prev_hunk<CR>'", {expr=true})
+    vim.keymap.set('n', ']c', "&diff ? ']c' : '<cmd>Gitsigns next_hunk<CR>'", {expr=true})
+    vim.keymap.set('n', '[c', "&diff ? '[c' : '<cmd>Gitsigns prev_hunk<CR>'", {expr=true})
 
     -- Actions
-    map('n', '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    map('v', '<leader>hs', ':Gitsigns stage_hunk<CR>')
-    map('n', '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    map('v', '<leader>hr', ':Gitsigns reset_hunk<CR>')
-    map('n', '<leader>hS', '<cmd>Gitsigns stage_buffer<CR>')
-    map('n', '<leader>hu', '<cmd>Gitsigns undo_stage_hunk<CR>')
-    map('n', '<leader>hR', '<cmd>Gitsigns reset_buffer<CR>')
-    map('n', '<leader>hp', '<cmd>Gitsigns preview_hunk<CR>')
-    map('n', '<leader>hb', '<cmd>lua require"gitsigns".blame_line{full=true}<CR>')
-    map('n', '<leader>tb', '<cmd>Gitsigns toggle_current_line_blame<CR>')
-    map('n', '<leader>hd', '<cmd>Gitsigns diffthis<CR>')
-    map('n', '<leader>hD', '<cmd>lua require"gitsigns".diffthis("~")<CR>')
-    map('n', '<leader>td', '<cmd>Gitsigns toggle_deleted<CR>')
+    vim.keymap.set('n', '<leader>hs', ':Gitsigns stage_hunk<CR>')
+    vim.keymap.set('v', '<leader>hs', ':Gitsigns stage_hunk<CR>')
+    vim.keymap.set('n', '<leader>hr', ':Gitsigns reset_hunk<CR>')
+    vim.keymap.set('v', '<leader>hr', ':Gitsigns reset_hunk<CR>')
+    vim.keymap.set('n', '<leader>hS', '<cmd>Gitsigns stage_buffer<CR>')
+    vim.keymap.set('n', '<leader>hu', '<cmd>Gitsigns undo_stage_hunk<CR>')
+    vim.keymap.set('n', '<leader>hR', '<cmd>Gitsigns reset_buffer<CR>')
+    vim.keymap.set('n', '<leader>hp', '<cmd>Gitsigns preview_hunk<CR>')
+    vim.keymap.set('n', '<leader>hb', '<cmd>lua require"gitsigns".blame_line{full=true}<CR>')
+    vim.keymap.set('n', '<leader>tb', '<cmd>Gitsigns toggle_current_line_blame<CR>')
+    vim.keymap.set('n', '<leader>hd', '<cmd>Gitsigns diffthis<CR>')
+    vim.keymap.set('n', '<leader>hD', '<cmd>lua require"gitsigns".diffthis("~")<CR>')
+    vim.keymap.set('n', '<leader>td', '<cmd>Gitsigns toggle_deleted<CR>')
 
     -- Text object
-    map('o', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
-    map('x', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    vim.keymap.set('o', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    vim.keymap.set('x', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
   end
 }
 ```


### PR DESCRIPTION
Usage of `map()` is no longer needed as [`vim.keymap.set()`](https://neovim.io/doc/user/lua.html#vim.keymap.set()) supports setting for multiple modes now. 