### PR TITLE
fix: gitsigns not automatically attached due to async not returning

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -119,6 +119,13 @@ end
 local function setup_attach()
   scheduler()
 
+  api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'BufWritePost' }, {
+    group = 'gitsigns',
+    callback = function(data)
+      M.attach(nil, nil, data.event)
+    end,
+  })
+
   -- Attach to all open buffers
   for _, buf in ipairs(api.nvim_list_bufs()) do
     if api.nvim_buf_is_loaded(buf) and api.nvim_buf_get_name(buf) ~= '' then
@@ -126,13 +133,6 @@ local function setup_attach()
       scheduler()
     end
   end
-
-  api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'BufWritePost' }, {
-    group = 'gitsigns',
-    callback = function(data)
-      M.attach(nil, nil, data.event)
-    end,
-  })
 end
 
 local function setup_cwd_head()


### PR DESCRIPTION
Attempt to fix #903.

## What's Going On?

This bug is triggered when opening neovim inside a directory, with both neo-tree and this plugin installed.

Opening the directory causes neovim to create a netrw buffer.

When the `setup()` function of this plugin is called, the plugin will eventually reach this particular part of the code:

https://github.com/lewis6991/gitsigns.nvim/blob/37d26d718f8120a8c5c107c580c8c98cf89fdf1f/lua/gitsigns.lua#L122-L128

At this point in time, the netrw buffer exists, so `M.attach()` will be called with that buffer. `M.attach()` will eventually give up control here with `async.scheduler_if_buf_valid()`:

https://github.com/lewis6991/gitsigns.nvim/blob/37d26d718f8120a8c5c107c580c8c98cf89fdf1f/lua/gitsigns/attach.lua#L296-L299

After giving up control, the neotree plugin will run the "hijack netrw" logic (NB: hijacking is the default behaviour of neotree and does not need to be configured manually.) The hijack logic can be found here:

https://github.com/nvim-neo-tree/neo-tree.nvim/blob/f86e871584bd3c5a00b4ff8344305889eb52ebff/lua/neo-tree/setup/netrw.lua#L53-L101

As part of the hijack, it deletes the netrw buffer:

```lua
    local remove_dir_buf = vim.schedule_wrap(function()
      log.trace("Deleting buffer in netrw hijack", dir_bufnr)
      pcall(vim.api.nvim_buf_delete, dir_bufnr, { force = true })
    end)
```

After the hijack is done, the `gitsigns` plugin regains control here:

https://github.com/lewis6991/gitsigns.nvim/blob/37d26d718f8120a8c5c107c580c8c98cf89fdf1f/lua/gitsigns/async.lua#L183-L189

Unfortunately, `buf` is not `nil` (it is the ID of the now-deleted netrw buffer), and `vim.api.nvim_buf_is_valid(buf)` returns false, so `cb()` is never executed, and so we never continue executing.

This is problematic, because the code after the for loop that contains `M.attach()` is the one responsible for adding the attach `autocmd`, but this adding is never executed:

```lua
  for _, buf in ipairs(api.nvim_list_bufs()) do
    if api.nvim_buf_is_loaded(buf) and api.nvim_buf_get_name(buf) ~= '' then
      M.attach(buf, nil, 'setup')  ----- never returns
      scheduler()
    end
  end

  api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'BufWritePost' }, {   ----- does not get executed as a result :(
    group = 'gitsigns',
    callback = function(data)
      M.attach(nil, nil, data.event)
    end,
  })
```

## Solution

Moved the autocmd to before the for loop, instead of after the for loop.

This solution feels like a temporary band-aid, but it does fix the problem.