### PR TITLE
Add compatibility with nvim v0.11 `winborder`

### DIFF
--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -627,7 +627,7 @@ M.schema = {
     type = 'table',
     deep_extend = true,
     default = {
-      border = 'single',
+      border = vim.fn.has('nvim-0.11') == 1 and vim.opt.winborder:get() ~= "" and vim.opt.winborder:get() or 'single',
       style = 'minimal',
       relative = 'cursor',
       row = 0,

--- a/lua/gitsigns/preview.lua
+++ b/lua/gitsigns/preview.lua
@@ -142,6 +142,7 @@ local function show_deleted_in_float(bufnr, nsd, hunk, staged)
     anchor = 'SW',
     bufpos = { hunk.added.start - bufpos_offset, 0 },
     style = 'minimal',
+    border = 'none',
   })
 
   vim.bo[pbufnr].filetype = vim.bo[bufnr].filetype


### PR DESCRIPTION
As pointed in the issue #1241 nvim v0.11 introduced a new winborder option. This PR is simply for adding compatibility with that.