### PR TITLE
fix(README): correct undefined `line()` to `vim.fn.line()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ require('gitsigns').setup{
     -- Actions
     map('n', '<leader>hs', gs.stage_hunk)
     map('n', '<leader>hr', gs.reset_hunk)
-    map('v', '<leader>hs', function() gs.stage_hunk {line("."), line("v")} end)
-    map('v', '<leader>hr', function() gs.reset_hunk {line("."), line("v")} end)
+    map('v', '<leader>hs', function() gs.stage_hunk {vim.fn.line("."), vim.fn.line("v")} end)
+    map('v', '<leader>hr', function() gs.reset_hunk {vim.fn.line("."), vim.fn.line("v")} end)
     map('n', '<leader>hS', gs.stage_buffer)
     map('n', '<leader>hu', gs.undo_stage_hunk)
     map('n', '<leader>hR', gs.reset_buffer)


### PR DESCRIPTION
The updated mapping examples for staging and resetting hunks in visual mode added in https://github.com/lewis6991/gitsigns.nvim/commit/5d840679cfba0a93b28ba573f982613ca25d3909 result in an error, because they reference an undefined `line()` function.

This PR corrects this to `vim.fn.line()`.