### PR TITLE
fix: add nil check

### DIFF
--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -136,7 +136,7 @@ local repo_cache = setmetatable({}, { __mode = 'v' })
 --- @return Gitsigns.Repo?
 function M.get(dir, gitdir, toplevel)
   local info = M.get_info(dir, gitdir, toplevel)
-  if not info then
+  if not info or not info.gitdir then
     return
   end
 


### PR DESCRIPTION
I got an error like https://github.com/lewis6991/gitsigns.nvim/issues/1085 and https://github.com/lewis6991/gitsigns.nvim/issues/1086 except at line 145 of

https://github.com/lewis6991/gitsigns.nvim/blob/863903631e676b33e8be2acb17512fdc1b80b4fb/lua/gitsigns/git/repo.lua#L144-L146

This PR adds a nil check like e784e5a078f993f7218b8a857cb581d5b9ca42dc, 375c44bdfdde25585466a966f00c2e291db74f2d, and 7178d1a430dcfff8a4c92d78b9e39e0297a779c0. Not sure what the underlying cause of all this is.

(the repo I was in is not empty and worked before without errors, can't seem to reproduce the error again.)