### PR TITLE
fix: accommodate watcher receiving a nil filename.

### DIFF
--- a/lua/gitsigns/watcher.lua
+++ b/lua/gitsigns/watcher.lua
@@ -116,6 +116,9 @@ function M.watch_gitdir(bufnr, gitdir)
 
     local info = string.format("Git dir update: '%s' %s", filename, inspect(events))
 
+    -- The luv docs say filename is passed as a string but it has been observed
+    -- to sometimes be nil.
+    --    https://github.com/lewis6991/gitsigns.nvim/issues/848
     if filename == nil or vim.endswith(filename, '.lock') then
       dprintf('%s (ignoring)', info)
       return

--- a/lua/gitsigns/watcher.lua
+++ b/lua/gitsigns/watcher.lua
@@ -116,7 +116,7 @@ function M.watch_gitdir(bufnr, gitdir)
 
     local info = string.format("Git dir update: '%s' %s", filename, inspect(events))
 
-    if vim.endswith(filename, '.lock') then
+    if filename == nil or vim.endswith(filename, '.lock') then
       dprintf('%s (ignoring)', info)
       return
     end


### PR DESCRIPTION
As per comment in https://github.com/lewis6991/gitsigns.nvim/issues/848#issuecomment-1668828577 the gitdir watcher sometimes erroneously receives a nil filename from `luv`/`libuv`.