### PR TITLE
fix: missing bottom border

### DIFF
--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -23,8 +23,9 @@ end
 -- Expand height until all lines are visible to account for wrapped lines.
 --- @param winid integer
 --- @param nlines integer
-local function expand_height(winid, nlines)
+local function expand_height(winid, nlines, border)
   local newheight = 0
+  local maxheight = vim.o.lines - vim.o.cmdheight - (border ~= '' and 2 or 0)
   for _ = 0, 50 do
     local winheight = api.nvim_win_get_height(winid)
     if newheight > winheight then
@@ -39,6 +40,10 @@ local function expand_height(winid, nlines)
       break
     end
     newheight = winheight + nlines - wd
+    if newheight > maxheight then
+      api.nvim_win_set_height(winid, maxheight)
+      break
+    end
     api.nvim_win_set_height(winid, newheight)
   end
 end
@@ -145,7 +150,7 @@ function M.create0(lines, opts, id)
   vim.w[winid].gitsigns_preview = id or true
 
   if not opts.height then
-    expand_height(winid, #lines)
+    expand_height(winid, #lines, opts.border)
   end
 
   if opts1.style == 'minimal' then


### PR DESCRIPTION
This PR fixes https://github.com/lewis6991/gitsigns.nvim/issues/841. 

The bottom border is missing because when the content is too much, the height of the floating window exceeds the maximum height of the screen. When it happens, we set the floating window height to the maximum height (the maximum height is `vim.o.lines` subtracting `cmdheight` and the heights of the top and bottom borders).

<img width="1728" alt="image" src="https://github.com/lewis6991/gitsigns.nvim/assets/11582667/9b6365a7-674e-4ac3-9f7d-594b41b566b2">

Thank you. 