### PR TITLE
fix(blame): avoid right-aligned blame overlapping buftext

### DIFF
--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -43,8 +43,8 @@ end
 
 --- @param winid integer
 --- @return integer
-local function win_width(winid)
-  winid = winid or api.nvim_get_current_win()
+local function win_width()
+  local winid = api.nvim_get_current_win()
   local wininfo = vim.fn.getwininfo(winid)[1]
   local textoff = wininfo and wininfo.textoff or 0
   return api.nvim_win_get_width(winid) - textoff
@@ -54,7 +54,8 @@ end
 --- @param lnum integer
 --- @return integer
 local function line_len(bufnr, lnum)
-  return #api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, true)[1]
+  local line = api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, true)[1]
+  return api.nvim_strwidth(line)
 end
 
 --- @param fmt string
@@ -103,7 +104,7 @@ local function handle_blame_info(bufnr, lnum, blame_info, opts)
   if opts.virt_text then
     local virt_text_pos = opts.virt_text_pos
     if virt_text_pos == 'right_align' then
-      if #virt_text_str > (win_width(0) - line_len(bufnr, lnum)) then
+      if api.nvim_strwidth(virt_text_str) > (win_width() - line_len(bufnr, lnum)) then
         virt_text_pos = 'eol'
       end
     end


### PR DESCRIPTION
## Problem

When using `virt_text_pos = 'right_align'`, the placement strategy sometimes doesn't switch to `'eol'` (to avoid overlaps) until it's too late.

## Hypothesis

When the blame text's length exceeds the available space to the right of the buffer's text, the intention is to switch to the 'eol' extmark placement. However, there were a number of issues that could trip up the time at which it swtiches to 'eol':

- if the buffer line or virtual text contain multibyte characters, they weren't counted properly in terms of screen cells that they'd consume
- incorrect window identifer was passed when calculating the available space, meaning that signs/folds/numbers columns weren't properly accounted for.

## Before / After

<details>
  <summary>Before (using reproduction steps below)</summary>

https://github.com/lewis6991/gitsigns.nvim/assets/30904/631722f6-8e81-4a62-b627-ea2ab42bc9db
</details>

<details>
  <summary>After (with fix applied)</summary>

https://github.com/lewis6991/gitsigns.nvim/assets/30904/b9307503-e14b-4a9d-a862-77b76babfdff
</details>

## Reproduction steps

With the following `minimal.lua`:

```lua
for name, url in pairs{
  gitsigns = 'https://github.com/lewis6991/gitsigns.nvim',
} do
  local install_path = vim.fn.fnamemodify('gitsigns_issue/'..name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end

require('gitsigns').setup{
  debug_mode = true, -- You must add this to enable debug messages

  -- blame format includes multibyte '«' character:
  current_line_blame_formatter = ' « <committer_time:%R>: <summary> [<abbrev_sha>]',
  current_line_blame_opts = { virt_text_pos = 'right_align' },
  current_line_blame = true,
}

-- Consume some extra window width:
vim.wo.number = true
vim.wo.signcolumn = 'yes'
```

Run:

```bash
nvim --clean -u minimal.lua -- lua/gitsigns/manager.lua
```
