### PR TITLE
Added `on_attach_after` config option

### DIFF
--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -365,6 +365,9 @@ local attach_throttled = throttle_by_id(function(cbuf, ctx, aucmd)
 
   -- Initial update
   manager.update(cbuf)
+  if config.on_attach_after then
+    config.on_attach_after(cbuf)
+  end
 
   if config.current_line_blame then
     require('gitsigns.current_line_blame').update(cbuf)

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -67,6 +67,7 @@
 --- @field sign_priority integer
 --- @field _on_attach_pre fun(bufnr: integer, callback: fun(_: table))
 --- @field on_attach fun(bufnr: integer)
+--- @field on_attach_after fun(bufnr: integer)
 --- @field watch_gitdir { enable: boolean, follow_files: boolean }
 --- @field max_file_length integer
 --- @field update_debounce integer
@@ -386,6 +387,26 @@ M.schema = {
           toplevel = ...
         }
       end
+      <
+    ]],
+  },
+
+  on_attach_after = {
+    type = 'function',
+    default = nil,
+    description = [[
+      Callback called after initial update of attached buffer.
+      The buffer number is passed as the only argument.
+
+      Use this callback if you need hunk information,
+      for example to automatically navigate to some hunk
+
+      Example: >lua
+        on_attach_after = function(bufnr)
+          if jump_to_first_hunk then
+            require("gitsigns").nav_hunk("first")
+          end
+        end
       <
     ]],
   },


### PR DESCRIPTION
## Why

When trying to navigate to a hunk automatically on some condition, I noticed that `on_attach` does not work like I thought, it gets called without hunk info.

Thus you need to use `vim.defer_fn` which is an unstable solution which I dislike https://github.com/nvim-telescope/telescope.nvim/issues/3341#issuecomment-2480802930
