### PR TITLE
fix(blame): show the winbar if the main window has it enabled

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -289,6 +289,11 @@ M.blame = function()
   blm_wlo.winfixwidth = true
   blm_wlo.wrap = false
 
+  if vim.wo[win].winbar ~= '' then
+    local name = api.nvim_buf_get_name(bufnr)
+    blm_wlo.winbar = vim.fn.fnamemodify(name, ':.')
+  end
+
   if vim.fn.exists('&winfixbuf') then
     blm_wlo.winfixbuf = true
   end


### PR DESCRIPTION
It causes the two-window not to align correctly if the main window has a `'winbar'`.