### PR TITLE
fix: blame incompatible neovim function

### DIFF
--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -59,11 +59,21 @@ local function get_hash_color(sha)
   return hl_name
 end
 
+--- @param str string
+--- @return integer
+local function get_str_len(str)
+  if vim.fn.has('nvim-0.11') == 1 then
+    return vim.str_utfindex(str, 'utf-8')
+  else
+    return vim.str_utfindex(str)
+  end
+end
+
 ---@param amount integer
 ---@param text string
 ---@return string
 local function lalign(amount, text)
-  local len = vim.str_utfindex(text, 'utf-8')
+  local len = get_str_len(text)
   return text .. string.rep(' ', math.max(0, amount - len))
 end
 
@@ -86,11 +96,7 @@ local function render(blame, win, main_win, buf_sha)
   local entries = blame.entries
 
   for _, b in pairs(entries) do
-    if vim.fn.has('nvim-0.11') == 1 then
-      max_author_len = math.max(max_author_len, (vim.str_utfindex(b.commit.author, 'utf-8')))
-    else
-      max_author_len = math.max(max_author_len, #b.commit.author)
-    end
+    max_author_len = math.max(max_author_len, get_str_len(b.commit.author))
   end
 
   local lines = {} --- @type string[]

--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -59,21 +59,11 @@ local function get_hash_color(sha)
   return hl_name
 end
 
---- @param str string
---- @return integer
-local function get_str_len(str)
-  if vim.fn.has('nvim-0.11') == 1 then
-    return vim.str_utfindex(str, 'utf-8')
-  else
-    return vim.str_utfindex(str)
-  end
-end
-
 ---@param amount integer
 ---@param text string
 ---@return string
 local function lalign(amount, text)
-  local len = get_str_len(text)
+  local len = vim.fn.strdisplaywidth(text)
   return text .. string.rep(' ', math.max(0, amount - len))
 end
 
@@ -96,7 +86,7 @@ local function render(blame, win, main_win, buf_sha)
   local entries = blame.entries
 
   for _, b in pairs(entries) do
-    max_author_len = math.max(max_author_len, get_str_len(b.commit.author))
+    max_author_len = math.max(max_author_len, vim.fn.strdisplaywidth(b.commit.author))
   end
 
   local lines = {} --- @type string[]


### PR DESCRIPTION
This PR addresses #1405 and #1388, which are caused by the incompatible function signature `vim.str_utfindex` in Neovim v0.11.

- `vim.str_utfindex` before 0.11:
  ```lua
  --- @param str string
  --- @param index? integer
  --- @return integer UTF-32 index
  --- @return integer UTF-16 index
  function vim.str_utfindex(str, index) end
  ```
- `vim.str_utfindex` since 0.11:
  ```lua
  --- Parameters:
  --- {s} (string)
  --- {encoding} ("utf-8"|"utf-16"|"utf-32")
  --- {index} (integer)
  --- {strict_indexing} (boolean?) default: true
  --- Return:
  --- (integer)
  vim.str_byteindex(s, encoding, index, strict_indexing)
  ```

At first, I considered simply using a helper function to wrap the incompatible functions, but that felt too tedious for such a common task. Then I found the vimscript API function `vim.fn.strdisplaywidth`, which seems to do the job and makes more sense in this context.

You can find these implementations in the two separate commits. Both commits work fine.

[Vim functions: strchars vs strwidth vs strlen vs strdisplaywidth](https://renenyffenegger.ch/notes/development/vim/script/vimscript/functions/_str_len_width_chars_etc) for reference.

Also, many thanks to Lewis. Gitsigns is awesome!