### PR TITLE
fix: more EOL fixes

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -308,13 +308,18 @@ end
 --- @param lines string[]
 function Obj:stage_lines(lines)
   self.lock = true
+
+  -- Concatenate the lines into a single string to ensure EOL
+  -- is respected
+  local text = table.concat(lines, '\n')
+
   local new_object = self.repo:command({
     'hash-object',
     '-w',
     '--path',
     self.relpath,
     '--stdin',
-  }, { stdin = lines })[1]
+  }, { stdin = text })[1]
 
   self.repo:command({
     'update-index',

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -134,9 +134,13 @@ function M.set_lines(bufnr, start_row, end_row, lines)
   if vim.bo[bufnr].fileformat == 'dos' then
     lines = M.strip_cr(lines)
   end
-  if start_row == 0 and end_row == -1 and lines[#lines] == '' then
-    lines = vim.deepcopy(lines)
-    lines[#lines] = nil
+  if start_row == 0 and end_row == -1 then
+    if lines[#lines] == '' then
+      lines = vim.deepcopy(lines)
+      lines[#lines] = nil
+    else
+      vim.bo[bufnr].eol = false
+    end
   end
   vim.api.nvim_buf_set_lines(bufnr, start_row, end_row, false, lines)
 end

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -63,6 +63,7 @@ local function command(cmd)
 end
 
 local function retry(f)
+  local orig_delay = delay
   local ok, err
 
   for _ = 1, 20 do
@@ -75,6 +76,7 @@ local function retry(f)
   end
 
   if err then
+    delay = orig_delay
     error(err)
   end
 end


### PR DESCRIPTION
- When staging files, convert the text into a string before passing to
  system() to ensure EOL is respected.
- When setting lines. If text doesn't end with an empty line then set
  'eol=false'.

Fixes #1145
