### PR TITLE
feat: allow hiding hunks from full blame

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -302,6 +302,8 @@ blame_line({opts})                                     *gitsigns.blame_line()*
                                Display full commit message with hunk.
                              • {ignore_whitespace}: (boolean)
                                Ignore whitespace when running blame.
+                             • {hide_hunks}: (boolean)
+                               Do not show hunks when running with full = true.
 
                 Attributes: ~
                     {async}

--- a/teal/gitsigns/actions.tl
+++ b/teal/gitsigns/actions.tl
@@ -37,6 +37,7 @@ end
 local record BlameOpts
   full: boolean
   ignore_whitespace: boolean
+  hide_hunks: boolean
 end
 
 local record StageHunkOpts
@@ -842,7 +843,7 @@ local function get_blame_hunk(repo: git.Repo, info: git.BlameInfo): Hunk, intege
   return hunk, i, #hunks
 end
 
-local function create_blame_fmt(is_committed: boolean, full: boolean): popup.LinesSpec
+local function create_blame_fmt(is_committed: boolean, full: boolean, hide_hunks: boolean): popup.LinesSpec
   if not is_committed then
     return {
       {{'<author>', 'Label'}},
@@ -856,12 +857,32 @@ local function create_blame_fmt(is_committed: boolean, full: boolean): popup.Lin
     {':', 'NormalFloat'}
   }
 
+  local body = {
+    {'<body>', 'NormalFloat'}
+  }
+
+  local hunk_header = {
+    {'Hunk <hunk_no> of <num_hunks>', 'Title'},
+    {' <hunk_head>', 'LineNr'}
+  }
+
+  local hunk = {
+    {'<hunk>', 'NormalFloat'}
+  }
+
   if full then
+    if hide_hunks then
+      return {
+        header,
+        body
+      }
+    end
+
     return {
       header,
-      {{'<body>', 'NormalFloat'}},
-      {{'Hunk <hunk_no> of <num_hunks>', 'Title'}, {' <hunk_head>', 'LineNr'}},
-      {{'<hunk>', 'NormalFloat'}}
+      body,
+      hunk_header,
+      hunk
     }
   end
 
@@ -882,6 +903,8 @@ end
 ---                Display full commit message with hunk.
 ---              • {ignore_whitespace}: (boolean)
 ---                Ignore whitespace when running blame.
+---              • {hide_hunks}: (boolean)
+---                Do not show hunks when running with full = true.
 ---
 --- Attributes: ~
 ---     {async}
@@ -911,20 +934,24 @@ M.blame_line = void(function(opts: BlameOpts)
 
   local is_committed = result.sha and tonumber('0x'..result.sha) ~= 0
 
-  local blame_fmt = create_blame_fmt(is_committed, opts.full)
+  local blame_fmt = create_blame_fmt(is_committed, opts.full, opts.hide_hunks)
 
   local info = result as util.FmtInfo
 
   if is_committed and opts.full then
     info.body = bcache.git_obj:command{ 'show', '-s', '--format=%B', result.sha } as string
 
-    local hunk: Hunk
+    if opts.hide_hunks then
+      table.remove(info.body as {string})
+    else
+      local hunk: Hunk
 
-    hunk, info.hunk_no, info.num_hunks = get_blame_hunk(bcache.git_obj.repo, result)
+      hunk, info.hunk_no, info.num_hunks = get_blame_hunk(bcache.git_obj.repo, result)
 
-    info.hunk = gs_hunks.patch_lines(hunk, fileformat)
-    info.hunk_head = hunk.head
-    insert_hunk_hlmarks(blame_fmt, hunk)
+      info.hunk = gs_hunks.patch_lines(hunk, fileformat)
+      info.hunk_head = hunk.head
+      insert_hunk_hlmarks(blame_fmt, hunk)
+    end
   end
 
   scheduler()


### PR DESCRIPTION
Fixes #765.

Hi! I am trying to implement a feature described in #765, I have a couple questions:

1) I was able to successfully hide hunks from full blame, but I have trouble to find the origin of trailing newline that is added after the commit message
2) I've not found unit tests for `blame_line` function, only for `current_line_blame`. Should I add a new unit test and if yes, how can I approach this?