### PR TITLE
fix: handle terminal-only highlights

### DIFF
--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -296,19 +296,19 @@ M.hls = {
 ---@param name string
 ---@return table<string, any>
 local function get_hl(name)
-  --- @diagnostic disable-next-line:deprecated
-  return api.nvim_get_hl_by_name(name, true)
+  return api.nvim_get_hl(0, { name = name, link = false })
 end
 
 --- @param hl_name string
 --- @return boolean
 local function is_hl_set(hl_name)
-  -- TODO: this only works with `set termguicolors`
-  local exists, hl = pcall(get_hl, hl_name)
-  if not exists then
-    return false
-  end
-  local color = hl.foreground or hl.background or hl.reverse
+  local hl = get_hl(hl_name)
+  local color = hl.fg
+    or hl.bg
+    or hl.reverse
+    or hl.ctermfg
+    or hl.ctermbg
+    or hl.cterm and hl.cterm.reverse
   return color ~= nil
 end
 
@@ -341,12 +341,11 @@ local function derive(hl, hldef)
     if is_hl_set(d) then
       dprintf('Deriving %s from %s', hl, d)
       if hldef.fg_factor then
-        hldef.fg_factor = hldef.fg_factor or 1
         local dh = get_hl(d)
         api.nvim_set_hl(0, hl, {
           default = true,
-          fg = cmul(dh.foreground, hldef.fg_factor),
-          bg = dh.background,
+          fg = cmul(dh.fg, hldef.fg_factor),
+          bg = dh.bg,
         })
       else
         api.nvim_set_hl(0, hl, { default = true, link = d })


### PR DESCRIPTION
This PR fixes an issue where where highlight groups which only define `cterm*` fields wouldn't be considered by `highlight.lua`.