### PR TITLE
build: add check.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ nvim-test
 stylua
 luals
 luals_check
+/check.json


### PR DESCRIPTION
It's generated when running `make luals-check`.
