### PR TITLE
Fixes the signature of setup to not require an argument

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -154,7 +154,7 @@ end
 --- Attributes: ~
 ---     {async}
 ---
---- @param cfg table Configuration for Gitsigns.
+--- @param cfg table|nil Configuration for Gitsigns.
 ---     See |gitsigns-usage| for more details.
 M.setup = void(function(cfg)
   gs_config.build(cfg)

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -442,15 +442,15 @@ M.schema = {
   count_chars = {
     type = 'table',
     default = {
-      [1] = '1', -- '₁',
-      [2] = '2', -- '₂',
-      [3] = '3', -- '₃',
-      [4] = '4', -- '₄',
-      [5] = '5', -- '₅',
-      [6] = '6', -- '₆',
-      [7] = '7', -- '₇',
-      [8] = '8', -- '₈',
-      [9] = '9', -- '₉',
+      [1] = '1',   -- '₁',
+      [2] = '2',   -- '₂',
+      [3] = '3',   -- '₃',
+      [4] = '4',   -- '₄',
+      [5] = '5',   -- '₅',
+      [6] = '6',   -- '₆',
+      [7] = '7',   -- '₇',
+      [8] = '8',   -- '₈',
+      [9] = '9',   -- '₉',
       ['+'] = '>', -- '₊',
     },
     description = [[
@@ -855,7 +855,7 @@ local function handle_deprecated(cfg)
   end
 end
 
---- @param user_config Gitsigns.Config
+--- @param user_config Gitsigns.Config|nil
 function M.build(user_config)
   user_config = user_config or {}
 


### PR DESCRIPTION
This fixes the signature of setup to allow now parameters (nil). 

Otherwise I would get an error:

<img width="950" alt="image" src="https://github.com/lewis6991/gitsigns.nvim/assets/6276582/00d84769-141e-441a-a2e0-5b91255dd321">


