### PR TITLE
ci: add ci.yml and Makefile as part of the cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: deps
-          key: build-1-${{ steps.get-nvim-sha.outputs.sha }}
+          key: ${{ steps.get-nvim-sha.outputs.sha }}-${{ hashFiles('.github/workflows/ci.yml, Makefile') }}
 
       - name: Install Lua Deps
         run: make lua_deps


### PR DESCRIPTION
If we change ci.yml or Makefile we should to rebuild all supported
neovim versions again. For example, if we accidentally remove a
dependency that works as expected on nightly but not on v0.7.2 we need
the CI job to fail immediately.
