### PR TITLE
fix(watcher): invalidate the cache earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: leafo/gh-actions-lua@v9
+      - uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.1.5"
 
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: leafo/gh-actions-lua@v9
+      - uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.1.5"
 
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: leafo/gh-actions-lua@v10
+      - uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.1.5"
 

--- a/lua/gitsigns/watcher.lua
+++ b/lua/gitsigns/watcher.lua
@@ -94,6 +94,7 @@ local function watcher_handler0(bufnr)
   local was_tracked = git_obj.object_name ~= nil
   local old_relpath = git_obj.relpath
 
+  bcache:invalidate(true)
   git_obj:refresh()
   if not bcache:schedule() then
     dprint('buffer invalid (3)')
@@ -109,8 +110,6 @@ local function watcher_handler0(bufnr)
       return
     end
   end
-
-  cache[bufnr]:invalidate(true)
 
   require('gitsigns.manager').update(bufnr)
 end


### PR DESCRIPTION
Make it so `Git rm %` doesn't cause an error.