### PR TITLE
feat: allow default user preference split for diff

### DIFF
--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -381,6 +381,16 @@ M.schema = {
     ]],
   },
 
+  split = {
+    type = 'string',
+    default = 'belowright',
+    description = [[
+      {split}: {string}. One of: 'aboveleft', 'belowright',
+      'botright', 'rightbelow', 'leftabove', 'topleft'. Defaults to
+      'belowright'.
+    ]],
+  },
+
   numhl = {
     type = 'boolean',
     default = false,

--- a/lua/gitsigns/diffthis.lua
+++ b/lua/gitsigns/diffthis.lua
@@ -143,12 +143,14 @@ local function diffthis_rev(base, opts)
   opts = opts or {}
 
   local cwin = api.nvim_get_current_win()
+  local config = require('gitsigns.config').config
 
   vim.cmd.diffsplit({
     bufname,
     mods = {
       vertical = opts.vertical,
-      split = opts.split or 'aboveleft',
+      -- split = opts.split or 'belowright',
+      split = opts.split or config.split or 'aboveleft',
       keepalt = true,
     },
   })


### PR DESCRIPTION
Augment `config` to define user preference when it comes to how to split when calling `diffthis`.