### PR TITLE
feat: new option to control how staged highlights are derived

### DIFF
--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -81,6 +81,7 @@
 --- @field worktrees {toplevel: string, gitdir: string}[]
 --- @field word_diff boolean
 --- @field trouble boolean
+--- @field staged_highlight_derivative_factor number
 --- -- Undocumented
 --- @field _refresh_staged_on_update boolean
 --- @field _threaded_diff boolean
@@ -856,6 +857,16 @@ M.schema = {
     ]],
   },
 
+  staged_highlight_derivative_factor = {
+    type = 'number',
+    default = 0.5,
+    description = [[
+    This determines the factor used when deriving highlight for staged
+    from base colors (e.g: GitSignsStagedAdd derives from GitSignsAdd).
+    Between 0 (black) and 1 (same color). The closer to 0 the darker.
+    ]],
+  },
+
   _refresh_staged_on_update = {
     type = 'boolean',
     default = false,
@@ -906,6 +917,14 @@ local function validate_config(config)
         vim.validate({ [k] = { v, ty } })
       end
     end
+  end
+
+  local darken = config['staged_highlight_derivative_factor']
+  if darken and (darken < 0 or darken > 1) then
+    warn(
+      'gitsigns: Ignoring invalid configuration field '
+        + "'staged_highlight_derivative_factor' must be between 0 and 1"
+    )
   end
 end
 

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -1,10 +1,11 @@
 local api = vim.api
+local config = require('gitsigns.config').config
 
 --- @class Gitsigns.Hldef
 --- @field [integer] string
 --- @field desc string
 --- @field hidden boolean
---- @field fg_factor number
+--- @field derives boolean
 
 local nvim10 = vim.fn.has('nvim-0.10') > 0
 
@@ -180,26 +181,26 @@ M.hls = {
   -- Don't set GitSignsDeleteLn by default
   -- {GitSignsDeleteLn = {}},
 
-  { GitSignsStagedAdd = { 'GitSignsAdd', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChange = { 'GitSignsChange', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedDelete = { 'GitSignsDelete', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangedelete = { 'GitSignsChangedelete', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedTopdelete = { 'GitSignsTopdelete', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedAddNr = { 'GitSignsAddNr', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangeNr = { 'GitSignsChangeNr', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedDeleteNr = { 'GitSignsDeleteNr', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangedeleteNr = { 'GitSignsChangedeleteNr', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedTopdeleteNr = { 'GitSignsTopdeleteNr', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedAddLn = { 'GitSignsAddLn', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangeLn = { 'GitSignsChangeLn', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedDeleteLn = { 'GitSignsDeleteLn', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangedeleteLn = { 'GitSignsChangedeleteLn', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedTopdeleteLn = { 'GitSignsTopdeleteLn', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedAddCul = { 'GitSignsAddCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangeCul = { 'GitSignsChangeCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedDeleteCul = { 'GitSignsDeleteCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedChangedeleteCul = { 'GitSignsChangedeleteCul', fg_factor = 0.5, hidden = true } },
-  { GitSignsStagedTopdeleteCul = { 'GitSignsTopdeleteCul', fg_factor = 0.5, hidden = true } },
+  { GitSignsStagedAdd = { 'GitSignsAdd', derives = true, hidden = true } },
+  { GitSignsStagedChange = { 'GitSignsChange', derives = true, hidden = true } },
+  { GitSignsStagedDelete = { 'GitSignsDelete', derives = true, hidden = true } },
+  { GitSignsStagedChangedelete = { 'GitSignsChangedelete', derives = true, hidden = true } },
+  { GitSignsStagedTopdelete = { 'GitSignsTopdelete', derives = true, hidden = true } },
+  { GitSignsStagedAddNr = { 'GitSignsAddNr', derives = true, hidden = true } },
+  { GitSignsStagedChangeNr = { 'GitSignsChangeNr', derives = true, hidden = true } },
+  { GitSignsStagedDeleteNr = { 'GitSignsDeleteNr', derives = true, hidden = true } },
+  { GitSignsStagedChangedeleteNr = { 'GitSignsChangedeleteNr', derives = true, hidden = true } },
+  { GitSignsStagedTopdeleteNr = { 'GitSignsTopdeleteNr', derives = true, hidden = true } },
+  { GitSignsStagedAddLn = { 'GitSignsAddLn', derives = true, hidden = true } },
+  { GitSignsStagedChangeLn = { 'GitSignsChangeLn', derives = true, hidden = true } },
+  { GitSignsStagedDeleteLn = { 'GitSignsDeleteLn', derives = true, hidden = true } },
+  { GitSignsStagedChangedeleteLn = { 'GitSignsChangedeleteLn', derives = true, hidden = true } },
+  { GitSignsStagedTopdeleteLn = { 'GitSignsTopdeleteLn', derives = true, hidden = true } },
+  { GitSignsStagedAddCul = { 'GitSignsAddCul', derives = true, hidden = true } },
+  { GitSignsStagedChangeCul = { 'GitSignsChangeCul', derives = true, hidden = true } },
+  { GitSignsStagedDeleteCul = { 'GitSignsDeleteCul', derives = true, hidden = true } },
+  { GitSignsStagedChangedeleteCul = { 'GitSignsChangedeleteCul', derives = true, hidden = true } },
+  { GitSignsStagedTopdeleteCul = { 'GitSignsTopdeleteCul', derives = true, hidden = true } },
 
   {
     GitSignsAddPreview = {
@@ -340,11 +341,11 @@ local function derive(hl, hldef)
   for _, d in ipairs(hldef) do
     if is_hl_set(d) then
       dprintf('Deriving %s from %s', hl, d)
-      if hldef.fg_factor then
+      if hldef.derives then
         local dh = get_hl(d)
         api.nvim_set_hl(0, hl, {
           default = true,
-          fg = cmul(dh.fg, hldef.fg_factor),
+          fg = cmul(dh.fg, config.staged_highlight_derivative_factor),
           bg = dh.bg,
         })
       else
@@ -353,7 +354,7 @@ local function derive(hl, hldef)
       return
     end
   end
-  if hldef[1] and not hldef.fg_factor then
+  if hldef[1] and not hldef.derives then
     -- No fallback found which is set. Just link to the first fallback
     -- if there are no modifiers
     dprintf('Deriving %s from %s', hl, hldef[1])


### PR DESCRIPTION
Commit message:
Colors for staged states derives from regular states (e.g: a hunk that is
added and staged has a color which derives from the color a hunk has if it
added and not staged).
This commit adds a parameter to determines the derivation factor.

For context (not included in the commit message):
Staged highlight are unreadable. They derive from my colors
highlight GitSignsAdd guifg=#4d783f
highlight GitSignsDelete guifg=#79323d
highlight GitSignsChange guifg=#9c9d0d

These colors are inspired from catppuccin but less flashy (because it's annoying to have brightful colors on dark theme) but as you can see the derived highlights are way too dim. So I use my PR to have a factor of 0.7 and now it looks cool
Before
![Capture d'écran 2024-11-23 112750](https://github.com/user-attachments/assets/cb58e765-f202-4f5e-9d8a-d9dcf6259890)
After
![Capture d'écran 2024-11-23 114304](https://github.com/user-attachments/assets/c064c664-fc16-4bc7-b743-41e601b61025)

