### PR TITLE
feat(cache): add support for fetching line ranges

### DIFF
--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -98,7 +98,7 @@ local BLAME_THRESHOLD_LEN = 10000
 
 --- @async
 --- @private
---- @param lnum? integer
+--- @param lnum? integer|[integer, integer]
 --- @param opts? Gitsigns.BlameOpts
 --- @return table<integer,Gitsigns.BlameInfo?>
 --- @return table<string,Gitsigns.CommitInfo?>
@@ -157,29 +157,55 @@ end
 
 --- If lnum is nil then run blame for the entire buffer.
 --- @async
---- @param lnum? integer
+--- @param lnum? integer|[integer, integer]
 --- @param opts? Gitsigns.BlameOpts
 --- @return Gitsigns.BlameInfo?
 function CacheEntry:get_blame(lnum, opts)
   local blame = self.blame
 
-  if not blame or not self:blame_valid(lnum) then
+  local blame_valid = true
+  if type(lnum) == 'table' then
+    local curr_lnum = lnum[1]
+    while blame_valid and curr_lnum <= lnum[2] do
+      blame_valid = self:blame_valid(curr_lnum)
+      curr_lnum = curr_lnum + 1
+    end
+  else
+    blame_valid = self:blame_valid(lnum)
+  end
+  if not blame or not blame_valid then
     self:wait_for_hunks()
     blame = blame or { entries = {} }
     local Hunks = require('gitsigns.hunks')
-    if lnum and Hunks.find_hunk(lnum, self.hunks) then
+    local has_hunks = true
+    if lnum then
+      local start_lnum = type(lnum) == 'table' and lnum[1] or lnum
+      local end_lnum = type(lnum) == 'table' and lnum[2] or lnum
+      for curr_lnum = start_lnum, end_lnum do
+        has_hunks = not not Hunks.find_hunk(curr_lnum, self.hunks)
+      end
+    end
+    if lnum and has_hunks then
       --- Bypass running blame (which can be expensive) if we know lnum is in a hunk
       local Blame = require('gitsigns.git.blame')
       local relpath = assert(self.git_obj.relpath)
-      local info = Blame.get_blame_nc(relpath, lnum)
-      blame.entries[lnum] = info
-      blame.max_time = info.commit.author_time
+      local start_lnum = type(lnum) == 'table' and lnum[1] or lnum
+      local end_lnum = type(lnum) == 'table' and lnum[2] or lnum
+      for curr_lnum = start_lnum, end_lnum do
+        local info = Blame.get_blame_nc(relpath, curr_lnum)
+        blame.entries[curr_lnum] = info
+        blame.max_time = info.commit.author_time
+      end
     else
       -- Refresh/update cache
       local b, commits, full = self:run_blame(lnum, opts)
       self.commits = vim.tbl_extend('force', self.commits or {}, commits)
       if lnum and not full then
-        blame.entries[lnum] = b[lnum]
+        local start_lnum = type(lnum) == 'table' and lnum[1] or lnum
+        local end_lnum = type(lnum) == 'table' and lnum[2] or lnum
+        for curr_lnum = start_lnum, end_lnum do
+          blame.entries[curr_lnum] = b[curr_lnum]
+        end
       else
         blame.entries = b
       end

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -152,7 +152,7 @@ end
 
 --- @async
 --- @param contents? string[]
---- @param lnum? integer
+--- @param lnum? integer|[integer, integer]
 --- @param revision? string
 --- @param opts? Gitsigns.BlameOpts
 --- @return table<integer,Gitsigns.BlameInfo?>

--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -214,7 +214,7 @@ end
 --- @async
 --- @param obj Gitsigns.GitObj
 --- @param contents? string[]
---- @param lnum? integer
+--- @param lnum? integer|[integer, integer]
 --- @param revision? string
 --- @param opts? Gitsigns.BlameOpts
 --- @return table<integer, Gitsigns.BlameInfo>
@@ -262,7 +262,7 @@ function M.run_blame(obj, contents, lnum, revision, opts)
       '--incremental',
       contents and { '--contents', '-' },
       opts.ignore_whitespace and '-w',
-      lnum and { '-L', lnum .. ',+1' },
+      lnum and { '-L', type(lnum) == 'table' and (lnum[1] .. ',' .. lnum[2]) or (lnum .. ',+1') },
       opts.extra_opts,
       uv.fs_stat(ignore_file) and { '--ignore-revs-file', ignore_file },
       revision,


### PR DESCRIPTION
I have this util for prefetching blame to make the popup show up faster, but it's not performant when fetching blame line individually, even when running them concurrently. Thus I changed the API to allow for fetching blame for a line range instead of just one line. I thought this functionality would be generally useful which is why I'm pushing upstream here, and also am thinking this prefetch utility in a cleaner form could also be upstreamed.

```lua
vim.api.nvim_create_autocmd({ 'BufEnter', 'CursorMoved', 'WinScrolled' }, {
  group = vim.api.nvim_create_augroup('gitsigns-prefetch-blame', { clear = true }),
  callback = function(opts)
    local bufnr = opts.buf
    local cache_entry = require('gitsigns.cache').cache[bufnr]
    if not cache_entry then
      return
    end
    local buf_line_count = vim.api.nvim_buf_line_count(bufnr)
    if blame_fetch_map[bufnr] then
      return
    end
    blame_fetch_map[bufnr] = true
    local config = require('gitsigns.config').config
    local gitsigns_async = require('gitsigns.async')
    ---@type fun(lnum: integer|[integer, integer], on_done: fun():nil): nil
    local prefetch_blame = gitsigns_async.create(
      2,
      ---@async
      ---@param lnum integer|[integer, integer]
      ---@param on_done fun():nil
      ---@return Gitsigns.BlameInfo?
      function(lnum, on_done)
        -- Defers error notification to hover keymap
        pcall(function() ---@async
          return cache_entry:get_blame(lnum, config.current_line_blame_opts)
        end)
        on_done()
      end
    )
    local cursor_lnum = vim.api.nvim_win_get_cursor(0)[1]
    local start_lnum = math.max(1, vim.fn.line('w0') - 10, cursor_lnum - 20)
    local end_lnum = math.min(buf_line_count, vim.fn.line('w$') + 10, cursor_lnum + 20)
    prefetch_blame({ start_lnum, end_lnum }, function()
      blame_fetch_map[bufnr] = false
    end)
  end,
})
```
