### PR TITLE
feat: use `vim.notify` for notifications

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -220,7 +220,7 @@ M.stage_hunk = mk_repeatable(async.create(2, function(range, opts)
   end
 
   if not hunk then
-    api.nvim_echo({ { 'No hunk to stage', 'WarningMsg' } }, false, {})
+    vim.notify('No hunk to stage', vim.log.levels.WARN, { title = 'gitsigns.nvim' })
     return
   end
 
@@ -287,7 +287,7 @@ M.reset_hunk = mk_repeatable(async.create(2, function(range, opts)
   local hunk = bcache:get_hunk(range, opts.greedy ~= false, false)
 
   if not hunk then
-    api.nvim_echo({ { 'No hunk to reset', 'WarningMsg' } }, false, {})
+    vim.notify('No hunk to reset', vim.log.levels.WARN, { title = 'gitsigns.nvim' })
     return
   end
 
@@ -308,7 +308,11 @@ M.reset_buffer = function()
 
   local hunks = bcache.hunks
   if not hunks or #hunks == 0 then
-    api.nvim_echo({ { 'No unstaged changes in the buffer to reset', 'WarningMsg' } }, false, {})
+    vim.notify(
+      'No unstaged changes in the buffer to reset',
+      vim.log.levels.WARN,
+      { title = 'gitsigns.nvim' }
+    )
     return
   end
 

--- a/lua/gitsigns/debug.lua
+++ b/lua/gitsigns/debug.lua
@@ -41,7 +41,7 @@ function M.dump_cache()
   local cache = (require('gitsigns.cache')).cache
   --- @type string
   local text = vim.inspect(cache, { process = process })
-  vim.api.nvim_echo({ { text } }, false, {})
+  vim.notify(text, vim.log.levels.DEBUG, { title = 'gitsigns.nvim' })
 end
 
 M.debug_messages = log.show

--- a/lua/gitsigns/debug/log.lua
+++ b/lua/gitsigns/debug/log.lua
@@ -183,7 +183,7 @@ end
 
 function M.show()
   for _, m in ipairs(M.messages) do
-    vim.api.nvim_echo(build_msg(m), false, {})
+    vim.notify(build_msg(m), vim.log.levels.TRACE, { title = 'gitsigns.nvim' })
   end
 end
 

--- a/lua/gitsigns/debug/log.lua
+++ b/lua/gitsigns/debug/log.lua
@@ -183,7 +183,7 @@ end
 
 function M.show()
   for _, m in ipairs(M.messages) do
-    vim.notify(build_msg(m), vim.log.levels.TRACE, { title = 'gitsigns.nvim' })
+    vim.api.nvim_echo(build_msg(m), false, {})
   end
 end
 

--- a/lua/gitsigns/nav.lua
+++ b/lua/gitsigns/nav.lua
@@ -101,7 +101,7 @@ function M.nav_hunk(direction, opts)
 
   if not hunks or vim.tbl_isempty(hunks) then
     if opts.navigation_message then
-      api.nvim_echo({ { 'No hunks', 'WarningMsg' } }, false, {})
+      vim.notify('No hunks', vim.log.levels.WARN, { title = 'gitsigns.nvim' })
     end
     return
   end
@@ -116,7 +116,7 @@ function M.nav_hunk(direction, opts)
 
     if not index then
       if opts.navigation_message then
-        api.nvim_echo({ { 'No more hunks', 'WarningMsg' } }, false, {})
+        vim.notify('No more hunks', vim.log.levels.WARN, { title = 'gitsigns.nvim' })
       end
       local _, col = vim.fn.getline(line):find('^%s*')
       api.nvim_win_set_cursor(0, { line, col })
@@ -154,7 +154,11 @@ function M.nav_hunk(direction, opts)
   end
 
   if index and opts.navigation_message then
-    api.nvim_echo({ { ('Hunk %d of %d'):format(index, #hunks), 'None' } }, false, {})
+    vim.notify(
+      ('Hunk %d of %d'):format(index, #hunks),
+      vim.log.levels.INFO,
+      { title = 'gitsigns.nvim' }
+    )
   end
 end
 


### PR DESCRIPTION
This PR updates `vim.api.nvim_echo` to `vim.notify` for displaying any kind of notifications. This will render the notifications in a prettier format for users of the `snacks.notifier` or `nvim-notify`.

(With the build-message logging as the only exception, since it applies a specific formatting for the output, and is also not user-facing anyway.)