### PR TITLE
bug fix: assert because M.version is nil

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -88,7 +88,8 @@ end
 --- @return boolean
 local function check_version(version)
   if not M.version then
-    return false
+    M._set_version(config._git_version)
+    return check_version(version)
   end
   if M.version.major < version[1] then
     return false


### PR DESCRIPTION
Fixed a bug related to version checking before the version was established. 

This issue likely arose due to the asynchronous nature of gitsigns operations. By adding logging for the check_version and _set_version functions, I observed the following behavior:

* Initial version check (2.13) was against nil;  no version being set and returning false.
* Subsequently, the version was correctly set, showing values for major, minor, and patch levels.
However, an error occurred when checking the version again due to an attempt to access a non-existent .git directory, causing a failure in the coroutine.

Bellow is the logs I capture

```
check version { 2, 13 } against nil  <- inside check_version() git.lua:90
no version nil return false               <- after   if not M.version then in     check_version()                                                                                                                                                                                                                              
version set:  {                                   <- version is set                                                                                                                                                                                                              
  major = 2,                                                                                                                                                                                                                                                    
  minor = 39,                                                                                                                                                                                                                                                   
  patch = 3                                                                                                                                                                                                                                                     
}                                                                                                                                                                                                                                                               
check version { 2, 13 } against {    <- following calls are OK                                                                                                                                                                                                                           
  major = 2,                                                                                                                                                                                                                                                    
  minor = 39,                                                                                                                                                                                                                                                   
  patch = 3                                                                                                                                                                                                                                                     
}                                                                                                                                                                                                                                                               
Error executing luv callback:                                                                                                                                                                                                                                   
...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:85: The coroutine failed with this message: ...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:316: ENOENT: no such file or directory: .git                                                
stack traceback:                                                                                                                                                                                                                                                
        [C]: in function 'assert'                                                                                                                                                                                                                               
        ...local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/git.lua:316: in function 'get_repo_info'                                                                                                                                                            
        ...xu/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:53: in function 'update_cwd_head'                                                                                                                                                           
        ...xu/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:143: in function 'setup_cwd_head'                                                                                                                                                           
        ...xu/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:189: in function <...xu/.local/share/nvim/lazy/gitsigns.nvim/lua/gitsigns.lua:162>          
```

This issue appears to be sporadic and not consistently reproducible for a couple of reasons:

1. The version eventually gets correctly set, depending on the timing and manner of the Git command execution.
2. My setup involves a mini session manager, where the root folder contains a .git folder, but the working folder does not. For example, my root folder might be `nvim`, but my working directory is `nvim/lua/plugin`. If the version has not yet been set, Lua asserts an error due to the absence of the `.git` directory in the working folder.