### PR TITLE
fix(setqflist): don't strip trailing newline from working tree state

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -1143,7 +1143,7 @@ local function buildqflist(target)
         if stat and stat.type == 'file' then
           local a = r:get_show_text(':0:' .. f)
           async.scheduler()
-          local hunks = run_diff(a, util.file_lines(f_abs))
+          local hunks = run_diff(a, util.file_lines(f_abs, { raw = true }))
           hunks_to_qflist(f_abs, hunks, qflist)
         end
       end

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -24,14 +24,21 @@ function M.dirname(file)
   return file:match(string.format('^(.+)%s[^%s]+', M.path_sep, M.path_sep))
 end
 
---- @param file string
+--- @param path string
+--- @param opts {raw: boolean}?
 --- @return string[]
-function M.file_lines(file)
-  local text = {} --- @type string[]
-  for line in io.lines(file) do
-    text[#text + 1] = line
+function M.file_lines(path, opts)
+  opts = opts or {}
+  local file = assert(io.open(path))
+  local contents = file:read('*a')
+  local lines = vim.split(contents, '\n', { plain = true })
+  if not opts.raw then
+    -- If contents ends with a newline, then remove the final empty string after the split
+    if lines[#lines] == '' then
+      lines[#lines] = nil
+    end
   end
-  return text
+  return lines
 end
 
 M.path_sep = package.config:sub(1, 1)


### PR DESCRIPTION
### Summary
The fix of https://github.com/lewis6991/gitsigns.nvim/issues/779 in https://github.com/lewis6991/gitsigns.nvim/pull/862 broke `setqflist`. An empty hunk is being added to the quickfix for each changed file and no hunks is being added for a newline appended to a file.

### Problem
`Repo:get_show_text` is used to retrieve the lines of the index state and `utils.file_lines` is used to retrieve the lines of the working tree state. The trailing empty line is being retained by `Repo:get_show_text` (by providing `{ raw = true }` to [Repo:command](https://github.com/lewis6991/gitsigns.nvim/blob/907ae8636016aab2f283576fc60d46ca3427e579/lua/gitsigns/git.lua#L324)) https://github.com/lewis6991/gitsigns.nvim/blob/907ae8636016aab2f283576fc60d46ca3427e579/lua/gitsigns/git.lua#L404-L405 but not `utils.file_lines` https://github.com/lewis6991/gitsigns.nvim/blob/907ae8636016aab2f283576fc60d46ca3427e579/lua/gitsigns/util.lua#L29-L35 (`io.lines` strips trailing newlines by default).

This PR fixes the problem by adding the option to retain the trailing empty line to `utils.file_lines` as well. I can see that this method is only used by `buildqflist` at the moment so we could just make this the default behaviour but: 
1. This doesn't seem like the behaviour which you'd expect.
2. This wouldn't be in keeping with `Repo:command` which strips the trailing empty line by default.

### Reproduction of bug and fix
1. Setup a test repo and clone the current and fixed states of the plugin. `foo` has had a trailing new line appended as in https://github.com/lewis6991/gitsigns.nvim/issues/779 and `bar` has had its first line modified.
```shell
mkdir setqflist-newline && \
  cd setqflist-newline && \
  git clone https://github.com/lewis6991/gitsigns.nvim --depth 1 gitsigns/before && \
  git clone https://github.com/marcuscaisey/gitsigns.nvim.git --depth 1 --branch setqflist-newline gitsigns/after && \
  git init && \
  echo -n "a" > foo && \
  echo -n "a\nb\nc\n" > bar && \
  git add foo bar && \
  git commit -m "add foo and bar" && \
  echo -n "a\n" > foo && \
  echo -n "d\nb\nc\n" > bar
```
2.
```shell
git diff
```
<img width="494" alt="image" src="https://github.com/lewis6991/gitsigns.nvim/assets/34950778/bde58ae4-cd04-4067-a193-ee1dfdff9b7b">

3. Current behaviour
```shell
nvim --clean \
  -c "lua vim.opt.runtimepath:append('gitsigns/before')" \
  -c "lua require('gitsigns').setup()" \
  -c "lua require('gitsigns').setqflist('all')"
```
<img width="276" alt="image" src="https://github.com/lewis6991/gitsigns.nvim/assets/34950778/21d994fc-bbb4-4f22-a9f8-4458cb76df0a">

4. Fixed behaviour
```shell
nvim --clean \
  -c "lua vim.opt.runtimepath:append('gitsigns/after')" \
  -c "lua require('gitsigns').setup()" \
  -c "lua require('gitsigns').setqflist('all')"
```
<img width="247" alt="image" src="https://github.com/lewis6991/gitsigns.nvim/assets/34950778/0451700b-d830-49e7-a123-10c031de3db0">
