### PR TITLE
feat: support `git blame -C` option

### DIFF
--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -99,7 +99,8 @@ function CacheEntry:run_blame(lnum, opts)
     local tick = vim.b[self.bufnr].changedtick
     local lnum0 = #buftext > BLAME_THRESHOLD_LEN and lnum or nil
     -- TODO(lewis6991): Cancel blame on changedtick
-    blame_cache = self.git_obj:run_blame(buftext, lnum0, opts.ignore_whitespace)
+    blame_cache =
+      self.git_obj:run_blame(buftext, lnum0, opts.ignore_whitespace, opts.detect_move_or_copy)
     async.scheduler_if_buf_valid(self.bufnr)
   until vim.b[self.bufnr].changedtick == tick
   return blame_cache

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -43,6 +43,7 @@
 --- @field virt_text_pos 'eol'|'overlay'|'right_align'
 --- @field delay integer
 --- @field ignore_whitespace boolean
+--- @field detect_move_or_copy 'C'|'CC'|'CCC'
 --- @field virt_text_priority integer
 
 --- @class (exact) Gitsigns.Config

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -604,8 +604,9 @@ end
 --- @param lines string[]
 --- @param lnum? integer
 --- @param ignore_whitespace? boolean
+--- @param detect_move_or_copy? string
 --- @return table<integer,Gitsigns.BlameInfo?>?
-function Obj:run_blame(lines, lnum, ignore_whitespace)
+function Obj:run_blame(lines, lnum, ignore_whitespace, detect_move_or_copy)
   local ret = {} --- @type table<integer,Gitsigns.BlameInfo>
 
   if not self.object_name or self.repo.abbrev_head == '' then
@@ -634,6 +635,10 @@ function Obj:run_blame(lines, lnum, ignore_whitespace)
 
   if ignore_whitespace then
     args[#args + 1] = '-w'
+  end
+
+  if detect_move_or_copy ~= nil and detect_move_or_copy ~= '' then
+    args[#args + 1] = '-' .. detect_move_or_copy
   end
 
   local ignore_file = self.repo.toplevel .. '/.git-blame-ignore-revs'


### PR DESCRIPTION
Adds support for `-C`/`-CC`/`-CCC` option for current line blame
```
-C[<num>]
           In addition to -M, detect lines moved or copied from other files that were modified in the same commit. This is useful
           when you reorganize your program and move code around across files. When this option is given twice, the command
           additionally looks for copies from other files in the commit that creates the file. When this option is given three times,
           the command additionally looks for copies from other files in any commit.

           <num> is optional but it is the lower bound on the number of alphanumeric characters that Git must detect as
           moving/copying between files for it to associate those lines with the parent commit. And the default value is 40. If there
           are more than one -C options given, the <num> argument of the last -C will take effect.
```
Code doesn't check for `-CCCC`, but since `git blame` itself accepts such option, I think it's better to keep gitsigns code simpler. 