### PR TITLE
fix(attach): don't skip all `.git*` files at the root of the repo

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -249,7 +249,7 @@ function Obj.new(file, revision, encoding, gitdir, toplevel)
     return
   end
 
-  if vim.startswith(vim.fn.fnamemodify(file, ':p'), repo.gitdir) then
+  if vim.startswith(vim.fn.fnamemodify(file, ':p'), vim.fn.fnamemodify(repo.gitdir, ':p')) then
     -- Normally this check would be caught (unintended) in the above
     -- block, as gitdir resolution will fail if `file` is inside a gitdir.
     -- If gitdir is explicitly passed (or set in the env with GIT_DIR)


### PR DESCRIPTION
[This commit](c80e0b4bfc411d5740a47adc8775fd1070f2028b) introduced a check, as I understand, to avoid attaching to files inside `.git` dir. Turns out it also make it not attach to `.gitignore` at the root of the repo, for example. Adding this log confirms it:

```diff
diff --git a/lua/gitsigns/git.lua b/lua/gitsigns/git.lua
index a319558..b431451 100644
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -249,6 +249,8 @@ function Obj.new(file, revision, encoding, gitdir, toplevel)
     return
   end
 
+  vim.print(vim.fn.fnamemodify(file, ':p'), repo.gitdir)
+
   if vim.startswith(vim.fn.fnamemodify(file, ':p'), repo.gitdir) then
     -- Normally this check would be caught (unintended) in the above
     -- block, as gitdir resolution will fail if `file` is inside a gitdir.
```

The output when I open a `.gitignore` looks like this:

```
.../dotfiles/.gitignore
.../dotfiles/.git
```

So it matches any `.git*` path at the root of the repo, not only `.git/*`.

Adding a path separator at the end of `repo.gitdir` fixes it. `fnamemodify` can take care of it as it adds a path separator at the end if a given path is a directory (I assume it will be a correct separator on Windows as well).