### PR TITLE
feat(blame): add key binding for `q` to close Gitsings blame side panel

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -367,11 +367,19 @@ function M.blame()
     buffer = blm_bufnr,
   })
 
+  vim.keymap.set('n', 'q', function()
+    api.nvim_buf_delete(blm_bufnr, { force = true })
+  end, {
+    desc = 'Closes the blame buffer',
+    buffer = blm_bufnr,
+  })
+
   menu('GitsignsBlame', {
     { 'Reblame at commit', 'r' },
     { 'Reblame at commit parent', 'R' },
     { 'Show commit (vsplit)', 's' },
     { '            (tab)', 'S' },
+    { 'Close blame', 'q' },
   })
 
   local group = api.nvim_create_augroup('GitsignsBlame', {})

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -75,6 +75,24 @@ describe('gitsigns (with screen)', function()
     screen:detach()
   end)
 
+  it('q closes the blame buffer', function()
+    setup_test_repo()
+    setup_gitsigns(test_config)
+
+    edit(test_file)
+    helpers.sleep(100)
+
+    eq(1, #helpers.api.nvim_list_bufs())
+
+    command('Gitsigns blame')
+    helpers.sleep(100)
+    eq(2, #helpers.api.nvim_list_bufs())
+
+    feed('q')
+    helpers.sleep(100)
+    eq(1, #helpers.api.nvim_list_bufs())
+  end)
+
   it('can run basic setup', function()
     setup_gitsigns()
     check({ status = {}, signs = {} })


### PR DESCRIPTION
This change adds a key-binding for `q` key within the "Gitsings blame" side-panel.  This is for convenience purposes to quickly close the blame panel and destroy its associated scratch buffer.

@lewis6991  I'm aware that you're interested mostly in bugfixes but this is such a small addition that perhaps you bend the rule?