### PR TITLE
Add space at the end of blame virtual text

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -802,7 +802,7 @@ current_line_blame_formatter_opts
         • relative_time: boolean
 
 current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
-      Type: `string|function`, Default: `' <author>, <author_time> - <summary>'`
+      Type: `string|function`, Default: `' <author>, <author_time> - <summary> '`
 
       String or function used to format the virtual text of
       |gitsigns-config-current_line_blame|.

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -586,7 +586,7 @@ M.schema = {
 
    current_line_blame_formatter = {
       type = { 'string', 'function' },
-      default = ' <author>, <author_time> - <summary>',
+      default = ' <author>, <author_time> - <summary> ',
       description = [[
       String or function used to format the virtual text of
       |gitsigns-config-current_line_blame|.

--- a/teal/gitsigns/config.tl
+++ b/teal/gitsigns/config.tl
@@ -586,7 +586,7 @@ M.schema = {
 
   current_line_blame_formatter = {
     type = {'string', 'function'},
-    default = ' <author>, <author_time> - <summary>',
+    default = ' <author>, <author_time> - <summary> ',
     description = [[
       String or function used to format the virtual text of
       |gitsigns-config-current_line_blame|.


### PR DESCRIPTION
When using `current_line_blame = true` with a highlight that defines a `bg`, the virtual text has a space at the beginning but not at the end. This looks a bit off (e.g.: the virtual text looks like a small label with the text not properly aligned).

This is invisible when using a highlight without `bg`.

This small changes adds a space at the end so that virtual text in such situations makes better sense visually.

Fixes: https://github.com/lewis6991/gitsigns.nvim/issues/745