### PR TITLE
feat!: remove current_line_blame_formatter_opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,7 @@ require('gitsigns').setup {
     ignore_whitespace = false,
     virt_text_priority = 100,
   },
-  current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
-  current_line_blame_formatter_opts = {
-    relative_time = false,
-  },
+  current_line_blame_formatter = '<author>, <author_time:%R> - <summary>',
   sign_priority = 6,
   update_debounce = 100,
   status_formatter = nil, -- Use default

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -59,10 +59,7 @@ of the default settings:
         ignore_whitespace = false,
         virt_text_priority = 100,
       },
-      current_line_blame_formatter = '<author>, <author_time:%Y-%m-%d> - <summary>',
-      current_line_blame_formatter_opts = {
-        relative_time = false,
-      },
+      current_line_blame_formatter = '<author>, <author_time:%R> - <summary>',
       sign_priority = 6,
       update_debounce = 100,
       status_formatter = nil, -- Use default
@@ -828,23 +825,8 @@ current_line_blame_opts              *gitsigns-config-current_line_blame_opts*
         • extra_opts: string[]
           Extra options passed to `git-blame`.
 
-current_line_blame_formatter_opts
-                           *gitsigns-config-current_line_blame_formatter_opts*
-   DEPRECATED
-
-      Type: `table[extended]`
-      Default: >
-        `{
-          relative_time = false
-        }`
-<
-      Options for the current line blame annotation formatter.
-
-      Fields: ~
-        • relative_time: boolean
-
 current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
-      Type: `string|function`, Default: `" <author>, <author_time> - <summary> "`
+      Type: `string|function`, Default: `" <author>, <author_time:%R> - <summary> "`
 
       String or function used to format the virtual text of
       |gitsigns-config-current_line_blame|.
@@ -912,9 +894,6 @@ current_line_blame_formatter    *gitsigns-config-current_line_blame_formatter*
 
                        Note that the keys map onto the output of:
                          `git blame --line-porcelain`
-
-          {opts}       Passed directly from
-                       |gitsigns-config-current_line_blame_formatter_opts|.
 
         Return: ~
           The result of this function is passed directly to the `opts.virt_text`

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -46,10 +46,7 @@
 --- | 'changedelete'
 --- | 'untracked'
 
---- @class (exact) Gitsigns.CurrentLineBlameFmtOpts
---- @field relative_time boolean
-
---- @alias Gitsigns.CurrentLineBlameFmtFun fun(user: string, info: table<string,any>, opts: Gitsigns.CurrentLineBlameFmtOpts): {[1]:string,[2]:string}[]
+--- @alias Gitsigns.CurrentLineBlameFmtFun fun(user: string, info: table<string,any>): {[1]:string,[2]:string}[]
 
 --- @class (exact) Gitsigns.CurrentLineBlameOpts : Gitsigns.BlameOpts
 --- @field virt_text? boolean
@@ -85,7 +82,6 @@
 --- @field update_debounce integer
 --- @field status_formatter fun(_: table<string,any>): string
 --- @field current_line_blame boolean
---- @field current_line_blame_formatter_opts { relative_time: boolean }
 --- @field current_line_blame_formatter string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_formatter_nc string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_opts Gitsigns.CurrentLineBlameOpts
@@ -108,7 +104,6 @@ local M = {
     DiffOpts = {},
     SignConfig = {},
     watch_gitdir = {},
-    current_line_blame_formatter_opts = {},
     current_line_blame_opts = {},
     Worktree = {},
   },
@@ -688,24 +683,9 @@ M.schema = {
     ]],
   },
 
-  current_line_blame_formatter_opts = {
-    type = 'table',
-    deep_extend = true,
-    deprecated = true,
-    default = {
-      relative_time = false,
-    },
-    description = [[
-      Options for the current line blame annotation formatter.
-
-      Fields: ~
-        • relative_time: boolean
-    ]],
-  },
-
   current_line_blame_formatter = {
     type = { 'string', 'function' },
-    default = ' <author>, <author_time> - <summary> ',
+    default = ' <author>, <author_time:%R> - <summary> ',
     description = [[
       String or function used to format the virtual text of
       |gitsigns-config-current_line_blame|.
@@ -773,9 +753,6 @@ M.schema = {
 
                        Note that the keys map onto the output of:
                          `git blame --line-porcelain`
-
-          {opts}       Passed directly from
-                       |gitsigns-config-current_line_blame_formatter_opts|.
 
         Return: ~
           The result of this function is passed directly to the `opts.virt_text`

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -28,7 +28,7 @@ local function expand_blame_format(fmt, name, info)
   if info.author == name then
     info.author = 'You'
   end
-  return util.expand_format(fmt, info, config.current_line_blame_formatter_opts.relative_time)
+  return util.expand_format(fmt, info)
 end
 
 --- @param virt_text {[1]: string, [2]: string}[]
@@ -41,7 +41,6 @@ local function flatten_virt_text(virt_text)
   return table.concat(res)
 end
 
---- @param winid integer
 --- @return integer
 local function win_width()
   local winid = api.nvim_get_current_win()
@@ -61,7 +60,7 @@ end
 --- @param fmt string
 --- @return Gitsigns.CurrentLineBlameFmtFun
 local function default_formatter(fmt)
-  return function(username, blame_info, _opts)
+  return function(username, blame_info)
     return {
       {
         expand_blame_format(fmt, username, blame_info),
@@ -85,7 +84,7 @@ local function get_blame_virt_text(bufnr, blame_info)
     clb_formatter = default_formatter(clb_formatter)
   end
 
-  return clb_formatter(git_obj.repo.username, blame_info, config.current_line_blame_formatter_opts)
+  return clb_formatter(git_obj.repo.username, blame_info)
 end
 
 --- @param bufnr integer

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -264,9 +264,8 @@ end
 
 ---@param fmt string
 ---@param info table<string,any>
----@param reltime? boolean Use relative time as the default date format
 ---@return string
-function M.expand_format(fmt, info, reltime)
+function M.expand_format(fmt, info)
   local ret = {} --- @type string[]
 
   for _ = 1, 20 do -- loop protection
@@ -287,7 +286,7 @@ function M.expand_format(fmt, info, reltime)
       end
       if vim.endswith(key, '_time') then
         if time_fmt == '' then
-          time_fmt = reltime and '%R' or '%Y-%m-%d'
+          time_fmt = '%Y-%m-%d'
         end
         v = expand_date(time_fmt, v)
       end


### PR DESCRIPTION
- Also make relative time the default time format for current_line_blame_formatter
- When `current_line_blame_formatter` is passed as a function it is no longer passed an opts argument.

