### PR TITLE
fix(qflist): sanitize NUL bytes before VimL conversion

### DIFF
--- a/lua/gitsigns/actions/qflist.lua
+++ b/lua/gitsigns/actions/qflist.lua
@@ -24,11 +24,8 @@ local function hunks_to_qflist(buf_or_filename, hunks, qflist)
       hunk.added.start,
       hunk.added.count ~= 1 and ',' .. tostring(hunk.added.count) or ''
     )
-    local text = ('%-7s (%s): %s'):format(
-      kind,
-      header,
-      hunk.added.lines[1] or hunk.removed.lines[1]
-    )
+    local line = hunk.added.lines[1] or hunk.removed.lines[1] or ''
+    local text = ('%-7s (%s): %s'):format(kind, header, util.lua2viml_str(line))
     qflist[#qflist + 1] = {
       bufnr = type(buf_or_filename) == 'number' and buf_or_filename or nil,
       filename = type(buf_or_filename) == 'string' and buf_or_filename or nil,

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -60,6 +60,18 @@ function M.file_lines(path)
   return vim.split(contents, '\n')
 end
 
+--- Convert a Lua string to a value accepted by VimL APIs.
+--- @param line string
+--- @return string
+function M.lua2viml_str(line)
+  -- VimL String values cannot safely carry embedded NUL bytes. Replace them
+  -- with a readable sentinel before crossing the vim.fn.* boundary.
+  if line:find('\0', 1, true) then
+    return (line:gsub('%z', '<NUL>'))
+  end
+  return line
+end
+
 M.path_sep = package.config:sub(1, 1)
 
 --- @param ... integer


### PR DESCRIPTION
Add util.lua2viml_str() to normalize Lua strings for VimL boundaries by
replacing embedded NUL bytes with "<NUL>", and use it when building
quickfix entry text.
