### PR TITLE
fix(blame): remove link highlight on whitespace

### DIFF
--- a/lua/gitsigns/actions/blame_line.lua
+++ b/lua/gitsigns/actions/blame_line.lua
@@ -115,7 +115,8 @@ local function create_blame_linespec(full, result, repo, fileformat, with_gh)
 
   --- @type Gitsigns.LineSpec
   local title = {
-    { result.abbrev_sha .. ' ', 'Directory', commit_url },
+    { result.abbrev_sha, 'Directory', commit_url },
+    { ' ', 'NormalFloat' },
   }
 
   if gh then


### PR DESCRIPTION
the link highlight for the commit hash was being applied on whitespace, which was a bit unseemly, especially for terminals that give an underline highlight when hovering over it. this pr changes the link highlight to only be on the commit hash
