### PR TITLE
fix(blame): do not unpack hunk linespec

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -673,10 +673,8 @@ local function create_blame_linespec(full, result, repo, fileformat)
     }
   end
 
-  vim.list_extend(ret, {
-    hunk_title,
-    unpack(Hunks.linespec_for_hunk(hunk, fileformat)),
-  })
+  table.insert(ret, hunk_title)
+  vim.list_extend(ret, Hunks.linespec_for_hunk(hunk, fileformat))
 
   return ret
 end


### PR DESCRIPTION
With extremely long hunks, `unpack()` fails with:

```
gitsigns.nvim/lua/gitsigns/actions.lua:678: too many results to unpack
```

We can avoid unpacking this list by simply passing it to `vim.list_extend()` as is.