### PR TITLE
fix(util.lua): skip boolean values in flatten function to prevent errors

### DIFF
--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -458,6 +458,8 @@ function M.flatten(x)
       ret[#ret + 1] = v
     elseif v == nil then
       -- skip
+    elseif type(v) == 'boolean' then
+      -- skip booleans fix
     else
       error('Expected string or table, got ' .. type(v))
     end


### PR DESCRIPTION
Fix issues: #1457