### PR TITLE
ci: fix nightly

### DIFF
--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -258,6 +258,7 @@ function M.setup_gitsigns(config, on_attach)
         end
       end
       require('gitsigns').setup(config)
+      vim.o.diffopt= 'internal,filler,closeoff'
     ]],
     config,
     on_attach


### PR DESCRIPTION
Nightly now sets linematch by default. Force it off in tests.
