### PR TITLE
fix(watcher): throttle watcher handler

### DIFF
--- a/lua/gitsigns/watcher.lua
+++ b/lua/gitsigns/watcher.lua
@@ -8,6 +8,7 @@ local util = require('gitsigns.util')
 
 local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
+local throttle_by_id = require('gitsigns.debounce').throttle_by_id
 local debounce_trailing = require('gitsigns.debounce').debounce_trailing
 local manager = require('gitsigns.manager')
 
@@ -64,8 +65,9 @@ local function handle_moved(bufnr, old_relpath)
   dprintf('%s buffer %d from %s to %s', msg, bufnr, old_name, bcache.file)
 end
 
+--- @async
 --- @param bufnr integer
-local watcher_handler = async.create(1, function(bufnr)
+local function watcher_handler0(bufnr)
   local __FUNC__ = 'watcher_handler'
 
   -- Avoid cache hit for detached buffer
@@ -104,9 +106,13 @@ local watcher_handler = async.create(1, function(bufnr)
   cache[bufnr]:invalidate(true)
 
   require('gitsigns.manager').update(bufnr)
-end)
+end
 
-local watcher_handler_debounced = debounce_trailing(200, watcher_handler, 1)
+--- Debounce and throttle the handler.
+--- We also throttle in case the debounce delay is not enough and to prevent
+--- too many handlers from being launched (and interleaved).
+local watcher_handler =
+  debounce_trailing(200, async.create(1, throttle_by_id(watcher_handler0, true)))
 
 --- vim.inspect but on one line
 --- @param x any
@@ -147,7 +153,7 @@ function M.watch_gitdir(bufnr, gitdir)
 
     dprint(info)
 
-    watcher_handler_debounced(bufnr)
+    watcher_handler(bufnr)
   end)
   return w
 end


### PR DESCRIPTION
Throttle (in addition to debounce) in case the debounce delay is not
enough and to prevent too many handlers from being launched (and
interleaved).
