### PR TITLE
Returning Info about the 'blame' window

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -407,6 +407,8 @@ M.blame = function()
   })
 
   sync_cursors(group, { win, blm_win })
+
+  return { win=blm_win, bufnr=blm_bufnr }
 end
 
 return M

--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -408,7 +408,7 @@ M.blame = function()
 
   sync_cursors(group, { win, blm_win })
 
-  return { win=blm_win, bufnr=blm_bufnr }
+  return { win = blm_win, bufnr = blm_bufnr }
 end
 
 return M


### PR DESCRIPTION
I think it would be great if there was a "Toggle" ability to the `blame` window. But for that to happen the `blame` function need to return the information about the window.

Then the _async_ `blame` function could track the blame window and toggle it instead of re-open it, when a specific option was entered.

i.e. `require("gitsigns").blame({ toggle=true })`