### PR TITLE
fix: setqflist("all") should respect change_base

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -1294,11 +1294,18 @@ local function buildqflist(target)
     end
 
     for _, r in pairs(repos) do
-      for _, f in ipairs(r:files_changed()) do
+      for _, f in ipairs(r:files_changed(config.base)) do
         local f_abs = r.toplevel .. '/' .. f
         local stat = vim.loop.fs_stat(f_abs)
         if stat and stat.type == 'file' then
-          local a = r:get_show_text(':0:' .. f)
+          ---@type string
+          local obj
+          if config.base and config.base ~= ':0' then
+            obj = config.base .. ':' .. f
+          else
+            obj = ':0:' .. f
+          end
+          local a = r:get_show_text(obj)
           async.scheduler()
           local hunks = run_diff(a, util.file_lines(f_abs))
           hunks_to_qflist(f_abs, hunks, qflist)

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -44,18 +44,29 @@ function M:command(args, spec)
   return git_command(args1, spec)
 end
 
+--- @param base string?
 --- @return string[]
-function M:files_changed()
+function M:files_changed(base)
   --- @type string[]
-  local results = self:command({ 'status', '--porcelain', '--ignore-submodules' })
+  local results
+  if base and base ~= ':0' then
+    results = self:command({ 'diff', '--name-status', base })
 
-  local ret = {} --- @type string[]
-  for _, line in ipairs(results) do
-    if line:sub(1, 2):match('^.M') then
-      ret[#ret + 1] = line:sub(4, -1)
+    for i, result in ipairs(results) do
+      results[i] = vim.split(string.gsub(result, '\t', ' '), ' ', { plain = true })[2]
     end
+    return results
+  else
+    results = self:command({ 'status', '--porcelain', '--ignore-submodules' })
+
+    local ret = {} --- @type string[]
+    for _, line in ipairs(results) do
+      if line:sub(1, 2):match('^.M') then
+        ret[#ret + 1] = line:sub(4, -1)
+      end
+    end
+    return ret
   end
-  return ret
 end
 
 --- @param encoding string


### PR DESCRIPTION
If change_base is called, instead of run git status, run git diff against the changed base_commit.
Fix: #692 