### PR TITLE
docs: update text object mapping recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ require('gitsigns').setup{
     map('n', '<leader>td', gs.toggle_deleted)
 
     -- Text object
-    map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    map({'o', 'x'}, 'ih', '<cmd>Gitsigns select_hunk<CR>')
   end
 }
 ```
@@ -183,8 +183,8 @@ require('gitsigns').setup {
     map('n', '<leader>td', '<cmd>Gitsigns toggle_deleted<CR>')
 
     -- Text object
-    map('o', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
-    map('x', 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    map('o', 'ih', '<cmd>Gitsigns select_hunk<CR>')
+    map('x', 'ih', '<cmd>Gitsigns select_hunk<CR>')
   end
 }
 ```


### PR DESCRIPTION
Based on the [docs](https://github.com/neovim/neovim/blob/master/runtime/doc/map.txt#L332) using `<cmd>...<CR>` is superior to using `:<C-U>...<CR>`.