### PR TITLE
feat: add config option for git blame to split left or right

### DIFF
--- a/lua/gitsigns/blame.lua
+++ b/lua/gitsigns/blame.lua
@@ -2,6 +2,7 @@ local async = require('gitsigns.async')
 local cache = require('gitsigns.cache').cache
 local log = require('gitsigns.debug.log')
 local util = require('gitsigns.util')
+local config = require('gitsigns.config').config
 
 local api = vim.api
 
@@ -301,7 +302,7 @@ function M.blame()
   local top = vim.fn.line('w0') + vim.wo.scrolloff
   local current = vim.fn.line('.')
 
-  vim.cmd.vsplit({ mods = { keepalt = true, split = 'aboveleft' } })
+  vim.cmd.vsplit({ mods = { keepalt = true, split = config.split } })
   local blm_win = api.nvim_get_current_win()
 
   local blm_bufnr = api.nvim_create_buf(false, true)

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -38,6 +38,7 @@
 --- @alias Gitsigns.CurrentLineBlameFmtFun fun(user: string, info: table<string,any>): [string,string][]
 
 --- @class (exact) Gitsigns.CurrentLineBlameOpts : Gitsigns.BlameOpts
+--- @field split string
 --- @field virt_text? boolean
 --- @field virt_text_pos? 'eol'|'overlay'|'right_align'
 --- @field delay? integer
@@ -637,6 +638,11 @@ M.schema = {
       Option overrides for the Gitsigns preview window. Table is passed directly
       to `nvim_open_win`.
     ]],
+  },
+
+  split = {
+    type = 'string',
+    default = 'belowright',
   },
 
   auto_attach = {


### PR DESCRIPTION
Would you be open to consider the possibility to include a configuration parameter to specify where to split the git blame buffer?

This is of course just a concept: if you agree we could probably propagate the change to other entities and amend the help files accordingly. The default value is just an example for testing, it can be changed back to `aboveleft` as in the default case right now.