### PR TITLE
fix(blame): show same commit twice or more

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -193,7 +193,7 @@ local show_commit = async.create(3, function(win, open, bcache)
   local buffer_name = bcache:get_rev_bufname(sha, true)
   local commit_buf = nil
   -- find preexisting commit buffer or create a new one
-  for _, bufnr in pairs(api.nvim_list_bufs()) do
+  for _, bufnr in ipairs(api.nvim_list_bufs()) do
     if api.nvim_buf_get_name(bufnr) == buffer_name then
       commit_buf = bufnr
       break

--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -190,12 +190,24 @@ local show_commit = async.create(3, function(win, open, bcache)
   local sha = bcache.blame[cursor].commit.sha
   local res = bcache.git_obj.repo:command({ 'show', sha })
   async.scheduler()
-  local commit_buf = api.nvim_create_buf(true, true)
-  api.nvim_buf_set_name(commit_buf, bcache:get_rev_bufname(sha, true))
-  api.nvim_buf_set_lines(commit_buf, 0, -1, false, res)
+  local buffer_name = bcache:get_rev_bufname(sha, true)
+  local commit_buf = nil
+  -- find preexisting commit buffer or create a new one
+  for _, bufnr in pairs(api.nvim_list_bufs()) do
+    if api.nvim_buf_get_name(bufnr) == buffer_name then
+      commit_buf = bufnr
+      break
+    end
+  end
+  if commit_buf == nil then
+    commit_buf = api.nvim_create_buf(true, true)
+    api.nvim_buf_set_name(commit_buf, buffer_name)
+    api.nvim_buf_set_lines(commit_buf, 0, -1, false, res)
+  end
   vim.cmd[open]({ mods = { keepalt = true } })
   api.nvim_win_set_buf(0, commit_buf)
   vim.bo[commit_buf].filetype = 'git'
+  vim.bo[commit_buf].bufhidden = 'wipe'
 end)
 
 --- @param augroup integer


### PR DESCRIPTION
Fixes https://github.com/lewis6991/gitsigns.nvim/issues/1121

## issue
1. `show_commit()` always creates a new buffer and set its name according to the SHA1
2. that buffer is never wiped
3. when calling `show_commit()` twice on the same commit, we end up trying to create a 2nd buffer with the same name as a preexisting one
```
Error executing vim.schedule lua callback: ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:95: The async coroutine failed: ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/blame.lua:194: Failed to rename buffer
stack traceback:
        [C]: in function 'nvim_buf_set_name'
        ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/blame.lua:194: in function <...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/blame.lua:188>
stack traceback:
        [C]: in function 'error'
        ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:95: in function 'cb'
        ...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:145: in function <...cal/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/async.lua:144>
```

## fix
1. if preexisting buffer with right name: reuse it; else: create a new one
2. wipe the buffer when closing window

## how it was tested
* `Gitsigns blame`, press `s` multiple tiems on the same commit
* check buffer is not present/listed after its window(s) are closed (same behavior as `vim-fugitive`)