### PR TITLE
fix: error message when `:Gitsigns` select dialog is cancelled

### DIFF
--- a/lua/gitsigns/cli.lua
+++ b/lua/gitsigns/cli.lua
@@ -79,6 +79,9 @@ M.run = void(function(params)
 
   if not func then
     func = select(M.complete('', 'Gitsigns '), {}) --[[@as string]]
+    if not func then
+      return
+    end
   end
 
   local pos_args = vim.tbl_map(parse_to_lua, vim.list_slice(pos_args_raw, 2))


### PR DESCRIPTION
The `:Gitsigns` command prompts the user for an action via [`vim.ui.select`](https://neovim.io/doc/user/lua.html#vim.ui.select()) when called without arguments,  which yields `nil` when the dialog is cancelled.

Currently, this is not checked and if the user cancels the dialog, an error message is displayed: 'nil is not a valid function or action'. This PR simply returns from `cli.run()` silently if the `vim.ui.select` prompt was cancelled.