### PR TITLE
fix: update lua-guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ If you are using lspsaga.nvim you can config `code_action.extend_gitsigns` (defa
 [coc-git]: https://github.com/neoclide/coc-git
 [diff-linematch]: https://github.com/neovim/neovim/pull/14537
 [luv]: https://github.com/luvit/luv/blob/master/docs.md
-[nvim-lua-guide]: https://github.com/nanotee/nvim-lua-guide
+[nvim-lua-guide]: https://neovim.io/doc/user/lua-guide.html
 [release]: https://github.com/lewis6991/gitsigns.nvim/releases
 [trouble.nvim]: https://github.com/folke/trouble.nvim
 [vim-fugitive]: https://github.com/tpope/vim-fugitive


### PR DESCRIPTION
The previous link was pointing to the nvim-lua-guide project that has been archived in December 2022.