### PR TITLE
fix: preview inline error in non-buffer windows

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -195,6 +195,9 @@ end
 --- @param staged? boolean
 --- @return Gitsigns.Hunk.Hunk[]? hunks
 local function get_hunks(bufnr, bcache, greedy, staged)
+  if not bcache then
+    return nil
+  end
   if greedy and config.diff_opts.linematch then
     -- Re-run the diff without linematch
     local buftext = util.buf_lines(bufnr)


### PR DESCRIPTION
Added a condition to check whether the `bcache` is nil or not in `get_hunks` of `lua/gitsigns/actions.lua`.
Fix #979 