### PR TITLE
feat: file blame options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ require('gitsigns').setup {
     use_focus = true,
   },
   current_line_blame_formatter = '<author>, <author_time:%R> - <summary>',
+  file_blame_opts = {
+    auto_sha_colors = true,
+    lines = {
+      start = '┍',
+      continue = '│',
+      finish = '┕',
+    }
+  },
   sign_priority = 6,
   update_debounce = 100,
   status_formatter = nil, -- Use default

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -70,6 +70,14 @@ of the default settings:
         use_focus = true,
       },
       current_line_blame_formatter = '<author>, <author_time:%R> - <summary>',
+      file_blame_opts = {
+        auto_sha_colors = true,
+        lines = {
+          start = '┍',
+          continue = '│',
+          finish = '┕',
+        }
+      },
       sign_priority = 6,
       update_debounce = 100,
       status_formatter = nil, -- Use default
@@ -934,6 +942,46 @@ current_line_blame_formatter_nc
       |gitsigns-config-current_line_blame| for lines that aren't committed.
 
       See |gitsigns-config-current_line_blame_formatter| for more information.
+
+file_blame_opts                              *gitsigns-config-file_blame_opts*
+      Type: `table[extended]`
+      Default: >
+        {
+          auto_sha_colors = true,
+          lines = {
+            start = '┍',
+            continue = '│',
+            finish = '┕',
+          }
+        }
+<
+      Options for the whole file blame sidebar.
+
+      Fields: ~
+        • `auto_sha_colors`: boolean
+          Whether to generate commit colors from their hashe values or use
+          the user provided highlights.
+        • `lines`: Table containing the glyphs for drawng the commit region lines:
+            • `start`: string
+              Commit region start glyph
+            • `continue`: string
+              Commit region continuation glyph
+            • `finish`: string
+              Commit region end glyph
+
+      Uses the highlights:
+        • `GitSignsFileBlameAuthor` - commit author
+        • `GitSignsFileBlameDate` - commit date
+        • `GitSignsFileBlameSummary` - commit summary
+        • `GitSignsFileBlameCurrent` - commit matching current buffer
+        • `GitSignsFileBlameCursor` - commit under cursor
+        • `GitSignsFileBlameSeparator` - file content separator
+
+      When `auto_sha_colors` is `false` then user provided highlights with names
+      `GitSignsFileBlameHash1`, `GitSignsFileBlameHash2` and so on are used
+      for the commit sha colors. You can provide as many as you like.
+      When the blame results in more commits then the highlights provided then
+      the colors will be reused from the first one.
 
 trouble                                              *gitsigns-config-trouble*
       Type: `boolean`, Default: true if installed

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -51,6 +51,15 @@
 --- @class (exact) Gitsigns.LineBlameOpts : Gitsigns.BlameOpts
 --- @field full? boolean
 
+--- @alias Gitsigns.FileBlameRegionLineType
+--- | 'start'
+--- | 'continue'
+--- | 'finish'
+
+--- @class (exact) Gitsigns.FileBlameOpts
+--- @field auto_sha_colors boolean
+--- @field lines table<Gitsigns.FileBlameRegionLineType,string>
+
 --- @class (exact) Gitsigns.Config
 --- @field debug_mode boolean
 --- @field diff_opts Gitsigns.DiffOpts
@@ -75,6 +84,7 @@
 --- @field current_line_blame_formatter string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_formatter_nc string|Gitsigns.CurrentLineBlameFmtFun
 --- @field current_line_blame_opts Gitsigns.CurrentLineBlameOpts
+--- @field file_blame_opts Gitsigns.FileBlameOpts
 --- @field preview_config table<string,any>
 --- @field auto_attach boolean
 --- @field attach_to_untracked boolean
@@ -795,6 +805,56 @@ M.schema = {
       |gitsigns-config-current_line_blame| for lines that aren't committed.
 
       See |gitsigns-config-current_line_blame_formatter| for more information.
+    ]],
+  },
+
+  file_blame_opts = {
+    type = 'table',
+    deep_extend = true,
+    default = {
+      auto_sha_colors = true,
+      lines = {
+        start = '┍',
+        continue = '│',
+        finish = '┕',
+      },
+    },
+    default_help = [[{
+      auto_sha_colors = true,
+      lines = {
+        start = '┍',
+        continue = '│',
+        finish = '┕',
+      }
+    }]],
+    description = [[
+      Options for the whole file blame sidebar.
+
+      Fields: ~
+        • `auto_sha_colors`: boolean
+          Whether to generate commit colors from their hashe values or use
+          the user provided highlights.
+        • `lines`: Table containing the glyphs for drawng the commit region lines:
+            • `start`: string
+              Commit region start glyph
+            • `continue`: string
+              Commit region continuation glyph
+            • `finish`: string
+              Commit region end glyph
+
+      Uses the highlights:
+        • `GitSignsFileBlameAuthor` - commit author
+        • `GitSignsFileBlameDate` - commit date
+        • `GitSignsFileBlameSummary` - commit summary
+        • `GitSignsFileBlameCurrent` - commit matching current buffer
+        • `GitSignsFileBlameCursor` - commit under cursor
+        • `GitSignsFileBlameSeparator` - file content separator
+
+      When `auto_sha_colors` is `false` then user provided highlights with names
+      `GitSignsFileBlameHash1`, `GitSignsFileBlameHash2` and so on are used
+      for the commit sha colors. You can provide as many as you like.
+      When the blame results in more commits then the highlights provided then
+      the colors will be reused from the first one.
     ]],
   },
 

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -221,6 +221,25 @@ M.hls = {
 
   { GitSignsCurrentLineBlame = { 'NonText', desc = 'Used for current line blame.' } },
 
+  { GitSignsFileBlameAuthor = { 'Normal', desc = 'Used for file blame commit author.' } },
+  { GitSignsFileBlameDate = { 'Title', desc = 'Used for file blame commit date.' } },
+  { GitSignsFileBlameSummary = { 'Comment', desc = 'Used for file blame commit summary.' } },
+  {
+    GitSignsFileBlameCurrent = {
+      '@markup.italic',
+      desc = 'Used for file blame commit matching current buffer.',
+    },
+  },
+  {
+    GitSignsFileBlameCursor = {
+      '@markup.strong',
+      desc = 'Used for file blame commit under cursor.',
+    },
+  },
+  {
+    GitSignsFileBlameSeparator = { 'Comment', desc = 'Used for file blame file content separator.' },
+  },
+
   {
     GitSignsAddInline = {
       'TermCursor',


### PR DESCRIPTION
Default is kept:

![image](https://github.com/user-attachments/assets/14bb3e04-7aab-4a37-8efc-b8bb06e39712)

The new options and highlights let us match the current editor color theme:

![image](https://github.com/user-attachments/assets/73bd0b4a-c08b-463b-9c94-db62bfbeeb78)

