### PR TITLE
Version guard `clear_env = true` in `git_command`

### DIFF
--- a/lua/gitsigns/git/cmd.lua
+++ b/lua/gitsigns/git/cmd.lua
@@ -52,7 +52,9 @@ local function git_command(args, spec)
   end
 
   -- Fix #895. Only needed for Nvim 0.9 and older
-  spec.clear_env = true
+  if vim.fn.has('nvim-0.10') == 0 then
+    spec.clear_env = true
+  end
 
   --- @type vim.SystemCompleted
   local obj = asystem(cmd, spec)


### PR DESCRIPTION
Since some recent updates I'm getting an error on gitsigns attach event: `nvim/runtime/lua/vim/_system.lua:249: ENOENT: no such file or directory`.

I've found the `clear_env` setting in `git_command` was causing this. Version guarding the set works for me.

```
Error  08:00:12 msg_show.lua_error vim.schedule callback: ...unwrapped-nightly/share/nvim/runtime/lua/vim/_system.lua:249: ENOENT: no such file or directory
stack traceback:
 [thread: 0x7fad240f1df8] [C]: in function 'asystem'
 [thread: 0x7fad240f1df8] ...zyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/git/cmd.lua:58: in function 'git_command'
 [thread: 0x7fad240f1df8] ...yvim-nix-plugins/gitsigns.nvim/lua/gitsigns/git/repo.lua:213: in function 'get_info'
 [thread: 0x7fad240f1df8] ...yvim-nix-plugins/gitsigns.nvim/lua/gitsigns/git/repo.lua:126: in function 'get'
 [thread: 0x7fad240f1df8] ...4-lazyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/git.lua:243: in function 'new'
 [thread: 0x7fad240f1df8] ...azyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/attach.lua:217: in function 'fn'
 [thread: 0x7fad240f1df8] ...yvim-nix-plugins/gitsigns.nvim/lua/gitsigns/debounce.lua:78: in function 'attach_throttled'
 [thread: 0x7fad240f1df8] ...azyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/attach.lua:363: in function <...azyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/attach.lua:362>
stack traceback:
 [C]: in function 'error'
 ...lazyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/async.lua:229: in function '_finish'
 ...lazyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/async.lua:322: in function '_resume'
 ...lazyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/async.lua:317: in function <...lazyvim-nix-plugins/gitsigns.nvim/lua/gitsigns/async.lua:307>
```

btw, thanks for this great plugin, happily using it since a long time :)
