### PR TITLE
fix: Wrap asystem call in pcall

### DIFF
--- a/lua/gitsigns/git/cmd.lua
+++ b/lua/gitsigns/git/cmd.lua
@@ -5,7 +5,17 @@ local util = require('gitsigns.util')
 local system = require('gitsigns.system').system
 
 --- @type fun(cmd: string[], opts?: vim.SystemOpts): vim.SystemCompleted
-local asystem = async.awrap(3, system)
+local asystem = async.awrap(3, function(cmd, opts, on_exit)
+  --- @type boolean, vim.SystemCompleted | nil
+  local sucess, result = pcall(function()
+    return system(cmd, opts, on_exit):wait()
+  end)
+
+  if sucess then
+    return result
+  end
+  return { code = 1, stderr = result }
+end)
 
 --- @class Gitsigns.Git.JobSpec : vim.SystemOpts
 --- @field ignore_error? boolean


### PR DESCRIPTION
Attempt to fix #1277 

Long story short, `git_command` uses `vim.system` that can return an error *or throw it* if it can't run the command.
This PR fixes this in a way by wrapping this in `pcall`, but to be honest, it seems that it just silences the error 😅 
I'm not sure how to fix it properly or what the underlying cause of the issue is.