### PR TITLE
fix(blame): If it has been detached, the cache[bufnr] is nil

### DIFF
--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -144,6 +144,9 @@ end
 --- @param opts Gitsigns.CurrentLineBlameOpts
 local function handle_blame_info(bufnr, lnum, blame_info, opts)
   local bcache = cache[bufnr]
+  if not bcache then
+    return
+  end
   local virt_text ---@type {[1]: string, [2]: string}[]
   local clb_formatter = blame_info.author == 'Not Committed Yet'
       and config.current_line_blame_formatter_nc


### PR DESCRIPTION
```log
Error executing vim.schedule lua callback: ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:76: The coroutine failed with this message: ...m/lazy/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:154: attempt to index local 'bcache' (a nil value)
stack traceback:
	...m/lazy/gitsigns.nvim/lua/gitsigns/current_line_blame.lua: in function 'handle_blame_info'
	...m/lazy/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:238: in function <...m/lazy/gitsigns.nvim/lua/gitsigns/current_line_blame.lua:184>
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:76: in function 'cb'
	...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:113: in function 'cb'
	...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:186: in function <...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:184>

```