### PR TITLE
feat(attach): Allow attaching to files out of repo

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -752,6 +752,11 @@ attach_to_untracked                      *gitsigns-config-attach_to_untracked*
 
       Attach to untracked files.
 
+attach_to_out_of_repo                  *gitsigns-config-attach_to_out_of_repo*
+      Type: `boolean`, Default: `false`
+
+      Attach to files out of git repository to highlight unsaved changes.
+
 update_debounce                              *gitsigns-config-update_debounce*
       Type: `number`, Default: `100`
 

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -91,6 +91,7 @@
 --- @field preview_config table<string,any>
 --- @field auto_attach boolean
 --- @field attach_to_untracked boolean
+--- @field attach_to_out_of_repo boolean
 --- @field yadm { enable: boolean }
 --- @field worktrees {toplevel: string, gitdir: string}[]
 --- @field word_diff boolean
@@ -595,6 +596,14 @@ M.schema = {
     default = false,
     description = [[
       Attach to untracked files.
+    ]],
+  },
+
+  attach_to_out_of_repo = {
+    type = 'boolean',
+    default = false,
+    description = [[
+      Attach to files out of git repository to highlight unsaved changes.
     ]],
   },
 

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -23,7 +23,7 @@ local asystem = async.wrap(3, system)
 
 --- @param file string
 --- @return boolean
-local function in_git_dir(file)
+function M.in_git_dir(file)
   for _, p in ipairs(vim.split(file, util.path_sep)) do
     if p == '.git' then
       return true
@@ -800,12 +800,8 @@ end
 --- @param encoding string
 --- @param gitdir string?
 --- @param toplevel string?
---- @return Gitsigns.GitObj?
+--- @return Gitsigns.GitObj
 function Obj.new(file, encoding, gitdir, toplevel)
-  if in_git_dir(file) then
-    dprint('In git dir')
-    return nil
-  end
   local self = setmetatable({}, { __index = Obj })
 
   self.file = file
@@ -813,8 +809,7 @@ function Obj.new(file, encoding, gitdir, toplevel)
   self.repo = Repo.new(util.dirname(file), gitdir, toplevel)
 
   if not self.repo.gitdir then
-    dprint('Not in git repo')
-    return nil
+    return self
   end
 
   -- When passing gitdir and toplevel, suppress stderr when resolving the file

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -134,8 +134,7 @@ describe('gitsigns (with screen)', function()
       np(
         'run_job: git .* rev%-parse %-%-show%-toplevel %-%-absolute%-git%-dir %-%-abbrev%-ref HEAD'
       ),
-      n('new: Not in git repo'),
-      n('attach(1): Empty git obj'),
+      n('attach(1): Not in git repo'),
     })
     command('Gitsigns clear_debug')
 
@@ -148,8 +147,7 @@ describe('gitsigns (with screen)', function()
       np(
         'run_job: git .* rev%-parse %-%-show%-toplevel %-%-absolute%-git%-dir %-%-abbrev%-ref HEAD'
       ),
-      n('new: Not in git repo'),
-      n('attach(1): Empty git obj'),
+      n('attach(1): Not in git repo'),
     })
   end)
 
@@ -182,8 +180,7 @@ describe('gitsigns (with screen)', function()
 
       match_debug_messages({
         'attach(1): Attaching (trigger=BufReadPost)',
-        n('new: In git dir'),
-        n('attach(1): Empty git obj'),
+        n('attach(1): In git dir'),
       })
     end)
 


### PR DESCRIPTION
This will allow to highlight usaved changes in buffer, even if file is not in the git repo. This behaviour needs to be enabled by `attach_to_out_of_repo` config option (false by default).

Resolves #164

I feel like this may be a little out of scope of this project. But I wanted it myself, and saw other people want it, so I decided to share. I also think this is a small change and should not make any difference by default (needs to be explicitly enabled in user config). 
It is of course for the maintainer to decide, and I will understand if PR gets rejected. If you know a better way to do this, I would like to know and help implement it. 
Anyway, it is a pleasure to use this plugin, keep up the great work!