### PR TITLE
fix: nowait blame bindings

### DIFF
--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -453,6 +453,7 @@ function M.blame(opts)
   end, {
     desc = 'Reblame at commit',
     buffer = blm_bufnr,
+    nowait = true,
   })
 
   pmap('n', 'd', function()
@@ -460,6 +461,7 @@ function M.blame(opts)
   end, {
     desc = 'Diff (tab)',
     buffer = blm_bufnr,
+    nowait = true,
   })
 
   pmap('n', 'R', function()
@@ -467,6 +469,7 @@ function M.blame(opts)
   end, {
     desc = 'Reblame at commit parent',
     buffer = blm_bufnr,
+    nowait = true,
   })
 
   pmap('n', 's', function()
@@ -474,6 +477,7 @@ function M.blame(opts)
   end, {
     desc = 'Show commit in a vertical split',
     buffer = blm_bufnr,
+    nowait = true,
   })
 
   pmap('n', 'S', function()
@@ -481,6 +485,7 @@ function M.blame(opts)
   end, {
     desc = 'Show commit in a new tab',
     buffer = blm_bufnr,
+    nowait = true,
   })
 
   menu('GitsignsBlame', {


### PR DESCRIPTION
If a user had `s` bound, for instance, to a surround action (so `sa`, `sr`, `sd`), pressing `s` in the `:Gitsigns blame` view would wait instead of applying the binding immediately. Using a `nowait` binding would instead just terminate the chord and apply the binding.