### PR TITLE
fix(blame)!: replace dot with dash in blame file type name

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -276,7 +276,7 @@ M.blame = function()
   blm_bo.buftype = 'nofile'
   blm_bo.bufhidden = 'wipe'
   blm_bo.modifiable = false
-  blm_bo.filetype = 'gitsigns.blame'
+  blm_bo.filetype = 'gitsigns-blame'
 
   local blm_wlo = vim.wo[blm_win][0]
   blm_wlo.foldcolumn = '0'


### PR DESCRIPTION
Hello!

Current file type name `gitsigns.blame` does not allow a user to setup a `ftplugin` file.
Neovim does not pick up a file named `gitsigns.blame.lua` (or `gitsigns.blame.vim` for that matter).
`:h ftplugin-name` does not mention how to work around that limitation.

This PR fixes that behaviour.