### PR TITLE
fix(toggle_current_line_blame): check signs_normal is not nil

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -535,7 +535,9 @@ end
 
 function M.reset_signs()
    -- Remove all signs
-   signs_normal:reset()
+   if signs_normal then
+      signs_normal:reset()
+   end
    if signs_staged then
       signs_staged:reset()
    end

--- a/teal/gitsigns/manager.tl
+++ b/teal/gitsigns/manager.tl
@@ -535,7 +535,9 @@ end
 
 function M.reset_signs()
   -- Remove all signs
-  signs_normal:reset()
+  if signs_normal then
+    signs_normal:reset()
+  end
   if signs_staged then
     signs_staged:reset()
   end


### PR DESCRIPTION
checks signs_normal is not nil to avoid crashing when starting by invoking toggle_current_line_blame

fixes: #796