### PR TITLE
docs: require nvim 0.8+ in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Super fast git decorations implemented purely in lua/teal.
 
 ## Requirements
 
-- Neovim >= 0.7.0
+- Neovim >= 0.8.0
 
   **Note:** If your version of Neovim is too old, then you can use a past [release].
 


### PR DESCRIPTION
`vim.fs` used in https://github.com/lewis6991/gitsigns.nvim/blob/f412f51d0eaf0905a2759c8087090071689bb8fb/teal/gitsigns.tl#L27 was added in nvim 0.8.0 (https://github.com/neovim/neovim/releases/tag/v0.8.0), but the current readme still states nvim >= 0.7.0 is required.

I saw that 0.7.x has been dropped in CI (https://github.com/lewis6991/gitsigns.nvim/blob/main/.github/workflows/ci.yml), so this PR updates the readme to require 0.8.