### PR TITLE
fix: wrong api name in stable

### DIFF
--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -188,7 +188,7 @@ function M.redraw(opts)
   if vim.fn.has('nvim-0.10') == 1 then
     vim.api.nvim__redraw(opts)
   else
-    vim.api.nvim__buf_redraw(opts.buf, opts.range[1], opts.range[2])
+    vim.api.nvim__buf_redraw_range(opts.buf, opts.range[1], opts.range[2])
   end
 end
 


### PR DESCRIPTION
Sorry for that, I mistakenly wrote the wrong stable API name in https://github.com/lewis6991/gitsigns.nvim/pull/1012.