### PR TITLE
fix(select_hunk): compatible with <cmd> mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ require('gitsigns').setup{
     map('n', '<leader>tw', gitsigns.toggle_word_diff)
 
     -- Text object
-    map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+    map({'o', 'x'}, 'ih', '<cmd>Gitsigns select_hunk<CR>')
   end
 }
 ```

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -951,7 +951,11 @@ M.select_hunk = function(opts)
     return
   end
 
-  vim.cmd('normal! ' .. hunk.added.start .. 'GV' .. hunk.vend .. 'G')
+  if vim.fn.mode():find('v') ~= nil then
+    vim.cmd('normal! ' .. hunk.added.start .. 'GoV' .. hunk.vend .. 'G')
+  else
+    vim.cmd('normal! ' .. hunk.added.start .. 'GV' .. hunk.vend .. 'G')
+  end
 end
 
 --- Get hunk array for specified buffer.


### PR DESCRIPTION
Previous type vih will only select hunk lines which are below current line with mapping like
`map({ "o", "x" }, "ih", "<cmd>Gitsigns select_hunk<CR>")`.
Also update the readme to use the faster `<cmd>` mapping.