### PR TITLE
feat(diff): allow to diff against the working version

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -1083,6 +1083,9 @@ Gitsigns objects are Git revisions as defined in the "SPECIFYING REVISIONS"
 section in the gitrevisions(7) man page. For commands that accept an optional
 base, the default is the file in the index. Examples:
 
+Additionally, Gitsigns also accepts the value `FILE` to specify the working
+version of a file.
+
 Object        Meaning ~
 @             Version of file in the commit referenced by @ aka HEAD
 main          Version of file in the commit referenced by main

--- a/etc/doc_template.txt
+++ b/etc/doc_template.txt
@@ -105,6 +105,9 @@ Gitsigns objects are Git revisions as defined in the "SPECIFYING REVISIONS"
 section in the gitrevisions(7) man page. For commands that accept an optional
 base, the default is the file in the index. Examples:
 
+Additionally, Gitsigns also accepts the value `FILE` to specify the working
+version of a file.
+
 Object        Meaning ~
 @             Version of file in the commit referenced by @ aka HEAD
 main          Version of file in the commit referenced by main

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -118,6 +118,10 @@ end
 --- @param _ 'detach'
 --- @param bufnr integer
 local function on_detach(_, bufnr)
+  api.nvim_clear_autocmds({
+    group = 'gitsigns',
+    buffer = bufnr,
+  })
   M.detach(bufnr, true)
 end
 
@@ -360,6 +364,14 @@ local attach_throttled = throttle_by_id(function(cbuf, ctx, aucmd)
     on_lines = on_lines,
     on_reload = on_reload,
     on_detach = on_detach,
+  })
+
+  api.nvim_create_autocmd('BufWrite', {
+    group = 'gitsigns',
+    buffer = cbuf,
+    callback = function()
+      manager.update_debounced(cbuf)
+    end,
   })
 
   -- Initial update

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -517,6 +517,10 @@ end
 --- @param revision string
 --- @return string[] stdout, string? stderr
 function Obj:get_show_text(revision)
+  if revision == 'FILE' then
+    return util.file_lines(self.file, { raw = true })
+  end
+
   if not self.relpath then
     return {}
   end

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -465,8 +465,12 @@ M.update = throttle_by_id(function(bufnr)
 
   local git_obj = bcache.git_obj
 
-  if not bcache.compare_text or config._refresh_staged_on_update then
-    bcache.compare_text = git_obj:get_show_text(bcache:get_compare_rev())
+  local compare_rev = bcache:get_compare_rev()
+
+  local file_mode = compare_rev == 'FILE'
+
+  if not bcache.compare_text or config._refresh_staged_on_update or file_mode then
+    bcache.compare_text = git_obj:get_show_text(compare_rev)
     M.buf_check(bufnr, true)
   end
 
@@ -475,7 +479,7 @@ M.update = throttle_by_id(function(bufnr)
   bcache.hunks = run_diff(bcache.compare_text, buftext)
   M.buf_check(bufnr)
 
-  if config._signs_staged_enable then
+  if config._signs_staged_enable and not file_mode then
     if not bcache.compare_text_head or config._refresh_staged_on_update then
       local staged_compare_rev = bcache.commit and string.format('%s^', bcache.commit) or 'HEAD'
       bcache.compare_text_head = git_obj:get_show_text(staged_compare_rev)

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -557,7 +557,7 @@ describe('gitsigns', function()
         feed('iedit')
         check{ status = {head='master', added=0, changed=1, removed=0} }
         command("write")
-        command("bdelete")
+        command("bwipe")
         gitm{
           {'add', test_file},
           {"commit", "-m", "commit on main"},
@@ -571,7 +571,7 @@ describe('gitsigns', function()
         feed('idiff')
         check{ status = {head='abranch', added=0, changed=1, removed=0} }
         command("write")
-        command("bdelete")
+        command("bwipe")
         gitm{
           {'add', test_file},
           {"commit", "-m", "commit on branch"},


### PR DESCRIPTION
The `base` can now be set to `FILE` to diff against the working version.

Resolves #164
