### PR TITLE
fix(yadm): correct ls-files check

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -340,7 +340,7 @@ function Repo:try_yadm(dir, gitdir, toplevel)
     return
   end
 
-  if not #git_command({ 'ls-files', dir }, { command = 'yadm' }) ~= 0 then
+  if #git_command({ 'ls-files', dir }, { command = 'yadm' }) == 0 then
     return
   end
 


### PR DESCRIPTION
`not` has higher precedence than `~=`, so it was actually `(not #git_command(..)) ~= 0`.

To fix it, we can simplify the double negation as just a `==`.