### PR TITLE
Close blame buffer on closure of source buffer

### DIFF
--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -453,7 +453,7 @@ function M.blame(opts)
 
   local group = api.nvim_create_augroup('GitsignsBlame', {})
 
-  api.nvim_create_autocmd('BufHidden', {
+  api.nvim_create_autocmd({ 'BufHidden', 'QuitPre' }, {
     buffer = bufnr,
     group = group,
     once = true,


### PR DESCRIPTION
When the blame buffer is open and the source buffer is closed, this results in an error

> E855: Autocommands caused command to abort

and while this closes the blame buffer, the source buffer remains open.

We can fix this by calling `nvim_win_close` on `QuitPre`. We're already doing this on `BufHidden`, so can add `QuitPre` to the existing autocommand.