### PR TITLE
fix show_deleted when buffer not in cache

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -271,7 +271,7 @@ local function update_show_deleted(bufnr)
 
    clear_deleted(bufnr)
    if config.show_deleted then
-      for _, hunk in ipairs(bcache.hunks) do
+      for _, hunk in ipairs(bcache.hunks or {}) do
          M.show_deleted(bufnr, ns_rm, hunk)
       end
    end

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -271,7 +271,7 @@ local function update_show_deleted(bufnr: integer)
 
    clear_deleted(bufnr)
    if config.show_deleted then
-     for _, hunk in ipairs(bcache.hunks) do
+     for _, hunk in ipairs(bcache.hunks or {}) do
        M.show_deleted(bufnr, ns_rm, hunk)
      end
    end


### PR DESCRIPTION
I would get an error when running `gs.toggle_deleted(true)` from a [hydra.nvim](https://github.com/anuvyklack/hydra.nvim) setup function.

Error message:
```
Error executing vim.schedule lua callback: ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:105: The coroutine failed with this message: ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:274: bad argument #1 to 'ipai
rs' (table expected, got nil)                                                                                                                                                                                                                
stack traceback:                                                                                                                                                                                                                             
        [C]: in function 'ipairs'                                                                                                                                                                                                            
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:274: in function 'update_show_deleted'                                                                                                                                   
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:324: in function 'fn'                                                                                                                                                    
        .../share/nvim/lazy/gitsigns.nvim/lua/gitsigns/debounce.lua:76: in function 'update'                                                                                                                                                 
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/actions.lua:1294: in function <...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/actions.lua:1288>                                                                                     
stack traceback:                                                                                                                                                                                                                             
        [C]: in function 'error'                                                                                                                                                                                                             
        ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:105: in function 'cb'                                                                                                                                                    
        ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:140: in function 'cb'                                                                                                                                                    
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:48: in function <...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:46>
```

[My hydra config](https://github.com/garcia5/dotfiles/blob/18f52dae2f51e6c946970d4ed6716f3f225a138f/files/nvim/lua/ag/plugins/hydra.lua#L119)

I can't quite figure out how to reliably trigger this error, can spend more time investigating if this workaround isn't desirable