### PR TITLE
fix: use latest api in 0.10

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -115,7 +115,7 @@ M.toggle_word_diff = function(value)
     config.word_diff = not config.word_diff
   end
   -- Don't use refresh() to avoid flicker
-  api.nvim__buf_redraw_range(0, vim.fn.line('w0') - 1, vim.fn.line('w$'))
+  util.redraw({ buf = 0, range = { vim.fn.line('w0') - 1, vim.fn.line('w$') } })
   return config.word_diff
 end
 

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -210,7 +210,7 @@ local function apply_word_diff(bufnr, row)
     end
 
     api.nvim_buf_set_extmark(bufnr, ns, row, scol, opts)
-    api.nvim__buf_redraw_range(bufnr, row, row + 1)
+    util.redraw({ buf = bufnr, range = { row, row + 1 } })
   end
 end
 

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -183,6 +183,15 @@ function M.get_relative_time(timestamp)
   end
 end
 
+--- @param opts vim.api.keyset.redraw
+function M.redraw(opts)
+  if vim.fn.has('nvim-0.10') == 1 then
+    vim.api.nvim__redraw(opts)
+  else
+    vim.api.nvim__buf_redraw(opts.buf, opts.range[1], opts.range[2])
+  end
+end
+
 --- @param xs string[]
 --- @return boolean
 local function is_dos(xs)


### PR DESCRIPTION
Seems that `nvim__buf_redraw_range` was deprecated in https://github.com/neovim/neovim/pull/28101.