### PR TITLE
fix(diff): respect -diff attributes in attach and setqflist

### DIFF
--- a/lua/gitsigns/actions/qflist.lua
+++ b/lua/gitsigns/actions/qflist.lua
@@ -71,20 +71,25 @@ local function buildqflist(target)
     end
 
     for _, r in pairs(repos) do
-      for _, f in ipairs(r:files_changed(config.base, config.attach_to_untracked)) do
-        local f_abs = r.toplevel .. '/' .. f
-        local stat = uv.fs_stat(f_abs)
-        if stat and stat.type == 'file' then
-          ---@type string
-          local obj
-          if config.base and config.base ~= ':0' then
-            obj = config.base .. ':' .. f
-          else
-            obj = ':0:' .. f
+      local changed_files = r:files_changed(config.base, config.attach_to_untracked)
+      local diff_attrs = r:check_attr('diff', changed_files)
+
+      for _, f in ipairs(changed_files) do
+        if diff_attrs[f] ~= 'unset' then
+          local f_abs = r.toplevel .. '/' .. f
+          local stat = uv.fs_stat(f_abs)
+          if stat and stat.type == 'file' then
+            ---@type string
+            local obj
+            if config.base and config.base ~= ':0' then
+              obj = config.base .. ':' .. f
+            else
+              obj = ':0:' .. f
+            end
+            local a = r:get_show_text(obj)
+            local hunks = run_diff(a, util.file_lines(f_abs))
+            hunks_to_qflist(f_abs, hunks, qflist)
           end
-          local a = r:get_show_text(obj)
-          local hunks = run_diff(a, util.file_lines(f_abs))
-          hunks_to_qflist(f_abs, hunks, qflist)
         end
       end
     end

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -364,6 +364,13 @@ M.attach = throttle_async({ hash = 1 }, function(cbuf, ctx, aucmd)
     return
   end
 
+  local relpath = git_obj.relpath --[[@as string]]
+  local diff_attr = git_obj.repo:check_attr('diff', { relpath })[relpath]
+  if diff_attr == 'unset' then
+    dprint('File has -diff attribute')
+    return
+  end
+
   -- On windows os.tmpname() crashes in callback threads so initialise this
   -- variable on the main thread.
   async.schedule()

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -341,6 +341,36 @@ function M:files_changed(base, include_untracked)
   return ret
 end
 
+--- @async
+--- @param attr string
+--- @param files string[]
+--- @return table<string,'set'|'unset'|'unspecified'|string>
+function M:check_attr(attr, files)
+  local ret = {} --- @type table<string,'set'|'unset'|'unspecified'|string>
+
+  if #files == 0 then
+    return ret
+  end
+
+  for _, f in ipairs(files) do
+    ret[f] = 'unspecified'
+  end
+
+  local output = self:command({ 'check-attr', attr, '--stdin' }, { stdin = files })
+  local sep = ': ' .. attr .. ': '
+
+  for _, line in ipairs(output) do
+    local parts = vim.split(line, sep, { plain = true })
+    local file = parts[1]
+    if file and #parts >= 2 then
+      local value = table.concat(parts, sep, 2)
+      ret[file] = value
+    end
+  end
+
+  return ret
+end
+
 --- @param encoding string
 --- @return boolean
 local function iconv_supported(encoding)

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -212,6 +212,26 @@ describe('gitsigns (with screen)', function()
       check({ status = { head = 'main' } })
     end)
 
+    it('does not attach to nodiff files', function()
+      write_to_file(scratch .. '/.gitattributes', { '*.bar -diff' })
+
+      local nodiff_file = scratch .. '/dummy.bar'
+      write_to_file(nodiff_file, { 'dummy' })
+
+      git('add', scratch .. '/.gitattributes', nodiff_file)
+      git('commit', '-m', 'add nodiff file')
+
+      edit(nodiff_file)
+
+      match_debug_messages({
+        'attach.attach(1): Attaching (trigger=BufReadPost)',
+        np(revparse_pat),
+        np('attach%.attach%(1%): File has %-diff attribute'),
+      })
+
+      check({ status = { head = 'main' }, signs = {} })
+    end)
+
     it("doesn't attach to non-existent files", function()
       edit(newfile)
 
@@ -525,6 +545,7 @@ describe('gitsigns (with screen)', function()
         np(
           'system.system: git .* %-%-git%-dir .* %-%-stage %-%-others %-%-exclude%-standard %-%-eol.*'
         ),
+        np('system.system: git .* check%-attr diff %-%-stdin'),
         n('attach.attach(1): User on_attach() returned false'),
       })
     end)


### PR DESCRIPTION
Query git attributes via `check-attr diff` and skip files with
`diff=unset`. Also prevent attaching to buffers marked `-diff`.

Resolves #1402
