### PR TITLE
feat: make line_blame() preview be configurable with formatting string

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ require('gitsigns').setup {
   update_debounce = 100,
   status_formatter = nil, -- Use default
   max_file_length = 40000, -- Disable if file is longer than this (in lines)
+  line_blame_formatter = {
+    {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+    {{'<summary>', 'NormalFloat'}},
+
+    -- example of the blame format that previously was achieved by
+    -- running blame_line { full = true }
+    -- {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+    -- {{'<body>', 'NormalFloat'}},
+    -- {{'', 'Label'}},
+    -- {{'Hunk <hunk_no> of <num_hunks>', 'Title'}, {' <hunk_head>', 'LineNr'}},
+    -- {{'<hunk>', 'NormalFloat'}}
+  },
+  line_blame_ignore_whitespace = false,
   preview_config = {
     -- Options passed to nvim_open_win
     border = 'single',

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -63,6 +63,19 @@ of the default settings:
       update_debounce = 100,
       status_formatter = nil, -- Use default
       max_file_length = 40000, -- Disable if file is longer than this (in lines)
+      line_blame_formatter = {
+        {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+        {{'<summary>', 'NormalFloat'}},
+
+        -- example of the blame format that previously was achieved by
+        -- running blame_line { full = true }
+        -- {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+        -- {{'<body>', 'NormalFloat'}},
+        -- {{'', 'Label'}},
+        -- {{'Hunk <hunk_no> of <num_hunks>', 'Title'}, {' <hunk_head>', 'LineNr'}},
+        -- {{'<hunk>', 'NormalFloat'}}
+      },
+      line_blame_ignore_whitespace = false,
       preview_config = {
         -- Options passed to nvim_open_win
         border = 'single',
@@ -290,18 +303,10 @@ change_base({base}, {global})                         *gitsigns.change_base()*
                 For a more complete list of ways to specify bases, see
                 |gitsigns-revision|.
 
-blame_line({opts})                                     *gitsigns.blame_line()*
+blame_line()                                           *gitsigns.blame_line()*
                 Run git blame on the current line and show the results in a
                 floating window. If already open, calling this will cause the
                 window to get focus.
-
-                Parameters: ~
-                    {opts}   (table|nil):
-                             Additional options:
-                             • {full}: (boolean)
-                               Display full commit message with hunk.
-                             • {ignore_whitespace}: (boolean)
-                               Ignore whitespace when running blame.
 
                 Attributes: ~
                     {async}
@@ -694,6 +699,21 @@ max_file_length                              *gitsigns-config-max_file_length*
       Type: `number`, Default: `40000`
 
       Max file length (in lines) to attach to.
+
+line_blame_formatter                    *gitsigns-config-line_blame_formatter*
+      Type: `{{{string}}}`
+      Default: >
+        {
+          {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+          {{'<summary>', 'NormalFloat'}},
+        }
+<
+      Line blame formatter string.
+
+line_blame_ignore_whitespace    *gitsigns-config-line_blame_ignore_whitespace*
+      Type: `boolean`, Default: `false`
+
+      Ignore whitespace when running blame.
 
 preview_config                                *gitsigns-config-preview_config*
       Type: `table[extended]`

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -71,6 +71,8 @@ end
 --- @field current_line_blame_formatter string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_formatter_nc string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_opts Gitsigns.CurrentLineBlameOpts
+--- @field line_blame_formatter table<table<table<string>>>
+--- @field line_blame_ignore_whitespace boolean
 --- @field preview_config table<string,any>
 --- @field attach_to_untracked boolean
 --- @field yadm { enable: boolean }
@@ -490,6 +492,25 @@ M.schema = {
     default = 40000,
     description = [[
       Max file length (in lines) to attach to.
+    ]],
+  },
+
+  line_blame_formatter = {
+    type = 'table',
+    default = {
+      {{'<abbrev_sha> ', 'Directory'}, {'<author> ', 'MoreMsg'}, {'(<author_time:%Y-%m-%d %H:%M>)', 'Label'}, {':', 'NormalFloat'}},
+      {{'<summary>', 'NormalFloat'}},
+    },
+    description = [[
+      Line blame formatter string.
+    ]],
+  },
+
+  line_blame_ignore_whitespace = {
+    type = 'boolean',
+    default = false,
+    description = [[
+      Ignore whitespace when running blame.
     ]],
   },
 


### PR DESCRIPTION
This is the approach suggested in https://github.com/lewis6991/gitsigns.nvim/pull/767#issuecomment-1483364538, exposing blame formatting string to the config

Fixes #765