### PR TITLE
Change README.md configuration signs to match actual defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ the default settings:
 ```lua
 require('gitsigns').setup {
   signs = {
-    add          = { text = '│' },
-    change       = { text = '│' },
+    add          = { text = '┃' },
+    change       = { text = '┃' },
     delete       = { text = '_' },
     topdelete    = { text = '‾' },
     changedelete = { text = '~' },

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -35,8 +35,8 @@ of the default settings:
 >lua
     require('gitsigns').setup {
       signs = {
-        add          = { text = '│' },
-        change       = { text = '│' },
+        add          = { text = '┃' },
+        change       = { text = '┃' },
         delete       = { text = '_' },
         topdelete    = { text = '‾' },
         changedelete = { text = '~' },


### PR DESCRIPTION
The default text sign for add and change is a "Box Drawings Heavy Vertical" (U+2503). However, README.md uses "Box Drawings Light Vertical" (U+2502) in its configuration for these signs. This commit changes the sample configuration to match the actual defaults used in the code, which then gets propagated to gitsigns.txt when running gen_help.lua.

This way someone who wants to use the same symbol for untracked as add and change, as I did, gets the same character when they copy and paste from the documentation into their config.