### PR TITLE
fix: After closing the blame_line/preview_hunk window, the buffer should be wipeout.

### DIFF
--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -145,6 +145,8 @@ local function create_buf(lines, highlights)
   local bufnr = api.nvim_create_buf(false, true)
   assert(bufnr, 'Failed to create buffer')
 
+  vim.bo[bufnr].bufhidden = 'wipe'
+
   -- In case nvim was opened with '-M'
   vim.bo[bufnr].modifiable = true
   api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)


### PR DESCRIPTION
Hey everyone,
I noticed that after closing the blame_line/preview_hunk window, the buffer is not wipeout, which causes a [Scratch] entry to remain in the buffer list. With frequent opening and closing of these windows, the buffer list can become cluttered.

To better explain this issue, I recorded a video.


https://github.com/user-attachments/assets/01c7dade-d4f0-46d4-8de7-7f3e2f40e75c



Since I haven't fully read all the code yet, I'm not sure if this will cause other side effects. Regardless, this is an attempt.

Best wishes, and take care!