### PR TITLE
fix: sort get_nav_hunks to handle mixed hunk states

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -569,6 +569,9 @@ local function get_nav_hunks(bufnr, target, greedy)
     if target == 'all' then
       hunks = hunks_main
       vim.list_extend(hunks, hunks_head)
+      table.sort(hunks, function(h1, h2)
+        return h1.added.start < h2.added.start
+      end)
     elseif target == 'staged' then
       hunks = hunks_head
     end


### PR DESCRIPTION
Fixes #1113

`gitsigns.hunks.find_nearest_hunk`'s algorithm only works on a sorted list of hunks (because it returns `i+1` which it assumes is the next hunk), however `get_nav_hunks` did not return the list of hunks sorted.

So `get_nav_hunks` might return a list with lines 16, 29, 24 (staged hunks appended to unstaged); then when jumping from 16 to the next hunk, it would find and jump to 29 when you would expect it to find the hunk at line 24.

I'm not familiar with the codebase, but this does not look like it will break anything else. `find_nearest_hunk` is only used in `nav_hunk`.