### PR TITLE
Fix for `MSYS2 (Cygwin)`

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -58,7 +58,7 @@ end
 --- @async
 --- @return string? err
 function Obj:refresh()
-  local info, err = self.repo:file_info(self.file, self.revision)
+  local info, err = self.repo:file_info(self.relpath, self.revision)
 
   if err then
     log.eprint(err)

--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -247,7 +247,7 @@ function M.run_blame(obj, contents, lnum, revision, opts)
     uv.fs_stat(ignore_file) and { '--ignore-revs-file', ignore_file },
     revision,
     '--',
-    obj.file,
+    obj.relpath,
   }, {
     stdin = contents_str,
     stdout = on_stdout,

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -33,9 +33,9 @@ function M:command(args, spec)
   spec.cwd = self.toplevel
 
   return git_command({
-    '--git-dir',
-    self.gitdir,
-    self.detached and { '--work-tree', self.toplevel },
+    -- '--git-dir', self.gitdir,
+    -- self.detached and { '--work-tree', self.toplevel },
+    '-C', self.toplevel,
     args,
   }, spec)
 end
@@ -168,6 +168,8 @@ local function normalize_path(path)
     -- through cygpath
     --- @type string
     path = async.await(3, system, { 'cygpath', '-aw', path }).stdout
+
+    path = path:gsub( "\n", "" )
   end
   return path
 end
@@ -221,10 +223,9 @@ function M.get_info(cwd, gitdir, worktree)
   -- > environment variable)
   local stdout, stderr, code = git_command({
     gitdir and worktree and {
-      '--git-dir',
-      gitdir,
-      '--work-tree',
-      worktree,
+      -- '--git-dir', gitdir,
+      -- '--work-tree', worktree,
+      "-C", worktree,
     },
     'rev-parse',
     '--show-toplevel',


### PR DESCRIPTION
This patch apply fixes to make it work with `Cygwin` based `Git`.

The main problem is that under `Cygwin` all path in `git` command should be absolute in the unix style (`/c/path` instead of `c:/path`) or be relative to the `git` root dir.
It is hard to convert paths to the unix style for `Cygwin` only, better if just use relative paths everywhere.

Also this patch fixes problem in `Windowd Terminal`, then strings returned with the trailing `\n`.