### PR TITLE
fix: diffthis vertical option

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -1199,7 +1199,7 @@ M.diffthis = function(base, opts)
     base = tostring(base)
   end
   opts = opts or {}
-  if not opts.vertical then
+  if opts.vertical == nil then
     opts.vertical = config.diff_opts.vertical
   end
   require('gitsigns.diffthis').diffthis(base, opts)


### PR DESCRIPTION
### Error description

My default for opening splits is vertical. I try to open `diffthis` in vertical:
```lua
require('gitsigns').diffthis { '', vertical = false }
```
It still opens the diff vertically.

### Fix description


The error is that the value is replaced by the default because it compares the argument as a bool instead of comparing with `nil`.