### PR TITLE
use pcall to run reset in current_line_blame.lua

### DIFF
--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -190,7 +190,7 @@ M.setup = function()
    local group = api.nvim_create_augroup('gitsigns_blame', {})
 
    for k, _ in pairs(cache) do
-      reset(k)
+      pcall(reset, k)
    end
 
    if config.current_line_blame then


### PR DESCRIPTION
I have this error while using `null-ls` as formatter, however, I don't know how to reproduce it, but I think use `pcall` should fix it.
``` shell
E5108: Error executing lua .../pack/packer/opt/null-ls.nvim/lua/null-ls/formatting.lua:33: OptionSet Autocommands for "fileformat": Vim(append):Error executing lua callback: ...ite/pack/packer/opt/gitsigns.nvim/lua/gi
tsigns/async.lua:105: The coroutine failed with this message: ...er/opt/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:42: Invalid buffer id: 109                                                                     
stack traceback:                                                                                                                                                                                                         
        [C]: in function 'nvim_buf_del_extmark'                                                                                                                                                                          
        ...er/opt/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:42: in function 'reset'                                                                                                                              
        ...er/opt/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:193: in function 'setup'                                                                                                                             
        ...e/pack/packer/opt/gitsigns.nvim/lua/gitsigns/actions.lua:1291: in function <...e/pack/packer/opt/gitsigns.nvim/lua/gitsigns/actions.lua:1288>                                                                 
stack traceback:                                                                                                                                                                                                         
        [C]: in function 'error'                                                                                                                                                                                         
        ...ite/pack/packer/opt/gitsigns.nvim/lua/gitsigns/async.lua:105: in function 'step'                                                                                                                              
        ...ite/pack/packer/opt/gitsigns.nvim/lua/gitsigns/async.lua:129: in function 'refresh'                                                                                                                           
        ...te/pack/packer/opt/gitsigns.nvim/lua/gitsigns/attach.lua:175: in function <...te/pack/packer/opt/gitsigns.nvim/lua/gitsigns/attach.lua:174>                                                                   
        [C]: in function 'nvim_buf_set_option'                                                                                                                                                                           
        .../pack/packer/opt/null-ls.nvim/lua/null-ls/formatting.lua:33: in function 'handler'                                                                                                                            
        ...im/site/pack/packer/opt/null-ls.nvim/lua/null-ls/rpc.lua:90: in function 'handle'                                                                                                                             
        ...im/site/pack/packer/opt/null-ls.nvim/lua/null-ls/rpc.lua:105: in function 'request'                                                                                                                           
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1389: in function 'request'                                                                                                                                              
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:232: in function 'do_format'                                                                                                                                         
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:238: in function 'format'                                                                                                                                            
        [string ":lua"]:1: in main chunk                                                                                                                                                                                 
stack traceback:                                                                                                                                                                                                         
        [C]: in function 'nvim_buf_set_option'                                                                                                                                                                           
        .../pack/packer/opt/null-ls.nvim/lua/null-ls/formatting.lua:33: in function 'handler'                                                                                                                            
        ...im/site/pack/packer/opt/null-ls.nvim/lua/null-ls/rpc.lua:90: in function 'handle'                                                                                                                             
        ...im/site/pack/packer/opt/null-ls.nvim/lua/null-ls/rpc.lua:105: in function 'request'                                                                                                                           
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1389: in function 'request'                                                                                                                                              
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:232: in function 'do_format'                                                                                                                                         
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:238: in function 'format'                                                                                                                                            
        [string ":lua"]:1: in main chunk
```