### PR TITLE
perf(blame): better cache invalidation

### DIFF
--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -10,7 +10,6 @@ local hl = require('gitsigns.highlight')
 
 local gs_cache = require('gitsigns.cache')
 local cache = gs_cache.cache
-local CacheEntry = gs_cache.CacheEntry
 local Status = require('gitsigns.status')
 
 local gs_config = require('gitsigns.config')
@@ -111,6 +110,7 @@ end
 --- @param bufnr integer
 local function on_reload(_, bufnr)
   local __FUNC__ = 'on_reload'
+  cache[bufnr]:invalidate()
   dprint('Reload')
   manager.update_debounced(bufnr)
 end
@@ -336,7 +336,7 @@ local attach_throttled = throttle_by_id(function(cbuf, ctx, aucmd)
     return
   end
 
-  cache[cbuf] = CacheEntry.new({
+  cache[cbuf] = gs_cache.new({
     bufnr = cbuf,
     base = ctx and ctx.base or config.base,
     file = file,

--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -1,26 +1,27 @@
+local async = require('gitsigns.async')
 local config = require('gitsigns.config').config
+local util = require('gitsigns.util')
 
 local M = {
   CacheEntry = {},
 }
 
--- Timer object watching the gitdir
-
---- @class Gitsigns.CacheEntry
+--- @class (exact) Gitsigns.CacheEntry
 --- @field bufnr              integer
 --- @field file               string
 --- @field base?              string
 --- @field compare_text?      string[]
---- @field hunks              Gitsigns.Hunk.Hunk[]
+--- @field hunks?             Gitsigns.Hunk.Hunk[]
 --- @field force_next_update? boolean
 ---
 --- @field compare_text_head? string[]
 --- @field hunks_staged?      Gitsigns.Hunk.Hunk[]
 ---
---- @field staged_diffs       Gitsigns.Hunk.Hunk[]
+--- @field staged_diffs?      Gitsigns.Hunk.Hunk[]
 --- @field gitdir_watcher?    uv.uv_fs_event_t
 --- @field git_obj            Gitsigns.GitObj
 --- @field commit?            string
+--- @field blame?             table<integer,Gitsigns.BlameInfo?>
 local CacheEntry = M.CacheEntry
 
 function CacheEntry:get_compare_rev(base)
@@ -47,18 +48,93 @@ function CacheEntry:get_rev_bufname(rev)
   return string.format('gitsigns://%s/%s:%s', self.git_obj.repo.gitdir, rev, self.git_obj.relpath)
 end
 
-function CacheEntry:invalidate()
-  self.compare_text = nil
-  self.compare_text_head = nil
+--- Invalidate any state dependent on the buffer content.
+--- If 'all' is passed, then invalidate everything.
+--- @param all? boolean
+function CacheEntry:invalidate(all)
   self.hunks = nil
   self.hunks_staged = nil
+  self.blame = nil
+  if all then
+    -- The below doesn't need to be invalidated
+    -- if the buffer changes
+    self.compare_text = nil
+    self.compare_text_head = nil
+  end
 end
 
 --- @param o Gitsigns.CacheEntry
 --- @return Gitsigns.CacheEntry
-function CacheEntry.new(o)
+function M.new(o)
   o.staged_diffs = o.staged_diffs or {}
   return setmetatable(o, { __index = CacheEntry })
+end
+
+local sleep = async.wrap(function(duration, cb)
+  vim.defer_fn(cb, duration)
+end, 2)
+
+--- @private
+function CacheEntry:wait_for_hunks()
+  local loop_protect = 0
+  while not self.hunks and loop_protect < 10 do
+    loop_protect = loop_protect + 1
+    sleep(100)
+  end
+end
+
+--- @private
+--- @param opts Gitsigns.CurrentLineBlameOpts
+--- @return table<integer,Gitsigns.BlameInfo?>?
+function CacheEntry:run_blame(opts)
+  local blame_cache --- @type table<integer,Gitsigns.BlameInfo?>?
+  repeat
+    local buftext = util.buf_lines(self.bufnr)
+    local tick = vim.b[self.bufnr].changedtick
+    -- TODO(lewis6991): Cancel blame on changedtick
+    blame_cache = self.git_obj:run_blame(buftext, nil, opts.ignore_whitespace)
+    async.scheduler_if_buf_valid(self.bufnr)
+  until vim.b[self.bufnr].changedtick == tick
+  return blame_cache
+end
+
+--- @param file string
+--- @param lnum integer
+--- @return Gitsigns.BlameInfo
+local function get_blame_nc(file, lnum)
+  local Git = require('gitsigns.git')
+
+  return {
+    orig_lnum = 0,
+    final_lnum = lnum,
+    commit = Git.not_commited(file),
+    filename = file,
+  }
+end
+
+--- @param lnum integer
+--- @param opts Gitsigns.CurrentLineBlameOpts
+--- @return Gitsigns.BlameInfo?
+function CacheEntry:get_blame(lnum, opts)
+  local blame_cache = self.blame
+
+  if not blame_cache or not blame_cache[lnum] then
+    self:wait_for_hunks()
+    local Hunks = require('gitsigns.hunks')
+    if Hunks.find_hunk(lnum, self.hunks) then
+      --- Bypass running blame (which can be expensive) if we know lnum is in a hunk
+      blame_cache = blame_cache or {}
+      blame_cache[lnum] = get_blame_nc(self.git_obj.relpath, lnum)
+    else
+      -- Refresh cache
+      blame_cache = self:run_blame(opts)
+    end
+    self.blame = blame_cache
+  end
+
+  if blame_cache then
+    return blame_cache[lnum]
+  end
 end
 
 function CacheEntry:destroy()

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -70,7 +70,6 @@
 --- @field trouble boolean
 --- -- Undocumented
 --- @field _refresh_staged_on_update boolean
---- @field _blame_cache boolean
 --- @field _threaded_diff boolean
 --- @field _inline2 boolean
 --- @field _extmark_signs boolean
@@ -757,14 +756,6 @@ M.schema = {
       Always refresh the staged file on each update. Disabling this will cause
       the staged file to only be refreshed when an update to the index is
       detected.
-    ]],
-  },
-
-  _blame_cache = {
-    type = 'boolean',
-    default = true,
-    description = [[
-      Cache blame results for current_line_blame
     ]],
   },
 

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -75,6 +75,28 @@ local function apply_win_signs(bufnr, top, bot, clear)
   end
 end
 
+--- @param blame table<integer,Gitsigns.BlameInfo?>?
+--- @param first integer
+--- @param last_orig integer
+--- @param last_new integer
+local function on_lines_blame(blame, first, last_orig, last_new)
+  if not blame then
+    return
+  end
+
+  if last_new ~= last_orig then
+    if last_new < last_orig then
+      util.list_remove(blame, last_new, last_orig)
+    else
+      util.list_insert(blame, last_orig, last_new)
+    end
+  end
+
+  for i = math.min(first + 1, last_new), math.max(first + 1, last_new) do
+    blame[i] = nil
+  end
+end
+
 --- @param buf integer
 --- @param first integer
 --- @param last_orig integer
@@ -86,6 +108,8 @@ function M.on_lines(buf, first, last_orig, last_new)
     dprint('Cache for buffer was nil. Detaching')
     return true
   end
+
+  on_lines_blame(bcache.blame, first, last_orig, last_new)
 
   signs_normal:on_lines(buf, first, last_orig, last_new)
   if signs_staged then

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -191,19 +191,6 @@ function M.get_relative_time(timestamp)
   end
 end
 
---- @generic T
---- @param x T[]
---- @return T[]
-function M.copy_array(x)
-  local r = {}
-  --- @diagnostic disable-next-line:no-unknown
-  for i, e in ipairs(x) do
-    --- @diagnostic disable-next-line:no-unknown
-    r[i] = e
-  end
-  return r
-end
-
 --- Strip '\r' from the EOL of each line only if all lines end with '\r'
 --- @param xs0 string[]
 --- @return string[]
@@ -302,6 +289,51 @@ function M.convert_blame_info(x)
   local ret = vim.tbl_extend('error', x, x.commit)
   ret.commit = nil
   return ret
+end
+
+--- Efficiently remove items from middle of a list a list.
+---
+--- Calling table.remove() in a loop will re-index the tail of the table on
+--- every iteration, instead this function will re-index  the table exactly
+--- once.
+---
+--- Based on https://stackoverflow.com/questions/12394841/safely-remove-items-from-an-array-table-while-iterating/53038524#53038524
+---
+---@param t any[]
+---@param first integer
+---@param last integer
+function M.list_remove(t, first, last)
+  local n = #t
+  for i = 0, n - first do
+    t[first + i] = t[last + 1 + i]
+    t[last + 1 + i] = nil
+  end
+end
+
+--- Efficiently insert items into the middle of a list.
+---
+--- Calling table.insert() in a loop will re-index the tail of the table on
+--- every iteration, instead this function will re-index  the table exactly
+--- once.
+---
+--- Based on https://stackoverflow.com/questions/12394841/safely-remove-items-from-an-array-table-while-iterating/53038524#53038524
+---
+---@param t any[]
+---@param first integer
+---@param last integer
+---@param v any
+function M.list_insert(t, first, last, v)
+  local n = #t
+
+  -- Shift table forward
+  for i = n - first, 0, -1 do
+    t[last + 1 + i] = t[first + i]
+  end
+
+  -- Fill in new values
+  for i = first, last do
+    t[i] = v
+  end
 end
 
 return M

--- a/lua/gitsigns/watcher.lua
+++ b/lua/gitsigns/watcher.lua
@@ -87,7 +87,7 @@ local handler = debounce_trailing(
       buf_check(bufnr)
     end
 
-    cache[bufnr]:invalidate()
+    cache[bufnr]:invalidate(true)
 
     require('gitsigns.manager').update(bufnr)
   end),


### PR DESCRIPTION
The blame cache is now maintained in the CacheEntry object
and invalidated incrementally on buffer updates.

In addition git-blame is bypassed if the cursor line is within a hunk.
