### PR TITLE
ci: use clang instead of gcc compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  CC: clang
+
 jobs:
   commit_lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,9 @@ LUAROCKS_INIT  := eval $$($(LUAROCKS) --tree $(LUAROCKS_TREE) path) &&
 $(NVIM_DIR):
 	@mkdir -p $(DEPS_DIR)
 	git clone --depth 1 https://github.com/neovim/neovim --branch $(NEOVIM_BRANCH) $@
-	@# disable LTO to reduce compile time
 	make -C $@ \
 		DEPS_BUILD_DIR=$(dir $(LUAROCKS_TREE)) \
-		CMAKE_BUILD_TYPE=RelWithDebInfo \
-		CMAKE_EXTRA_FLAGS=-DENABLE_LTO=OFF
+		CMAKE_BUILD_TYPE=RelWithDebInfo
 
 TL := $(LUAROCKS_TREE)/bin/tl
 


### PR DESCRIPTION
Clang has faster link time optimization by default, which will should
save 10-20 seconds per CI run.
