### PR TITLE
feat: configurable auto attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ require('gitsigns').setup {
   watch_gitdir = {
     follow_files = true
   },
+  auto_attach = true,
   attach_to_untracked = true,
   current_line_blame = false, -- Toggle with `:Gitsigns toggle_current_line_blame`
   current_line_blame_opts = {

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -49,6 +49,7 @@ of the default settings:
       watch_gitdir = {
         follow_files = true
       },
+      auto_attach = true,
       attach_to_untracked = true,
       current_line_blame = false, -- Toggle with `:Gitsigns toggle_current_line_blame`
       current_line_blame_opts = {
@@ -712,6 +713,11 @@ preview_config                                *gitsigns-config-preview_config*
 <
       Option overrides for the Gitsigns preview window. Table is passed directly
       to `nvim_open_win`.
+
+auto_attach                                      *gitsigns-config-auto_attach*
+      Type: `boolean`, Default: `true`
+
+      Automatically attach to files.
 
 attach_to_untracked                      *gitsigns-config-attach_to_untracked*
       Type: `boolean`, Default: `true`

--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -183,7 +183,10 @@ M.setup = async.void(function(cfg)
     require('gitsigns.git')._set_version(config._git_version)
   end
 
-  setup_attach()
+
+  if config.auto_attach then
+    setup_attach()
+  end
   setup_cwd_head()
 
   M._setup_done = true

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -70,6 +70,7 @@
 --- @field current_line_blame_formatter_nc string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_opts Gitsigns.CurrentLineBlameOpts
 --- @field preview_config table<string,any>
+--- @field auto_attach boolean
 --- @field attach_to_untracked boolean
 --- @field yadm { enable: boolean }
 --- @field worktrees {toplevel: string, gitdir: string}[]
@@ -561,6 +562,15 @@ M.schema = {
       to `nvim_open_win`.
     ]],
   },
+
+  auto_attach = {
+    type = 'boolean',
+    default = true,
+    description = [[
+      Automatically attach to files.
+    ]],
+  },
+
 
   attach_to_untracked = {
     type = 'boolean',

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -571,7 +571,6 @@ M.schema = {
     ]],
   },
 
-
   attach_to_untracked = {
     type = 'boolean',
     default = true,


### PR DESCRIPTION
In my own workflow I prefer to attach gitsigns manually whenever I need it. This adds a configuration flag to accommodate this.