### PR TITLE
fix: git rc release version causes assertion error

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -71,7 +71,8 @@ local function parse_version(version)
   if parts[3] == 'GIT' then
     ret.patch = 0
   else
-    ret.patch = assert(tonumber(parts[3]))
+    local patch_ver = vim.split(parts[3], '-')
+    ret.patch = assert(tonumber(patch_ver[1]))
   end
 
   return ret


### PR DESCRIPTION
My git version is `git version 2.42.0-rc0`.

This causes the following error because the patch number includes a string.

```lua
   Error  04:43:36 PM msg_show.lua_error     Error executing luv callback:
...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:76: The coroutine failed with this message: ...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:74: assertion failed!
stack traceback:
	[C]: in function 'assert'
	...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:74: in function 'parse_version'
	...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:121: in function '_set_version'
	...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:135: in function 'git_command'
	...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:424: in function 'new'
	...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:753: in function 'new'
	...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:288: in function 'fn'
	.../share/nvim/lazy/gitsigns.nvim/lua/gitsigns/debounce.lua:76: in function 'attach_throttled'
	...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:423: in function 'attach'
	...ta/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:125: in function 'setup_attach'
	...ta/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:183: in function <...ta/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:159>
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:76: in function 'cb'
	...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:113: in function 'callback'
	...hare/nvim/lazy/gitsigns.nvim/lua/gitsigns/subprocess.lua:98: in function <...hare/nvim/lazy/gitsigns.nvim/lua/gitsigns/subprocess.lua:86>
	[C]: in function 'system'
	...l/share/nvim/lazy/cmp-tabnine/lua/cmp_tabnine/source.lua:116: in function 'binary'
	...l/share/nvim/lazy/cmp-tabnine/lua/cmp_tabnine/source.lua:267: in function 'on_exit'
	...l/share/nvim/lazy/cmp-tabnine/lua/cmp_tabnine/source.lua:141: in function 'new'
	...cal/share/nvim/lazy/cmp-tabnine/lua/cmp_tabnine/init.lua:20: in function <...cal/share/nvim/lazy/cmp-tabnine/lua/cmp_tabnine/init.lua:19>
```

According to git's tagging rules, it seems to be OK If you separate them with a hyphen.
https://github.com/git/git/releases/tag/v2.42.0-rc0