### PR TITLE
fix(blame): set nolist in the blame window

### DIFF
--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -373,6 +373,7 @@ function M.blame()
   blm_wlo.spell = false
   blm_wlo.winfixwidth = true
   blm_wlo.wrap = false
+  blm_wlo.list = false
 
   if vim.wo[win].winbar ~= '' and blm_wlo.winbar == '' then
     local name = api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
This is a super simple UI improvement. It's just that if I have `list` and `listchars` set globally, the blame window looks ugly:

<img width="934" height="493" alt="image" src="https://github.com/user-attachments/assets/1bac8691-fb23-42e3-bf32-87bc6fe914cc" />

With my PR:

<img width="931" height="473" alt="image" src="https://github.com/user-attachments/assets/b040730c-4dd1-4393-8bae-b4bc71724e52" />