### PR TITLE
feat(setqflist): include untracked files with 'all' target

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -160,7 +160,9 @@ setqflist({target}, {opts}, {callback})                 *gitsigns.setqflist()*
                      • `"attached"`: All attached buffers.
                      • `"all"`: All modified files for each git
                        directory of all attached buffers in addition
-                       to the current working directory.
+                       to the current working directory. When
+                       `attach_to_untracked` is enabled, untracked
+                       files are also included.
         {opts}     (`Gitsigns.SetqflistOpts?`): Additional options.
                    • {use_location_list}: (`boolean?`)
                      Populate the location list instead of the quickfix list.

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -896,7 +896,9 @@ CP.show_commit = complete_heads
 ---   - `"attached"`: All attached buffers.
 ---   - `"all"`: All modified files for each git
 ---     directory of all attached buffers in addition
----     to the current working directory.
+---     to the current working directory. When
+---     `attach_to_untracked` is enabled, untracked
+---     files are also included.
 --- @param opts Gitsigns.SetqflistOpts? Additional options.
 --- @param callback? fun(err?: string)
 function M.setqflist(target, opts, callback)

--- a/lua/gitsigns/actions/qflist.lua
+++ b/lua/gitsigns/actions/qflist.lua
@@ -74,7 +74,7 @@ local function buildqflist(target)
     end
 
     for _, r in pairs(repos) do
-      for _, f in ipairs(r:files_changed(config.base)) do
+      for _, f in ipairs(r:files_changed(config.base, config.attach_to_untracked)) do
         local f_abs = r.toplevel .. '/' .. f
         local stat = uv.fs_stat(f_abs)
         if stat and stat.type == 'file' then


### PR DESCRIPTION
## Summary
- When `setqflist('all')` is called and `attach_to_untracked` is enabled, untracked files are now included in the quickfix list
- `files_changed()` accepts a new `include_untracked` parameter: uses `??` status from `git status --porcelain` (default base) or `git ls-files --others --exclude-standard` (custom base)
- Updated docs for the `"all"` target to document the new behavior

Closes #829

## Test plan
- [ ] Set `attach_to_untracked = true` in config
- [ ] Create an untracked file in the repo
- [ ] Run `:Gitsigns setqflist all` and verify the untracked file appears in the quickfix list
- [ ] Run with `attach_to_untracked = false` and verify untracked files are excluded
- [ ] Test with a custom `config.base` to verify untracked files are included via `ls-files`

Assisted with claude code