### PR TITLE
fix(scm-rockspec): add 'plugin' to copy_directories

### DIFF
--- a/gitsigns.nvim-scm-1.rockspec
+++ b/gitsigns.nvim-scm-1.rockspec
@@ -32,6 +32,7 @@ end
 build = {
   type = 'builtin',
   copy_directories = {
-    'doc'
+    'doc',
+    'plugin'
   }
 }


### PR DESCRIPTION
Note: The updated scm rockspec will need to be uploaded to luarocks.org (Technically, it's an scm-2 now, but you can also force upload).