### PR TITLE
ci: bump luarocks-tag-release action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get Version
         run: echo "LUAROCKS_VERSION=${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v5
+        uses: nvim-neorocks/luarocks-tag-release@v7
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:


### PR DESCRIPTION
`v5` of luarocks-tag-release doesn't auto-detect runtime directories (`plugin`, `ftplugin`, ...) to add to the rockspec's `build.copy_directories` list (`v7` does).

Note: The [current rockspec for version 1.0.2](https://luarocks.org/manifests/lewis6991/gitsigns.nvim-1.0.2-1.rockspec) doesn't include the `plugin` directory.
It will either require a new release to fix that, or you can manually upload a `gitsigns.nvim-1.0.2-2.rockspec` with the fixed `copy_directories`.