### PR TITLE
fix: derive Staged*Cul highlight correctly

### DIFF
--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -198,8 +198,8 @@ M.hls = {
   { GitSignsStagedAddCul = { 'GitSignsAddCul', fg_factor = 0.5, hidden = true } },
   { GitSignsStagedChangeCul = { 'GitSignsChangeCul', fg_factor = 0.5, hidden = true } },
   { GitSignsStagedDeleteCul = { 'GitSignsDeleteCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangedeleteCul = { 'GitSignsStagedChangeCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedTopdeleteCul = { 'GitSignsStagedDeleteCul', fg_factor = 0.5, hidden = true } },
+  { GitSignsStagedChangedeleteCul = { 'GitSignsChangedeleteCul', fg_factor = 0.5, hidden = true } },
+  { GitSignsStagedTopdeleteCul = { 'GitSignsTopdeleteCul', fg_factor = 0.5, hidden = true } },
 
   {
     GitSignsAddPreview = {


### PR DESCRIPTION
The `GitSignsStagedTopdeleteCul` highlight (especially the foreground) was very hard to read. It seems the issue was that `GitSignsStagedTopdeleteCul` incorrectly derived from `GitSignsStagedDeleteCul` instead of the expected `GitSignsTopdeleteCul`.

So I think the `fg_factor` ended up being `0.5` of `0.5` equals `0.25`, foreground extremely dim.

Likely just a simply cut-and-paste oversight.

With this change the dim problem goes away.