### PR TITLE
feat(nav): add nav_hunk()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here is a suggested example:
 require('gitsigns').setup{
   ...
   on_attach = function(bufnr)
-    local gs = package.loaded.gitsigns
+    local gitsigns = require('gitsigns')
 
     local function map(mode, l, r, opts)
       opts = opts or {}
@@ -123,31 +123,35 @@ require('gitsigns').setup{
 
     -- Navigation
     map('n', ']c', function()
-      if vim.wo.diff then return ']c' end
-      vim.schedule(function() gs.next_hunk() end)
-      return '<Ignore>'
-    end, {expr=true})
+      if vim.wo.diff then
+        vim.cmd.normal({']c', bang = true})
+      else
+        gitsigns.nav_hunk('next')
+      end
+    end)
 
     map('n', '[c', function()
-      if vim.wo.diff then return '[c' end
-      vim.schedule(function() gs.prev_hunk() end)
-      return '<Ignore>'
-    end, {expr=true})
+      if vim.wo.diff then
+        vim.cmd.normal({'[c', bang = true})
+      else
+        gitsigns.nav_hunk('prev')
+      end
+    end)
 
     -- Actions
-    map('n', '<leader>hs', gs.stage_hunk)
-    map('n', '<leader>hr', gs.reset_hunk)
-    map('v', '<leader>hs', function() gs.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
-    map('v', '<leader>hr', function() gs.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
-    map('n', '<leader>hS', gs.stage_buffer)
-    map('n', '<leader>hu', gs.undo_stage_hunk)
-    map('n', '<leader>hR', gs.reset_buffer)
-    map('n', '<leader>hp', gs.preview_hunk)
-    map('n', '<leader>hb', function() gs.blame_line{full=true} end)
-    map('n', '<leader>tb', gs.toggle_current_line_blame)
-    map('n', '<leader>hd', gs.diffthis)
-    map('n', '<leader>hD', function() gs.diffthis('~') end)
-    map('n', '<leader>td', gs.toggle_deleted)
+    map('n', '<leader>hs', gitsigns.stage_hunk)
+    map('n', '<leader>hr', gitsigns.reset_hunk)
+    map('v', '<leader>hs', function() gitsigns.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
+    map('v', '<leader>hr', function() gitsigns.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
+    map('n', '<leader>hS', gitsigns.stage_buffer)
+    map('n', '<leader>hu', gitsigns.undo_stage_hunk)
+    map('n', '<leader>hR', gitsigns.reset_buffer)
+    map('n', '<leader>hp', gitsigns.preview_hunk)
+    map('n', '<leader>hb', function() gitsigns.blame_line{full=true} end)
+    map('n', '<leader>tb', gitsigns.toggle_current_line_blame)
+    map('n', '<leader>hd', gitsigns.diffthis)
+    map('n', '<leader>hD', function() gitsigns.diffthis('~') end)
+    map('n', '<leader>td', gitsigns.toggle_deleted)
 
     -- Text object
     map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -343,6 +343,8 @@ preview_hunk()                                       *gitsigns.preview_hunk()*
                 will cause the window to get focus.
 
 prev_hunk({opts}, {callback?})                          *gitsigns.prev_hunk()*
+                DEPRECATED: use |gitsigns.nav_hunk()|
+
                 Jump to the previous hunk in the current buffer. If a hunk preview
                 (popup or inline) was previously opened, it will be re-opened
                 at the previous hunk.
@@ -351,9 +353,11 @@ prev_hunk({opts}, {callback?})                          *gitsigns.prev_hunk()*
                     {async}
 
                 Parameters: ~
-                    See |gitsigns.next_hunk()|.
+                    See |gitsigns.nav_hunk()|.
 
 next_hunk({opts}, {callback?})                          *gitsigns.next_hunk()*
+                DEPRECATED: use |gitsigns.nav_hunk()|
+
                 Jump to the next hunk in the current buffer. If a hunk preview
                 (popup or inline) was previously opened, it will be re-opened
                 at the next hunk.
@@ -362,23 +366,37 @@ next_hunk({opts}, {callback?})                          *gitsigns.next_hunk()*
                     {async}
 
                 Parameters: ~
-                    {opts} (table|nil): Configuration table. Keys:
-                           • {wrap}: (boolean)
-                             Whether to loop around file or not. Defaults
-                             to the value 'wrapscan'
-                           • {navigation_message}: (boolean)
-                             Whether to show navigation messages or not.
-                             Looks at 'shortmess' for default behaviour.
-                           • {foldopen}: (boolean)
-                             Expand folds when navigating to a hunk which is
-                             inside a fold. Defaults to `true` if 'foldopen'
-                             contains `search`.
-                           • {preview}: (boolean)
-                             Automatically open preview_hunk() upon navigating
-                             to a hunk.
-                           • {greedy}: (boolean)
-                             Only navigate between non-contiguous hunks. Only useful if
-                             'diff_opts' contains `linematch`. Defaults to `true`.
+                    See |gitsigns.nav_hunk()|.
+
+nav_hunk({direction}, {opts}, {callback?})                 *gitsigns.nav_hunk()*
+                Jump to hunk in the current buffer. If a hunk preview
+                (popup or inline) was previously opened, it will be re-opened
+                at the next hunk.
+
+                Attributes: ~
+                    {async}
+
+                Parameters: ~
+                    {direction} ('first'|'last'|'next'|'prev'):
+                    {opts}      (table|nil): Configuration table. Keys:
+                                • {wrap}: (boolean)
+                                  Whether to loop around file or not. Defaults
+                                  to the value 'wrapscan'
+                                • {navigation_message}: (boolean)
+                                  Whether to show navigation messages or not.
+                                  Looks at 'shortmess' for default behaviour.
+                                • {foldopen}: (boolean)
+                                  Expand folds when navigating to a hunk which is
+                                  inside a fold. Defaults to `true` if 'foldopen'
+                                  contains `search`.
+                                • {preview}: (boolean)
+                                  Automatically open preview_hunk() upon navigating
+                                  to a hunk.
+                                • {greedy}: (boolean)
+                                  Only navigate between non-contiguous hunks. Only useful if
+                                  'diff_opts' contains `linematch`. Defaults to `true`.
+                                • {count}: (integer)
+                                  Number of times to advance. Defaults to |v:count1|.
 
 reset_buffer_index()                           *gitsigns.reset_buffer_index()*
                 Unstage all hunks for current buffer in the index. Note:

--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -316,39 +316,35 @@ end
 
 --- @param lnum integer
 --- @param hunks Gitsigns.Hunk.Hunk[]
---- @param forwards boolean
+--- @param direction 'first'|'last'|'next'|'prev'
 --- @param wrap boolean
---- @return Gitsigns.Hunk.Hunk, integer
-function M.find_nearest_hunk(lnum, hunks, forwards, wrap)
-  local ret --- @type Gitsigns.Hunk.Hunk
-  local index --- @type integer
-  local distance = math.huge
-  if forwards then
-    for i = 1, #hunks do
-      local hunk = hunks[i]
-      local dist = hunk.added.start - lnum
-      if dist > 0 and dist < distance then
-        distance = dist
-        ret = hunk
-        index = i
-      end
-    end
-  else
+--- @return integer?
+function M.find_nearest_hunk(lnum, hunks, direction, wrap)
+  if direction == 'first' then
+    return 1
+  elseif direction == 'last' then
+    return #hunks
+  elseif direction == 'next' then
     for i = #hunks, 1, -1 do
-      local hunk = hunks[i]
-      local dist = lnum - math.max(hunk.vend, 1)
-      if dist > 0 and dist < distance then
-        distance = dist
-        ret = hunk
-        index = i
+      if hunks[i].added.start <= lnum then
+        if i + 1 <= #hunks and hunks[i + 1].added.start > lnum then
+          return i + 1
+        elseif wrap then
+          return 1
+        end
+      end
+    end
+  elseif direction == 'prev' then
+    for i = 1, #hunks do
+      if lnum <= math.max(hunks[i].vend, 1) then
+        if i > 1 and math.max(hunks[i - 1].vend, 1) < lnum then
+          return i - 1
+        elseif wrap then
+          return #hunks
+        end
       end
     end
   end
-  if not ret and wrap then
-    index = forwards and 1 or #hunks
-    ret = hunks[index]
-  end
-  return ret, index
 end
 
 --- @param a Gitsigns.Hunk.Hunk[]?


### PR DESCRIPTION
- Deprecated `next_hunk()` and `prev_hunk()`.
- Can now navigate to the first/last hunk using `nav_hunk('first'|'last')`.
- Added `count` to navigation options. Defaults to `v:count1`.
- Updated recommended keymaps for navigation.
- Navigation actions now navigate to the first non-blank column.
