### PR TITLE
fix(dos): correct check for dos files

### DIFF
--- a/lua/gitsigns/diffthis.lua
+++ b/lua/gitsigns/diffthis.lua
@@ -31,14 +31,17 @@ local bufread = async.void(function(bufnr, dbufnr, base)
     async.scheduler_if_buf_valid(bufnr)
   end
 
+  vim.bo[dbufnr].fileformat = vim.bo[bufnr].fileformat
+  vim.bo[dbufnr].filetype = vim.bo[bufnr].filetype
+  vim.bo[dbufnr].bufhidden = 'wipe'
+
   local modifiable = vim.bo[dbufnr].modifiable
   vim.bo[dbufnr].modifiable = true
+
   util.set_lines(dbufnr, 0, -1, text)
 
   vim.bo[dbufnr].modifiable = modifiable
   vim.bo[dbufnr].modified = false
-  vim.bo[dbufnr].filetype = vim.bo[bufnr].filetype
-  vim.bo[dbufnr].bufhidden = 'wipe'
 end)
 
 --- @param bufnr integer

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -191,16 +191,27 @@ function M.get_relative_time(timestamp)
   end
 end
 
+--- @param xs string[]
+--- @return boolean
+local function is_dos(xs)
+  -- Do not check CR at EOF
+  for i = 1, #xs - 1 do
+    if xs[i]:sub(-1) ~= '\r' then
+      return false
+    end
+  end
+  return true
+end
+
 --- Strip '\r' from the EOL of each line only if all lines end with '\r'
 --- @param xs0 string[]
 --- @return string[]
 function M.strip_cr(xs0)
-  for i = 1, #xs0 do
-    if xs0[i]:sub(-1) ~= '\r' then
-      -- don't strip, return early
-      return xs0
-    end
+  if not is_dos(xs0) then
+    -- don't strip, return early
+    return xs0
   end
+
   -- all lines end with '\r', need to strip
   local xs = vim.deepcopy(xs0)
   for i = 1, #xs do


### PR DESCRIPTION
When scanning for CRLF do not check EOF.

Fixes #927
