### PR TITLE
fix(blame): do not show stale blames popup

### DIFF
--- a/lua/gitsigns/actions/blame_line.lua
+++ b/lua/gitsigns/actions/blame_line.lua
@@ -171,12 +171,15 @@ return function(opts)
 
   local fileformat = vim.bo[bufnr].fileformat
   local lnum = api.nvim_win_get_cursor(0)[1]
+  local function is_stale()
+    return api.nvim_get_current_buf() ~= bufnr or api.nvim_win_get_cursor(0)[1] ~= lnum
+  end
   local info = bcache:get_blame(lnum, opts)
   pcall(function()
     loading:close()
   end)
 
-  if not bcache:schedule() then
+  if not bcache:schedule() or is_stale() then
     return
   end
 
@@ -185,7 +188,7 @@ return function(opts)
   local blame_linespec =
     create_blame_linespec(opts.full, result, bcache.git_obj.repo, fileformat, false)
 
-  if not bcache:schedule() then
+  if not bcache:schedule() or is_stale() then
     return
   end
 
@@ -193,7 +196,7 @@ return function(opts)
 
   blame_linespec = create_blame_linespec(opts.full, result, bcache.git_obj.repo, fileformat, true)
 
-  if not bcache:schedule() then
+  if not bcache:schedule() or is_stale() then
     return
   end
 


### PR DESCRIPTION
When a blame takes a while to popup, when I discard it, it's pretty distracting that it pops up later when I'm somewhere else either in antoher buffer or line within the buffer. This pr prevents creating the popup when this situation occurs.
