### PR TITLE
Fix for windows

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -334,8 +334,14 @@ function Repo:try_yadm(dir, gitdir, toplevel)
     return
   end
 
-  if not vim.startswith(dir, assert(os.getenv('HOME'))) then
-    return
+  if vim.loop.os_uname().sysname == 'Windows_NT' then
+    if not vim.startswith(dir, assert(os.getenv('USERPROFILE'))) then
+      return
+    end
+  else
+    if not vim.startswith(dir, os.getenv('HOME')) then
+      return
+    end
   end
 
   if not #git_command({ 'ls-files', dir }, { command = 'yadm' }) ~= 0 then


### PR DESCRIPTION
When the program does a check for the home directory it checks the unix HOME variable only
added a check for windows and made it check the USERPROFILE variable instead of the unix one