### PR TITLE
fix(actions): allow bufnr to be 0

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -311,11 +311,11 @@ get_hunks({bufnr})                                      *gitsigns.get_hunks()*
                 Get hunk array for specified buffer.
 
                 Parameters: ~
-                    {bufnr} (integer): Buffer number, if not provided (or 0)
+                    {bufnr} (integer?): Buffer number, if not provided (or 0)
                             will use current buffer.
 
                 Returns: ~
-                    (table|nil): Array of hunk objects.
+                    (Gitsigns.Hunk.Hunk_Public[]?): Array of hunk objects.
                     Each hunk object has keys:
                         • `"type"`: String with possible values: "add", "change",
                           "delete"

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -571,9 +571,9 @@ end
 
 --- Get hunk array for specified buffer.
 ---
---- @param bufnr integer Buffer number, if not provided (or 0)
+--- @param bufnr integer? Buffer number, if not provided (or 0)
 ---             will use current buffer.
---- @return table|nil : Array of hunk objects.
+--- @return Gitsigns.Hunk.Hunk_Public[]? : Array of hunk objects.
 ---     Each hunk object has keys:
 ---         • `"type"`: String with possible values: "add", "change",
 ---           "delete"
@@ -588,7 +588,9 @@ end
 ---           • `"start"`: Line number (1-based)
 ---           • `"count"`: Line count
 M.get_hunks = function(bufnr)
-  bufnr = bufnr or current_buf()
+  if bufnr == nil or bufnr == 0 then
+    bufnr = current_buf()
+  end
   if not cache[bufnr] then
     return
   end


### PR DESCRIPTION
**Problem**: documentation mentions that `bufnr` can be 0 for `get_hunks`, but 0 is truthy, so the current logic does not work

**Solution**: properly check if the current buf should be used (same logic as `vim._resolve_bufnr`)

I also took the liberty of updating the type annotations to be more precise.

---

There are two other instances where the same logic is being used, but for them, **0 is not documented as being the current buf** (so I haven't updated them):

https://github.com/lewis6991/gitsigns.nvim/blob/1ee5c1fd068c81f9dd06483e639c2aa4587dc197/lua/gitsigns/attach.lua#L413-L431

https://github.com/lewis6991/gitsigns.nvim/blob/1ee5c1fd068c81f9dd06483e639c2aa4587dc197/lua/gitsigns/actions.lua#L71-L95

