### PR TITLE
fix: check preview popup before navigating

### DIFF
--- a/lua/gitsigns/nav.lua
+++ b/lua/gitsigns/nav.lua
@@ -127,6 +127,9 @@ function M.nav_hunk(direction, opts)
     line = forwards and hunk.added.start or hunk.vend
   end
 
+  -- Check if preview popup is open before moving the cursor
+  local should_preview = opts.preview or Popup.is_open('hunk') ~= nil
+
   -- Handle topdelete
   line = math.max(line, 1)
 
@@ -146,7 +149,7 @@ function M.nav_hunk(direction, opts)
 
   local Preview = require('gitsigns.preview')
 
-  if opts.preview or Popup.is_open('hunk') ~= nil then
+  if should_preview then
     -- Close the popup in case one is open which will cause it to focus the
     -- popup
     Popup.close('hunk')


### PR DESCRIPTION
Navigation won't open a new preview popup if there is one since 9296d3048dd1f13c642f08f392fb22a256061d50. I believe this is due to `nav_hunk` moves the cursor before checking `Popup.is_open('hunk')`, and `autocmd CursorMoved` created by `Popup.create` will close the popup, so it will never open a new popup if `opt.preview` is not set.