### PR TITLE
fix: help triggering text autocmds

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -1213,4 +1213,3 @@ GitSignsChanged    After any event in which Gitsigns can potentially change
 
 ------------------------------------------------------------------------------
 vim:tw=78:ts=8:ft=help:norl:
-

--- a/gen_help.lua
+++ b/gen_help.lua
@@ -7,22 +7,13 @@ local startswith = vim.startswith
 
 local config = require('lua.gitsigns.config')
 
---- @param path string
---- @return string
-local function read_file(path)
-  local f = assert(io.open(path, 'r'))
-  local t = f:read('*all')
-  f:close()
-  return t
-end
-
 -- To make sure the output is consistent between runs (to minimise diffs), we
 -- need to iterate through the schema keys in a deterministic way. To do this we
 -- do a smple scan over the file the schema is defined in and collect the keys
 -- in the order they are defined.
 --- @return string[]
 local function get_ordered_schema_keys()
-  local ci = read_file('lua/gitsigns/config.lua'):gmatch('[^\n\r]+')
+  local ci = io.lines('lua/gitsigns/config.lua') --- @type Iterator[string]
 
   for l in ci do
     if startswith(l, 'M.schema = {') then
@@ -356,7 +347,7 @@ end
 --- @param path string
 --- @return string
 local function gen_functions_doc_from_file(path)
-  local i = read_file(path):gmatch('([^\n]*)\n?') --- @type Iterator[string]
+  local i = io.lines(path) --- @type Iterator[string]
 
   local blocks = {} --- @type string[][]
 
@@ -450,7 +441,7 @@ end
 
 --- @return string
 local function get_setup_from_readme()
-  local readme = read_file('README.md'):gmatch('([^\n]*)\n?') --- @type Iterator
+  local readme = io.lines('README.md') --- @type Iterator[string]
   local res = {} --- @type string[]
 
   local function append(line)
@@ -493,7 +484,7 @@ local function get_marker_text(marker)
 end
 
 local function main()
-  local template = read_file('etc/doc_template.txt'):gmatch('([^\n]*)\n?') --- @type Iterator
+  local template = io.lines('etc/doc_template.txt') --- @type Iterator[string]
 
   local out = assert(io.open('doc/gitsigns.txt', 'w'))
 


### PR DESCRIPTION
The default filetype detection algorithm only checks the last lines of
.txt files for "ft=help" before setting the filetype to "text". Since
there was an empty line at the end, the help page was getting marked as
having filetype text first, and then help, which meant both autocmds
were triggered. This fixes that by removing the extraneous newline; note
that there is still a newline at the end of file, as is customary, and
this just removes the second, unnecessary newline.

Furthermore, this simplifies the logic for "gen_help.lua" and increases
its robustness by using the "io.lines" function rather than reading the
entire file as a string and using regular expressions to split it into
lines.