### PR TITLE
Tiny fix to the wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ If installed and enabled (via `config.trouble`; defaults to true if installed), 
 
 ### Implement every feature in [vim-fugitive]
 
-This plugin is actively developed and by one of the most well regarded vim plugin developers.
+That plugin is actively developed and by one of the most well regarded vim plugin developers.
 Gitsigns will only implement features of this plugin if: it is simple, or, the technologies leveraged by Gitsigns (LuaJIT, Libuv, Neovim's API, etc) can provide a better experience.
 
 ### Support for other VCS


### PR DESCRIPTION
A paragraph starting with "This plugin is actively developed [...]" in a readme makes it very easy to interpret the sentence as talking about Gitsigns at first, so I thought changing the sentence to start with "That" costs nothing but makes the readme less confusing when reading through it quickly.