### PR TITLE
Fix accessible paths being ommited from normalization on windows systems

### DIFF
--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -625,12 +625,14 @@ function M.get_info(dir, gitdir, worktree)
   end
   --- @cast stdout [string, string, string]
 
-  local toplevel_r = stdout[1]
-  local gitdir_r = stdout[2]
+  -- Normalize path for comparison
+  local toplevel_r = util.cygpath(stdout[1], 'mixed')
+  local gitdir_r = util.cygpath(stdout[2], 'mixed')
 
   -- On windows, git will emit paths with `/` but dir may contain `\` so need to
   -- normalize.
-  if dir and not vim.startswith(vim.fs.normalize(dir), toplevel_r) then
+  -- Normalize with util.cygpath (`/\` not enough if `C:\xxx` vs. `/c/xxx`)
+  if dir and not vim.startswith(util.cygpath(dir, 'mixed'), toplevel_r) then
     log.dprintf("'%s' is outside worktree '%s'", dir, toplevel_r)
     -- outside of worktree
     return

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -426,7 +426,7 @@ local has_cygpath --- @type boolean?
 
 --- @async
 --- @param path string
---- @param mode? 'unix'|'windows' (default: 'windows')
+--- @param mode? 'unix'|'windows'|'mixed' (default: 'windows')
 --- @return string
 function M.cygpath(path, mode)
   local async = require('gitsigns.async')
@@ -436,7 +436,9 @@ function M.cygpath(path, mode)
     has_cygpath = is_win and vim.fn.executable('cygpath') == 1
   end
 
-  if not has_cygpath or uv.fs_stat(path) then
+  -- skip fs_stat.
+  -- For comparison, normalization *required* even if path is accessible.
+  if not has_cygpath then
     return path
   end
 


### PR DESCRIPTION
This problem affects me and gould-3m has found a solution, I hope there's no side effects.
This fixes when vim can see the path exists, but incorrectly omits it from being normalized.
I'm on windows MSYS2. I think this also fixes things on Cygwin, but not sure.