### PR TITLE
fix(word_diff): no "No newline at end of file" shown in popup

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -1273,6 +1273,11 @@ GitSignsDeletePreview
         Used for deleted lines in previews.
 
         Fallbacks: `GitGutterDeleteLine`, `SignifyLineDelete`, `DiffDelete`
+                                                        *hl-GitSignsNoEOLPreview*
+GitSignsNoEOLPreview
+        Used for "No newline at end of file".
+
+        Fallbacks: `DiffNoEOL`, `Constant`
                                                         *hl-GitSignsCurrentLineBlame*
 GitSignsCurrentLineBlame
         Used for current line blame.

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -126,6 +126,14 @@ vim.list_extend(M.hls, {
     },
   },
 
+  {
+    GitSignsNoEOLPreview = {
+      'DiffNoEOL',
+      'Constant',
+      desc = 'Used for "No newline at end of file".',
+    },
+  },
+
   { GitSignsCurrentLineBlame = { 'NonText', desc = 'Used for current line blame.' } },
 
   {

--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -578,6 +578,15 @@ function M.linespec_for_hunk(hunk, fileformat)
       }
       hls[#hls + 1] = { { spec.sym .. l, { mark } } }
     end
+    if config.diff_opts.internal then
+      if
+        spec.lines == removed and hunk.removed.no_nl_at_eof
+        or spec.lines == added and hunk.added.no_nl_at_eof
+      then
+        local mark = { start_row = 0, end_row = 1, hl_group = 'GitSignsNoEOLPreview' }
+        hls[#hls + 1] = { { spec.sym .. '\\ No newline at end of file', { mark } } }
+      end
+    end
   end
 
   if config.diff_opts.internal then

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -970,6 +970,25 @@ describe('gitsigns (with screen)', function()
 
     check_screen(true)
   end)
+
+  it('shows "No newline at end of file" in preview popup', function()
+    setup_test_repo({ test_file_text = { 'a' } })
+    setup_gitsigns(config)
+    screen:try_resize(30, 10)
+    edit(test_file)
+    wait_for_attach()
+
+    -- Remove newline at end of file (`printf a >a`)
+    local file_path = scratch .. '/dummy.txt'
+    local f = assert(io.open(file_path, 'wb'))
+    f:write('a') -- Write without trailing newline
+    f:close()
+
+    command('checktime')
+    helpers.sleep(50)
+    feed('mhp')
+    screen:expect({ any = [[No newline at end of file]] })
+  end)
 end)
 
 describe('gitsigns attach', function()


### PR DESCRIPTION
Also add `GitSignsNoEOLPreivew` hlgroup.
* https://github.com/tpope/vim-fugitive/blob/2019e0e4139390f485a024d7a2411218b004a5b3/syntax/fugitive.vim#L30
* https://github.com/neovim/neovim/blob/35a7642647858f7b4ddc204ee869c399b678e7e8/runtime/syntax/diff.vim#L379

Test
```sh
mkdir ./repro && cd ./repro && git init
echo a >a && git add . && git commit -m 'this file has newline'
printf a >a && nvim --clean --cmd 'set rtp^=..' a +'lua vim.defer_fn(function() vim.cmd[[Gitsigns preview_hunk]] end, 100)'
```
