### PR TITLE
feat!: deprecate some functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,37 @@ require('gitsigns').setup{
     -- Actions
     map('n', '<leader>hs', gitsigns.stage_hunk)
     map('n', '<leader>hr', gitsigns.reset_hunk)
-    map('v', '<leader>hs', function() gitsigns.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
-    map('v', '<leader>hr', function() gitsigns.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end)
+
+    map('v', '<leader>hs', function()
+      gitsigns.stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })
+    end)
+
+    map('v', '<leader>hr', function()
+      gitsigns.reset_hunk({ vim.fn.line('.'), vim.fn.line('v') })
+    end)
+
     map('n', '<leader>hS', gitsigns.stage_buffer)
-    map('n', '<leader>hu', gitsigns.undo_stage_hunk)
     map('n', '<leader>hR', gitsigns.reset_buffer)
     map('n', '<leader>hp', gitsigns.preview_hunk)
-    map('n', '<leader>hb', function() gitsigns.blame_line{full=true} end)
-    map('n', '<leader>tb', gitsigns.toggle_current_line_blame)
+    map('n', '<leader>hi', gitsigns.preview_hunk_inline)
+
+    map('n', '<leader>hb', function()
+      gitsigns.blame_line({ full = true })
+    end)
+
     map('n', '<leader>hd', gitsigns.diffthis)
-    map('n', '<leader>hD', function() gitsigns.diffthis('~') end)
+
+    map('n', '<leader>hD', function()
+      gitsigns.diffthis('~')
+    end)
+
+    map('n', '<leader>hQ', function() gitsigns.setqflist('all') end)
+    map('n', '<leader>hq', gitsigns.setqflist)
+
+    -- Toggles
+    map('n', '<leader>tb', gitsigns.toggle_current_line_blame)
     map('n', '<leader>td', gitsigns.toggle_deleted)
+    map('n', '<leader>tw', gitsigns.toggle_word_diff)
 
     -- Text object
     map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -432,6 +432,8 @@ stage_buffer()                                       *gitsigns.stage_buffer()*
                     {async}
 
 undo_stage_hunk()                                 *gitsigns.undo_stage_hunk()*
+                DEPRECATED: use |gitsigns.stage_hunk()| on staged signs
+
                 Undo the last call of stage_hunk().
 
                 Note: only the calls to stage_hunk() performed in the current
@@ -481,6 +483,8 @@ stage_hunk({range}, {opts}, {callback?})               *gitsigns.stage_hunk()*
                               contains `linematch`. Defaults to `true`.
 
 toggle_deleted({value})                            *gitsigns.toggle_deleted()*
+                DEPRECATED: Use |gitsigns.preview_hunk_inline()|
+
                 Toggle |gitsigns-config-show_deleted|
 
                 Parameters: ~
@@ -699,6 +703,8 @@ culhl                                                  *gitsigns-config-culhl*
       and linked to the corresponding highlight group in `signs.*.hl`.
 
 show_deleted                                    *gitsigns-config-show_deleted*
+      DEPRECATED
+
       Type: `boolean`, Default: `false`
 
       Show the old version of hunks inline in the buffer (via virtual lines).

--- a/gen_help.lua
+++ b/gen_help.lua
@@ -39,9 +39,9 @@ end
 --- @param out fun(_: string?)
 local function gen_config_doc_deprecated(dep_info, out)
   if type(dep_info) == 'table' and dep_info.hard then
-    out('   HARD-DEPRECATED')
+    out('      HARD-DEPRECATED')
   else
-    out('   DEPRECATED')
+    out('      DEPRECATED')
   end
   if type(dep_info) == 'table' then
     if dep_info.message then

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -134,6 +134,7 @@ M.toggle_current_line_blame = function(value)
   return config.current_line_blame
 end
 
+--- @deprecated Use |gitsigns.preview_hunk_inline()|
 --- Toggle |gitsigns-config-show_deleted|
 ---
 --- @param value boolean|nil Value to set toggle. If `nil`
@@ -393,6 +394,7 @@ M.reset_buffer = function()
   end
 end
 
+--- @deprecated use |gitsigns.stage_hunk()| on staged signs
 --- Undo the last call of stage_hunk().
 ---
 --- Note: only the calls to stage_hunk() performed in the current
@@ -887,12 +889,8 @@ M.preview_hunk_inline = async.create(function()
 
   local winid --- @type integer
   manager.show_added(bufnr, ns_inline, hunk)
-  if config._inline2 then
-    if hunk.removed.count > 0 then
-      winid = manager.show_deleted_in_float(bufnr, ns_inline, hunk, staged)
-    end
-  else
-    manager.show_deleted(bufnr, ns_inline, hunk)
+  if hunk.removed.count > 0 then
+    winid = manager.show_deleted_in_float(bufnr, ns_inline, hunk, staged)
   end
 
   api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter' }, {

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -84,7 +84,6 @@
 --- -- Undocumented
 --- @field _refresh_staged_on_update boolean
 --- @field _threaded_diff boolean
---- @field _inline2 boolean
 --- @field _git_version string
 --- @field _verbose boolean
 --- @field _test_mode boolean
@@ -493,6 +492,7 @@ M.schema = {
 
   show_deleted = {
     type = 'boolean',
+    deprecated = true,
     default = false,
     description = [[
       Show the old version of hunks inline in the buffer (via virtual lines).
@@ -871,14 +871,6 @@ M.schema = {
     default = true,
     description = [[
       Run diffs on a separate thread
-    ]],
-  },
-
-  _inline2 = {
-    type = 'boolean',
-    default = true,
-    description = [[
-      Enable enhanced version of preview_hunk_inline()
     ]],
   },
 


### PR DESCRIPTION
- Deprecated config.show_deleted and toggle_deleted()
  - Use preview_hunk_inline()
- Deprecated undo_stage_hunk()
  - Use stage_hunk() on staged lines
- Updated keymap suggestion in README.md
- Removed hidden option config._inline2
