### PR TITLE
fix(word_diff): "No newline at eof" should show once for single hunk

### DIFF
--- a/lua/gitsigns/hunks.lua
+++ b/lua/gitsigns/hunks.lua
@@ -575,15 +575,6 @@ function M.linespec_for_hunk(hunk, fileformat)
       }
       hls[#hls + 1] = { { spec.sym .. l, { mark } } }
     end
-    if config.diff_opts.internal then
-      if
-        spec.lines == removed and hunk.removed.no_nl_at_eof
-        or spec.lines == added and hunk.added.no_nl_at_eof
-      then
-        local mark = { start_row = 0, end_row = 1, hl_group = 'GitSignsNoEOLPreview' }
-        hls[#hls + 1] = { { spec.sym .. '\\ No newline at end of file', { mark } } }
-      end
-    end
   end
 
   if config.diff_opts.internal then
@@ -610,6 +601,17 @@ function M.linespec_for_hunk(hunk, fileformat)
         start_col = region[3],
         end_col = region[4],
       }
+    end
+
+    local no_nl_at_eof ---@type integer?
+    if hunk.removed.no_nl_at_eof and not hunk.added.no_nl_at_eof then
+      no_nl_at_eof = hunk.removed.count + 1
+    elseif not hunk.removed.no_nl_at_eof and hunk.added.no_nl_at_eof then
+      no_nl_at_eof = hunk.removed.count + hunk.added.count + 1
+    end
+    if no_nl_at_eof then
+      local mark = { start_row = 0, end_row = 1, hl_group = 'GitSignsNoEOLPreview' }
+      table.insert(hls, no_nl_at_eof, { { '\\ No newline at end of file', { mark } } })
     end
   end
 

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -978,20 +978,19 @@ describe('gitsigns (with screen)', function()
   it('shows "No newline at end of file" in preview popup', function()
     setup_test_repo({ test_file_text = { 'a' } })
     setup_gitsigns(config)
-    screen:try_resize(30, 10)
+    screen:try_resize(30, 5)
     edit(test_file)
     wait_for_attach()
 
     -- Remove newline at end of file (`printf a >a`)
-    local file_path = scratch .. '/dummy.txt'
-    local f = assert(io.open(file_path, 'wb'))
+    local f = assert(io.open(test_file, 'wb'))
     f:write('a') -- Write without trailing newline
     f:close()
 
     command('checktime')
     helpers.sleep(50)
     feed('mhp')
-    screen:expect({ any = [[No newline at end of file]] })
+    screen:expect({ any = [[\ No newline at end of file]] })
   end)
 end)
 


### PR DESCRIPTION
Problem:
When use `require('gitsigns.diff_int').run_diff` I find
"no_nl_at_eof=true" can be set for both removed/added hunk, this make
"\ No newline at eof" appear multiple times.

Solution:
* Only show no_nl_at_eof when it changed, remove uselss +/- prefix.
* Also insert no_nl_at_eof after insert word diff to hls array
to avoid messup the hls[] array index.
