### PR TITLE
fix: prevent inline hunk preview from folding

### DIFF
--- a/lua/gitsigns/preview.lua
+++ b/lua/gitsigns/preview.lua
@@ -149,8 +149,8 @@ local function show_deleted_in_float(bufnr, nsd, hunk, staged)
   vim.wo[pwinid].scrolloff = 0
 
   api.nvim_win_call(pwinid, function()
-    -- Expand folds
-    vim.cmd('normal! ' .. 'zR')
+    -- Disable folds
+    vim.wo.foldenable = false
 
     -- Navigate to hunk
     vim.cmd('normal! ' .. tostring(hunk.removed.start) .. 'gg')


### PR DESCRIPTION
Switch from `normal! zR` to `set nofoldenable` for inline preview window, which not only unfolds everything, but prevents folds from being created in the future. Addresses an issue when used with kevinhwang91/nvim-ufo.