### PR TITLE
fix(README): add default config.current_line_blame_opts.virt_text_priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ require('gitsigns').setup {
     virt_text_pos = 'eol', -- 'eol' | 'overlay' | 'right_align'
     delay = 1000,
     ignore_whitespace = false,
+    virt_text_priority = 100,
   },
   current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
   sign_priority = 6,

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -56,6 +56,7 @@ of the default settings:
         virt_text_pos = 'eol', -- 'eol' | 'overlay' | 'right_align'
         delay = 1000,
         ignore_whitespace = false,
+        virt_text_priority = 100,
       },
       current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
       sign_priority = 6,


### PR DESCRIPTION
Add the default value of `config.current_line_blame_opts.virt_text_priority` to the README setup example.