### PR TITLE
fix: when diff dos format with unix format

### DIFF
--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -560,14 +560,16 @@ function M.linespec_for_hunk(hunk, fileformat)
 
   local removed, added = hunk.removed.lines, hunk.added.lines
 
+  if fileformat == 'dos' then
+    removed = util.strip_cr(removed)
+    added = util.strip_cr(added)
+  end
+
   for _, spec in ipairs({
     { sym = '-', lines = removed, hl = 'GitSignsDeletePreview' },
     { sym = '+', lines = added, hl = 'GitSignsAddPreview' },
   }) do
     for _, l in ipairs(spec.lines) do
-      if fileformat == 'dos' then
-        l = l:gsub('\r$', '') --[[@as string]]
-      end
       hls[#hls + 1] = {
         {
           spec.sym .. l,


### PR DESCRIPTION
Problem: when fileformat change from unix to dos,
`blame_line{full=true}` throw error:
```
vim.schedule callback:
/home/phan/lazy/gitsigns.nvim/lua/gitsigns/popup.lua:168: {
  end_col = 46,
  hl_group = "GitSignsAddInline",
  start_col = 44,
  start_row = 38
}
Invalid 'end_col': out of range
```

Solution: ensure run_word_diff and nvim_buf_set_extmark both use striped
version


Example: run `blame_line{full=true}` on this file https://github.com/microsoft/vcpkg/blob/8b4801fb4aba2e5f5667aa89d958d94cfc17c1d0/ports/apsi/fix-find-seal.patch#L10.