### PR TITLE
feat(setup)!: make setup() synchronous

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -93,11 +93,8 @@ Note functions with the {async} attribute are run asynchronously and accept
 an optional {callback} argument.
 
 
-setup({cfg}, {callback?})                                   *gitsigns.setup()*
+setup({cfg})                                                *gitsigns.setup()*
                 Setup and start Gitsigns.
-
-                Attributes: ~
-                    {async}
 
                 Parameters: ~
                     {cfg} (table|nil): Configuration for Gitsigns.

--- a/lua/gitsigns/git/version.lua
+++ b/lua/gitsigns/git/version.lua
@@ -34,6 +34,7 @@ local function parse_version(version)
   return ret
 end
 
+--- @async
 local function set_version()
   local version = gs_config.config._git_version
   if version ~= 'auto' then
@@ -70,6 +71,7 @@ local function set_version()
   M.version = parse_version(parts[3])
 end
 
+--- @async
 --- Usage: check_version{2,3}
 --- @param version {[1]: integer, [2]:integer, [3]:integer}?
 --- @return boolean

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -259,17 +259,11 @@ function M.setup_gitsigns(config, on_attach)
           return false
         end
       end
-      _SETUP_DONE = false
-      require('gitsigns').setup(config, function()
-        _SETUP_DONE = true
-      end)
+      require('gitsigns').setup(config)
     ]],
     config,
     on_attach
   )
-  M.expectf(function()
-    return exec_lua([[return _SETUP_DONE]])
-  end)
 end
 
 --- @param status table<string,string|integer>


### PR DESCRIPTION
Previously `setup()` was asynchronous in order to run a system command
to check the git version.

As support for v0.8 is dropped, this is no longer required.
