### PR TITLE
fix(blame): render blame end_col out of range

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -113,8 +113,9 @@ local function render(blame, win, main_win, buf_sha)
     })
 
     if commit_lines[i] then
-      api.nvim_buf_set_extmark(bufnr, ns, i - 1, win_width - 10, {
-        end_col = win_width,
+      local width = string.len(lines[i])
+      api.nvim_buf_set_extmark(bufnr, ns, i - 1, width - 10, {
+        end_col = width,
         hl_group = 'Title',
       })
     else


### PR DESCRIPTION
Fix blame window render error: `end_col` out of range. Resolve #1050 and #1073

The reason of this error is that the `00000000 Not Committed Yet` line is different than `max_author_len`.