### PR TITLE
docs(README): add documentation for `current_line_blame_formatter_opts.relative_time`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ require('gitsigns').setup {
     virt_text_priority = 100,
   },
   current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
+  current_line_blame_formatter_opts = {
+    relative_time = false,
+  },
   sign_priority = 6,
   update_debounce = 100,
   status_formatter = nil, -- Use default


### PR DESCRIPTION
Documents the default for PR #236 in the Readme.