### PR TITLE
fix: `stage_hunk` on staged hunk should behave like `undo_stage_hunk`

### DIFF
--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -224,12 +224,15 @@ function CacheEntry:get_hunks(greedy, staged)
   return vim.deepcopy(self.hunks)
 end
 
+--- @param hunks? Gitsigns.Hunk.Hunk[]?
 --- @return Gitsigns.Hunk.Hunk? hunk
 --- @return integer? index
-function CacheEntry:get_cursor_hunk()
-  local hunks = {}
-  vim.list_extend(hunks, self.hunks or {})
-  vim.list_extend(hunks, self.hunks_staged or {})
+function CacheEntry:get_cursor_hunk(hunks)
+  if not hunks then
+    hunks = {}
+    vim.list_extend(hunks, self.hunks or {})
+    vim.list_extend(hunks, self.hunks_staged or {})
+  end
 
   local lnum = api.nvim_win_get_cursor(0)[1]
   local Hunks = require('gitsigns.hunks')
@@ -247,7 +250,7 @@ function CacheEntry:get_hunk(range, greedy, staged)
   local hunks = self:get_hunks(greedy, staged)
 
   if not range then
-    return self:get_cursor_hunk()
+    return self:get_cursor_hunk(hunks)
   end
 
   table.sort(range)

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -118,6 +118,18 @@ describe('actions', function()
       signs = { changed = 1 },
     })
 
+    command('Gitsigns stage_hunk')
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    command('Gitsigns stage_hunk')
+    check({
+      status = { head = 'main', added = 0, changed = 1, removed = 0 },
+      signs = { changed = 1 },
+    })
+
     -- Add multiple edits
     feed('ggccThat<esc>')
 


### PR DESCRIPTION
I recently noticed some unexpected behavior when using `stage_hunk` on a staged hunk (previously it work like `undo_stage_hunk`)
Not sure if it's a regression: https://github.com/lewis6991/gitsigns.nvim/blob/b95d08a0607328d7d973cfcdaf4133a1a5fb3f2e/lua/gitsigns/actions.lua#L157-L171
