### PR TITLE
fix: prevent gitsigns from calling diffthis on fugitive status window

### DIFF
--- a/lua/gitsigns/diffthis.lua
+++ b/lua/gitsigns/diffthis.lua
@@ -203,7 +203,10 @@ M.update = throttle_by_id(async.void(function(bufnr)
     if api.nvim_win_is_valid(w) then
       local b = api.nvim_win_get_buf(w)
       local bname = api.nvim_buf_get_name(b)
-      if bname == bufname or vim.startswith(bname, 'fugitive://') then
+      local is_fugitive_diff_window = vim.startswith(bname, 'fugitive://')
+        and vim.fn.exists('*FugitiveParse')
+        and vim.fn.FugitiveParse(bname)[1] ~= ':'
+      if bname == bufname or is_fugitive_diff_window then
         if should_reload(b) then
           api.nvim_buf_call(b, function()
             vim.cmd.doautocmd('BufReadCmd')


### PR DESCRIPTION
Fixes: #916

`vim.cmd.diffthis()` was being called on fugitive's status window, so all 3 windows got diffed

tpope's explanation: https://github.com/tpope/vim-fugitive/issues/2238#issuecomment-1824709495