### PR TITLE
feat: add ability to copy or open blame commit in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Deep buffer integration for Git
     - Enable with `setup({ current_line_blame = true })`.
     - Toggle with `:Gitsigns toggle_current_line_blame`
 
+  - Copy the commit SHA of the current line to the clipboard with `:Gitsigns copy_commit_sha`.
+
+  - Open the commit of the current line in your browser with `:Gitsigns open_commit_in_browser`.
+    - Uses GitHub CLI (`gh`) if available, otherwise parses the git remote URL.
+    - Supports GitHub, GitLab, and Bitbucket.
+
 </details>
 
 <details>
@@ -261,6 +267,9 @@ require('gitsigns').setup{
     map('n', '<leader>hb', function()
       gitsigns.blame_line({ full = true })
     end)
+
+    map('n', '<leader>hy', gitsigns.copy_commit_sha)
+    map('n', '<leader>ho', gitsigns.open_commit_in_browser)
 
     map('n', '<leader>hd', gitsigns.diffthis)
 

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -275,6 +275,20 @@ change_base({base}, {global}, {callback?})              *gitsigns.change_base()*
                     {base}   (string|nil): The object/revision to diff against.
                     {global} (boolean|nil): Change the base of all buffers.
 
+open_commit_in_browser({callback?})        *gitsigns.open_commit_in_browser()*
+                Open the commit of the current line in the browser.
+                Uses the GitHub CLI (`gh`) if available, otherwise attempts
+                to construct the URL from the git remote.
+
+                Attributes: ~
+                    {async}
+
+copy_commit_sha({callback?})                      *gitsigns.copy_commit_sha()*
+                Copy the commit SHA of the current line to the clipboard.
+
+                Attributes: ~
+                    {async}
+
 blame({callback?})                                          *gitsigns.blame()*
                 Run git-blame on the current file and open the results
                 in a scroll-bound vertical split.

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -646,6 +646,24 @@ M.blame = async.create(0, function()
   require('gitsigns.actions.blame').blame()
 end)
 
+--- Copy the commit SHA of the current line to the clipboard.
+---
+--- Attributes: ~
+---     {async}
+M.copy_commit_sha = async.create(0, function()
+  require('gitsigns.actions.blame_commit').copy_commit_sha()
+end)
+
+--- Open the commit of the current line in the browser.
+--- Uses the GitHub CLI (`gh`) if available, otherwise attempts
+--- to construct the URL from the git remote.
+---
+--- Attributes: ~
+---     {async}
+M.open_commit_in_browser = async.create(0, function()
+  require('gitsigns.actions.blame_commit').open_commit_in_browser()
+end)
+
 --- @async
 --- @param bcache Gitsigns.CacheEntry
 --- @param base string?

--- a/lua/gitsigns/actions/blame_commit.lua
+++ b/lua/gitsigns/actions/blame_commit.lua
@@ -1,0 +1,107 @@
+local async = require('gitsigns.async')
+local message = require('gitsigns.message')
+
+local cache = require('gitsigns.cache').cache
+local api = vim.api
+
+local M = {}
+
+--- Get the commit SHA for the current line
+--- @return string?, Gitsigns.CacheEntry?
+local function get_commit_sha()
+  local bufnr = api.nvim_get_current_buf()
+  local bcache = cache[bufnr]
+  if not bcache then
+    return
+  end
+
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local info = bcache:get_blame(lnum)
+  if not info then
+    message.warn('No blame information available for current line')
+    return
+  end
+
+  local sha = info.commit.sha
+  if not sha or tonumber('0x' .. sha) == 0 then
+    message.warn('Current line has no committed changes')
+    return
+  end
+
+  return sha, bcache
+end
+
+--- Copy the commit SHA of the current line to the clipboard
+--- Attributes: ~
+---     {async}
+M.copy_commit_sha = async.create(0, function()
+  local sha = get_commit_sha()
+  if not sha then
+    return
+  end
+
+  vim.fn.setreg('+', sha)
+  message.info('Copied commit SHA: %s', sha)
+end)
+
+--- Open the commit of the current line in the browser
+--- Attributes: ~
+---     {async}
+M.open_commit_in_browser = async.create(0, function()
+  local sha, bcache = get_commit_sha()
+  if not sha or not bcache then
+    return
+  end
+
+  -- Try using gh CLI first if available
+  local url = require('gitsigns.gh').commit_url(sha, bcache.git_obj.repo.toplevel)
+
+  -- Fallback to parsing remote URL
+  if not url then
+    local stdout = bcache.git_obj.repo:command(
+      { 'config', '--get', 'remote.origin.url' },
+      { text = true }
+    )
+    if stdout and #stdout > 0 then
+      local remote_url = vim.trim(stdout[1]):gsub('%.git$', '')
+      -- Convert SSH to HTTPS: git@github.com:user/repo -> https://github.com/user/repo
+      local host, path = remote_url:match('^git@([^:]+):(.+)$')
+      if host and path then
+        url = ('https://%s/%s/commit/%s'):format(host, path, sha)
+      elseif remote_url:match('^git://') then
+        url = ('%s/commit/%s'):format(remote_url:gsub('^git://', 'https://'), sha)
+      else
+        url = ('%s/commit/%s'):format(remote_url, sha)
+      end
+    end
+  end
+
+  if not url then
+    message.error('Could not determine remote URL for repository')
+    return
+  end
+
+  -- Determine platform-specific open command
+  local open_cmd
+  if vim.fn.has('mac') == 1 then
+    open_cmd = 'open'
+  elseif vim.fn.has('unix') == 1 then
+    open_cmd = 'xdg-open'
+  elseif vim.fn.has('win32') == 1 then
+    open_cmd = 'start'
+  else
+    message.error('Unsupported platform for opening URLs')
+    return
+  end
+
+  async.schedule()
+
+  vim.fn.system(('%s "%s"'):format(open_cmd, url))
+  if vim.v.shell_error == 0 then
+    message.info('Opened commit %s in browser', sha:sub(1, 7))
+  else
+    message.error('Failed to open URL in browser')
+  end
+end)
+
+return M

--- a/lua/gitsigns/message.lua
+++ b/lua/gitsigns/message.lua
@@ -3,6 +3,11 @@ local levels = vim.log.levels
 local M = {}
 
 --- @type fun(fmt: string, ...: string)
+M.info = vim.schedule_wrap(function(fmt, ...)
+  vim.notify(fmt:format(...), levels.INFO, { title = 'gitsigns' })
+end)
+
+--- @type fun(fmt: string, ...: string)
 M.warn = vim.schedule_wrap(function(fmt, ...)
   vim.notify(fmt:format(...), levels.WARN, { title = 'gitsigns' })
 end)


### PR DESCRIPTION
This PR adds functions to copy the blame commit SHA or open the blame in a browser.

## Changes

**New Functions:**
- `copy_commit_sha()` - Copies the commit SHA of the current line to the clipboard
- `open_commit_in_browser()` - Opens the commit of the current line in your browser
  - Uses GitHub CLI (gh) if available, otherwise parses the git remote URL
  - Supports GitHub, GitLab, and Bitbucket (SSH and HTTPS remotes)

**Additional:**
- Extended `message.lua` with `message.info()` for info-level notifications
- Updated README.md with feature documentation and suggested keybindings

**Usage**

```lua
-- Via command
:Gitsigns copy_commit_sha
:Gitsigns open_commit_in_browser

-- Or via keybindings
vim.keymap.set('n', '<leader>hy', '<cmd>Gitsigns copy_commit_sha<CR>')
vim.keymap.set('n', '<leader>ho', '<cmd>Gitsigns open_commit_in_browser<CR>')
```