### PR TITLE
perf(blame): general improvements

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -32,7 +32,7 @@ For basic setup with all batteries included:
 
 Configuration can be passed to the setup function. Here is an example with most
 of the default settings:
->
+>lua
     require('gitsigns').setup {
       signs = {
         add          = { text = '│' },
@@ -98,7 +98,7 @@ setup({cfg})                                                *gitsigns.setup()*
                     {async}
 
                 Parameters: ~
-                    {cfg} (table):  Configuration for Gitsigns.
+                    {cfg} (table|nil):  Configuration for Gitsigns.
                           See |gitsigns-usage| for more details.
 
 attach({bufnr}, {ctx})                                     *gitsigns.attach()*
@@ -200,7 +200,7 @@ show({revision})                                             *gitsigns.show()*
                 If {base} is the index, then the opened buffer is editable and
                 any written changes will update the index accordingly.
 
-                Examples: >
+                Examples: >vim
                   " View the index version of the file
                   :Gitsigns show
 
@@ -221,7 +221,7 @@ diffthis({base}, {opts})                                 *gitsigns.diffthis()*
                 If {base} is the index, then the opened buffer is editable and
                 any written changes will update the index accordingly.
 
-                Examples: >
+                Examples: >vim
                   " Diff against the index
                   :Gitsigns diffthis
 
@@ -261,7 +261,7 @@ change_base({base}, {global})                         *gitsigns.change_base()*
                 Attributes: ~
                     {async}
 
-                Examples: >
+                Examples: >vim
                   " Change base to 1 commit behind head
                   :lua require('gitsigns').change_base('HEAD~1')
 
@@ -537,7 +537,7 @@ worktrees                                          *gitsigns-config-worktrees*
       If normal attaching fails, then each entry in the table is attempted
       with the work tree details set.
 
-      Example: >
+      Example: >lua
         worktrees = {
           {
             toplevel = vim.env.HOME,
@@ -553,7 +553,7 @@ on_attach                                          *gitsigns-config-on_attach*
 
       This callback can return `false` to prevent attaching to the buffer.
 
-      Example: >
+      Example: >lua
         on_attach = function(bufnr)
           if vim.api.nvim_buf_get_name(bufnr):match(<PATTERN>) then
             -- Don't attach to specific buffers whose name matches a pattern

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -828,6 +828,7 @@ current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
                          • `summary`: string
                          • `previous`: string
                          • `filename`: string
+                         • `boundary`: true?
 
                        Note that the keys map onto the output of:
                          `git blame --line-porcelain`

--- a/etc/doc_template.txt
+++ b/etc/doc_template.txt
@@ -32,7 +32,7 @@ For basic setup with all batteries included:
 
 Configuration can be passed to the setup function. Here is an example with most
 of the default settings:
->
+>lua
 {{SETUP}}
 <
 

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -927,7 +927,7 @@ end
 --- Attributes: ~
 ---     {async}
 ---
---- Examples: >
+--- Examples: >vim
 ---   " Change base to 1 commit behind head
 ---   :lua require('gitsigns').change_base('HEAD~1')
 ---
@@ -995,7 +995,7 @@ end
 --- If {base} is the index, then the opened buffer is editable and
 --- any written changes will update the index accordingly.
 ---
---- Examples: >
+--- Examples: >vim
 ---   " Diff against the index
 ---   :Gitsigns diffthis
 ---
@@ -1064,7 +1064,7 @@ CP.diffthis = complete_heads
 --- If {base} is the index, then the opened buffer is editable and
 --- any written changes will update the index accordingly.
 ---
---- Examples: >
+--- Examples: >vim
 ---   " View the index version of the file
 ---   :Gitsigns show
 ---

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -337,6 +337,7 @@ local attach_throttled = throttle_by_id(function(cbuf, ctx, aucmd)
   end
 
   cache[cbuf] = CacheEntry.new({
+    bufnr = cbuf,
     base = ctx and ctx.base or config.base,
     file = file,
     commit = commit,

--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -7,6 +7,7 @@ local M = {
 -- Timer object watching the gitdir
 
 --- @class Gitsigns.CacheEntry
+--- @field bufnr              integer
 --- @field file               string
 --- @field base?              string
 --- @field compare_text?      string[]

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -658,6 +658,7 @@ M.schema = {
                          • `summary`: string
                          • `previous`: string
                          • `filename`: string
+                         • `boundary`: true?
 
                        Note that the keys map onto the output of:
                          `git blame --line-porcelain`

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -245,7 +245,7 @@ M.schema = {
       If normal attaching fails, then each entry in the table is attempted
       with the work tree details set.
 
-      Example: >
+      Example: >lua
         worktrees = {
           {
             toplevel = vim.env.HOME,
@@ -265,7 +265,7 @@ M.schema = {
       This callback must call its callback argument. The callback argument can
       accept an optional table argument with the keys: 'gitdir' and 'toplevel'.
 
-      Example: >
+      Example: >lua
       on_attach_pre = function(bufnr, callback)
         ...
         callback {
@@ -286,7 +286,7 @@ M.schema = {
 
       This callback can return `false` to prevent attaching to the buffer.
 
-      Example: >
+      Example: >lua
         on_attach = function(bufnr)
           if vim.api.nvim_buf_get_name(bufnr):match(<PATTERN>) then
             -- Don't attach to specific buffers whose name matches a pattern

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -250,4 +250,13 @@ function M.bufexists(buf)
   return vim.fn.bufexists(buf) == 1
 end
 
+--- @param x Gitsigns.BlameInfo
+--- @return Gitsigns.BlameInfoPublic
+function M.convert_blame_info(x)
+  --- @type Gitsigns.BlameInfoPublic
+  local ret = vim.tbl_extend('error', x, x.commit)
+  ret.commit = nil
+  return ret
+end
+
 return M

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -95,7 +95,7 @@ describe('gitsigns', function()
 
     check {
       status = {head='', added=18, changed=0, removed=0},
-      signs = {untracked=8}
+      signs = {untracked=nvim_ver == 10 and 7 or 8}
     }
 
     git{"add", test_file}


### PR DESCRIPTION
### fix(blame): do not run concurrent processes

Limits the amount of git-blame processes in the background to 1

### perf(blame): run blame for entire file instead of per line

Previously current_line_blame would run a git-blame process per line
(via the `-L` flag) in an attempt to be more efficient. However after
some investigation it seems that running git-blame for the entire file
rarely exceeds 2x the time it takes to run for a single line, even for
large files.

This change alters current_line_blame to run git-blame for the entire
file after each buffer edit and caches that in memory. This makes the
first git-blame after an edit ~2x slower, but makes any cursor movements
after that instant.

A follow-up to this would be for current_line_blame to track buffer
updates to avoid the cache needing to be invalidated on every edit.

Fixes #877
