### PR TITLE
feat(actions): Automatic inline diff preview on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ require('gitsigns').setup {
     ignore_whitespace = false,
   },
   current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
+  automatic_hunk_inline = false, -- `:h gitsigns-config-automatic_hunk_inline`
   sign_priority = 6,
   update_debounce = 100,
   status_formatter = nil, -- Use default
@@ -177,6 +178,7 @@ require('gitsigns').setup {
     map('n', '<leader>hu', '<cmd>Gitsigns undo_stage_hunk<CR>')
     map('n', '<leader>hR', '<cmd>Gitsigns reset_buffer<CR>')
     map('n', '<leader>hp', '<cmd>Gitsigns preview_hunk<CR>')
+    map('n', '<leader>hP', '<cmd>Gitsigns automatic_hunk_inline<CR>')
     map('n', '<leader>hb', '<cmd>lua require"gitsigns".blame_line{full=true}<CR>')
     map('n', '<leader>tb', '<cmd>Gitsigns toggle_current_line_blame<CR>')
     map('n', '<leader>hd', '<cmd>Gitsigns diffthis<CR>')
@@ -231,7 +233,7 @@ Ensures signs are always up to date                      | :white_check_mark: * 
 Never saves the buffer                                   | :white_check_mark:   | :white_check_mark: :heavy_exclamation_mark: * | * Writes [buffer](https://github.com/airblade/vim-gitgutter/blob/0f98634b92da9a35580b618c11a6d2adc42d9f90/autoload/gitgutter/diff.vim#L106) (and index) to short lived temp files
 Quick jumping between hunks                              | :white_check_mark:   | :white_check_mark:                            |
 Stage/reset/preview individual hunks                     | :white_check_mark:   | :white_check_mark:                            |
-Preview hunks directly in the buffer (inline)            | :white_check_mark: * |                                               | * Via `preview_hunk_inline`
+Preview hunks directly in the buffer (inline)            | :white_check_mark: * |                                               | * Via `preview_hunk_inline` on demand or on hover via `automatic_hunk_inline`
 Stage/reset hunks in range/selection                     | :white_check_mark:   | :white_check_mark: :heavy_exclamation_mark: * | * Only stage
 Stage/reset all hunks in buffer                          | :white_check_mark:   |                                               |
 Undo staged hunks                                        | :white_check_mark:   |                                               |

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -32,7 +32,7 @@ For basic setup with all batteries included:
 
 Configuration can be passed to the setup function. Here is an example with most
 of the default settings:
->
+>lua
     require('gitsigns').setup {
       signs = {
         add          = { text = '│' },
@@ -59,6 +59,7 @@ of the default settings:
         ignore_whitespace = false,
       },
       current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
+      automatic_hunk_inline = false, -- `:h gitsigns-config-automatic_hunk_inline`
       sign_priority = 6,
       update_debounce = 100,
       status_formatter = nil, -- Use default
@@ -333,6 +334,13 @@ select_hunk()                                         *gitsigns.select_hunk()*
 
 preview_hunk_inline()                         *gitsigns.preview_hunk_inline()*
                 Preview the hunk at the cursor position inline in the buffer.
+
+automatic_hunk_inline()                     *gitsigns.automatic_hunk_inline()*
+                Preview the hunk at the current cursor position inline in the
+                buffer automatically every time the CursorMoved event is
+                triggered. This function enables or disables the inline diff
+                functionality based on whether the cursor is inside or outside
+                of a hunk.
 
 preview_hunk()                                       *gitsigns.preview_hunk()*
                 Preview the hunk at the cursor position in a floating
@@ -919,6 +927,14 @@ debug_mode                                        *gitsigns-config-debug_mode*
       Enables debug logging and makes the following functions
       available: `dump_cache`, `debug_messages`, `clear_debug`.
 
+automatic_hunk_inline                  *gitsigns-config-automatic_hunk_inline*
+      Type: `boolean`, Default: `false`
+
+      The `automatic_hunk_inline` function enables automatic inline preview of
+      a hunk's diff when the cursor is inside the hunk. The preview is removed
+      when the cursor moves outside the hunk. This option ensures that any
+      newly attached buffer will have this functionality enabled by default,
+      without the need to manually call `Gitsigns automatic_hunk_inline`.
 
 ==============================================================================
 HIGHLIGHT GROUPS                                   *gitsigns-highlight-groups*

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -356,6 +356,10 @@ local attach_throttled = throttle_by_id(function(cbuf, ctx, aucmd)
   if config.keymaps and not vim.tbl_isempty(config.keymaps) then
     require('gitsigns.mappings')(config.keymaps, cbuf)
   end
+
+  if config.automatic_hunk_inline then
+    require('gitsigns.actions').automatic_hunk_inline()
+  end
 end)
 
 --- Detach Gitsigns from all buffers it is attached to.

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -77,6 +77,7 @@ end
 --- @field worktrees {toplevel: string, gitdir: string}[]
 --- @field word_diff boolean
 --- @field keymaps table<string,string>
+--- @field automatic_hunk_inline boolean
 --- -- Undocumented
 --- @field _refresh_staged_on_update boolean
 --- @field _blame_cache boolean
@@ -759,6 +760,18 @@ M.schema = {
           • `GitSignsAddVirtLnInline`
           • `GitSignsChangeVirtLnInline`
           • `GitSignsDeleteVirtLnInline`
+    ]],
+  },
+
+  automatic_hunk_inline = {
+    type = 'boolean',
+    default = false,
+    description = [[
+      The `automatic_hunk_inline` function enables automatic inline preview of
+      a hunk's diff when the cursor is inside the hunk. The preview is removed
+      when the cursor moves outside the hunk. This option ensures that any
+      newly attached buffer will have this functionality enabled by default,
+      without the need to manually call `Gitsigns automatic_hunk_inline`.
     ]],
   },
 


### PR DESCRIPTION
Introducing the ability to preview **inline diffs when hovering** over a hunk that has been added, modified, or removed.

To activate this functionality, you can either call the `Gitsigns automatic_hunk_inline` function directly to toggle it or have it by default in a new buffer by enabling `Config.automatic_hunk_inline` option.

When the **cursor is placed on a hunk**, the `preview_hunk_inline` function will be triggered automatically. Notably, if the cursor moves within the hunk's boundaries, the extmark (marker) will not flicker. However, if the **cursor exits the hunk**, the extmarks will be cleared automatically.

This behavior is achieved through an autocommand that listens for the `CursorMoved` event. Additionally, the implementation takes into consideration the `_inline2` **variant**.