### PR TITLE
feat: tweak how commit buffers are processed

### DIFF
--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -212,13 +212,12 @@ local function get_buf_context(bufnr)
     file = file,
     gitdir = gitdir,
     toplevel = toplevel,
-    -- Commit buffers have there base set back one revision with '^'
     -- Stage buffers always compare against the common ancestor (':1')
     -- :0: index
     -- :1: common ancestor
     -- :2: target commit (HEAD)
     -- :3: commit which is being merged
-    base = commit and (commit:match('^:[1-3]') and ':1' or commit .. '^') or nil,
+    base = commit and (commit:match('^:[1-3]') and ':1' or commit) or nil,
   }
 end
 

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -424,11 +424,15 @@ end
 --- @field object_name? string
 --- @field has_conflicts? true
 
+function Obj:from_tree()
+  return self.revision and not vim.startswith(self.revision, ':')
+end
+
 --- @param file? string
 --- @param silent? boolean
 --- @return Gitsigns.FileInfo
 function Obj:file_info(file, silent)
-  if self.revision and not vim.startswith(self.revision, ':') then
+  if self:from_tree() then
     return self:file_info_tree(file, silent)
   else
     return self:file_info_index(file, silent)
@@ -436,12 +440,16 @@ function Obj:file_info(file, silent)
 end
 
 --- @private
+--- Get information about files in the index and the working tree
 --- @param file? string
 --- @param silent? boolean
 --- @return Gitsigns.FileInfo
 function Obj:file_info_index(file, silent)
   local has_eol = check_version({ 2, 9 })
 
+  -- --others + --exclude-standard means ignored files won't return info, but
+  -- untracked files will. Unlike file_info_tree which won't return untracked
+  -- files.
   local cmd = {
     '-c',
     'core.quotepath=off',
@@ -499,6 +507,7 @@ function Obj:file_info_index(file, silent)
 end
 
 --- @private
+--- Get information about files in a certain revision
 --- @param file? string
 --- @param silent? boolean
 --- @return Gitsigns.FileInfo

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -488,9 +488,10 @@ M.update = throttle_by_id(function(bufnr)
     return
   end
 
-  if config.signs_staged_enable and not file_mode and not git_obj.revision then
+  if config.signs_staged_enable and not file_mode then
     if not bcache.compare_text_head or config._refresh_staged_on_update then
-      bcache.compare_text_head = git_obj:get_show_text('HEAD')
+      local staged_rev = git_obj:from_tree() and git_obj.revision .. '^' or 'HEAD'
+      bcache.compare_text_head = git_obj:get_show_text(staged_rev)
       if not M.schedule(bufnr, true) then
         return
       end


### PR DESCRIPTION
Previously when attaching to a commit buffer (via gitsigns or fugitive),
gitsigns would set the revision to diff against to the parent so the
signs of that commit would be displayed.

Now that we have staged signs, they are now used for that purpose, and
so the base is no longer set to the parent.
