### PR TITLE
fix: blame_line{full=true} stop work

### DIFF
--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -587,20 +587,24 @@ function M.linespec_for_hunk(hunk, fileformat)
 
     for _, region in ipairs(removed_regions) do
       local i = region[1]
-      table.insert(hls[i][1][2], {
+      local hlm = hls[i][1][2]
+      hlm[#hlm + 1] = {
+        start_row = 0,
         hl_group = 'GitSignsDeleteInline',
         start_col = region[3],
         end_col = region[4],
-      })
+      }
     end
 
     for _, region in ipairs(added_regions) do
       local i = hunk.removed.count + region[1]
-      table.insert(hls[i][1][2], {
-        hl_group = 'GitSignsAddInline',
+      local hlm = hls[i][1][2]
+      hlm[#hlm + 1] = {
+        start_row = 0,
+        hl_group = 'GitSignsDeleteInline',
         start_col = region[3],
         end_col = region[4],
-      })
+      }
     end
   end
 


### PR DESCRIPTION
Problem:
`blame_line({full=true})` can stop work after
https://github.com/lewis6991/gitsigns.nvim/commit/095a58efbd5aec16217e2a90b1fdc0ba9bf6ab27,

Reproduction:
* cd path/to/gitsigns.nvim
* `nvim README.md +3`
* `:lua require('gitsigns').blame_line({full=true})`

Solution:
`table.insert(t, obj)` seems suppress type check for `start_row`, use `t[#t + 1] = obj` instead.
