### PR TITLE
Small documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ make gen_help
 
 ## Testsuite
 
-The testsuite uses the same framework as Neovims funcitonaltest suite.
+The testsuite uses the same framework as Neovims functionaltest suite.
 This is just busted with lots of helper code to create headless neovim instances which are controlled via RPC.
 
 To run the testsuite:

--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ require('gitsigns').setup{
 
     -- Toggles
     map('n', '<leader>tb', gitsigns.toggle_current_line_blame)
-    map('n', '<leader>td', gitsigns.toggle_deleted)
     map('n', '<leader>tw', gitsigns.toggle_word_diff)
 
     -- Text object


### PR DESCRIPTION
Firstly, thanks for a great plugin.

I've started using it recently, and while copying the example keymaps from the README file noticed that one of the used function is marked as deprecated.

I've removed this function from the README example and fixed a small typo in the contributing guidelines.