### PR TITLE
fix(attach): resolve error viewing fugitive trees

### DIFF
--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -71,7 +71,7 @@ local function get_buf_path(bufnr)
     dprintf("Fugitive buffer for file '%s' from path '%s'", path, file)
     if path then
       local realpath = uv.fs_realpath(path)
-      if realpath then
+      if realpath and vim.fn.isdirectory(path) == 0 then
         return realpath, commit, true
       end
     end

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -71,7 +71,7 @@ local function get_buf_path(bufnr)
     dprintf("Fugitive buffer for file '%s' from path '%s'", path, file)
     if path then
       local realpath = uv.fs_realpath(path)
-      if realpath and vim.fn.isdirectory(path) == 0 then
+      if realpath and vim.fn.isdirectory(realpath) == 0 then
         return realpath, commit, true
       end
     end


### PR DESCRIPTION
Only attach to fugitive buffers for files, not directories.

Resolves #1057
