### PR TITLE
feat: add gitsignsupdatedone autocmd

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -325,6 +325,11 @@ M.update = throttle_by_id(function(bufnr, bcache)
 
       update_show_deleted(bufnr)
       bcache.force_next_update = false
+
+      api.nvim_exec_autocmds('User', {
+         pattern = 'GitSignsUpdate',
+         modeline = false,
+      })
    end
 
    local summary = gs_hunks.get_summary(bcache.hunks)

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -325,11 +325,6 @@ M.update = throttle_by_id(function(bufnr, bcache)
 
       update_show_deleted(bufnr)
       bcache.force_next_update = false
-
-      api.nvim_exec_autocmds('User', {
-         pattern = 'GitSignsUpdate',
-         modeline = false,
-      })
    end
 
    local summary = gs_hunks.get_summary(bcache.hunks)

--- a/lua/gitsigns/status.lua
+++ b/lua/gitsigns/status.lua
@@ -25,6 +25,11 @@ function Status:update(bufnr, status)
    vim.b[bufnr].gitsigns_head = status.head or ''
    vim.b[bufnr].gitsigns_status_dict = status
    vim.b[bufnr].gitsigns_status = self.formatter(status)
+
+   api.nvim_exec_autocmds('User', {
+      pattern = 'GitSignsUpdateDone',
+      modeline = false,
+   })
 end
 
 function Status:clear(bufnr)

--- a/lua/gitsigns/status.lua
+++ b/lua/gitsigns/status.lua
@@ -27,7 +27,7 @@ function Status:update(bufnr, status)
    vim.b[bufnr].gitsigns_status = self.formatter(status)
 
    api.nvim_exec_autocmds('User', {
-      pattern = 'GitSignsUpdateDone',
+      pattern = 'GitSignsUpdate',
       modeline = false,
    })
 end

--- a/teal/gitsigns/status.tl
+++ b/teal/gitsigns/status.tl
@@ -25,6 +25,11 @@ function Status:update(bufnr: integer, status: StatusObj)
   vim.b[bufnr].gitsigns_head = status.head or ''
   vim.b[bufnr].gitsigns_status_dict = status
   vim.b[bufnr].gitsigns_status = self.formatter(status)
+
+   api.nvim_exec_autocmds('User', {
+      pattern = 'GitSignsUpdate',
+      modeline = false,
+   })
 end
 
 function Status:clear(bufnr: integer)


### PR DESCRIPTION
how do you feel like add an event after update done ?  my situation is my statusline using coroutine and  refresh when event trigger. when the `GitSignsUpdate` triggered the `b:gitsigns_status_dict` may not set or updated so I can't get any useful data from it . add this event will more useful. or move the `GitSignsUpdate` position ?