### PR TITLE
fix(windows): normalize repo path comparisons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,34 @@ jobs:
       - name: Run Test
         run: make test
 
+  windows_smoke:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            mingw-w64-ucrt-x86_64-neovim
+
+      - name: Show Versions
+        run: |
+          git --version
+          nvim --version | head -n 1
+
+      - name: Run Windows Smoke Tests
+        run: nvim --headless -u test/windows/init.lua -l test/windows/run.lua
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,4 +28,5 @@
 
 ## Commit & Pull Request Guidelines
 - History follows a Conventional Commit style: `<type>(<scope>): <verb phrase>` (for instance, `fix(blame): close blame window on bufhidden`), so match that pattern and keep subjects under 72 characters.
+- Commit messages must have a detailed body explaining the problem and solution.
 - Ensure `make build`, the relevant `make test-*`, and `make doc-check` all pass locally.

--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -271,7 +271,7 @@ function M.run_blame(obj, contents, lnum, revision, opts)
       uv.fs_stat(ignore_file) and { '--ignore-revs-file', ignore_file },
       revision,
       '--',
-      obj.file,
+      obj.relpath,
     }),
     {
       stdin = contents_str,

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -536,6 +536,24 @@ function M.get(cwd, gitdir, toplevel)
   end)
 end
 
+local has_win_cygpath = vim.fn.has('win32') == 1 and vim.fn.executable('cygpath') == 1
+
+--- Normalize repo discovery paths for comparisons and returned repo metadata.
+--- On Windows with MSYS/Cygwin Git, convert `/c/...` style paths to mixed
+--- Windows form before applying `vim.fs.normalize()`.
+--- @async
+--- @param path? string
+--- @return string?
+local function normalize_path(path)
+  if not path then
+    return
+  end
+  if has_win_cygpath then
+    path = util.cygpath(path, 'mixed')
+  end
+  return vim.fs.normalize(path)
+end
+
 --- @async
 --- @param gitdir string
 --- @param head_str string
@@ -625,19 +643,21 @@ function M.get_info(dir, gitdir, worktree)
   end
   --- @cast stdout [string, string, string]
 
-  local toplevel_r = stdout[1]
-  local gitdir_r = stdout[2]
+  local toplevel_r = assert(normalize_path(stdout[1]))
+  local gitdir_r = assert(normalize_path(stdout[2]))
+  dir = normalize_path(dir)
+  gitdir = normalize_path(gitdir)
 
   -- On windows, git will emit paths with `/` but dir may contain `\` so need to
   -- normalize.
-  if dir and not vim.startswith(vim.fs.normalize(dir), toplevel_r) then
+  if dir and not vim.startswith(dir, toplevel_r) then
     log.dprintf("'%s' is outside worktree '%s'", dir, toplevel_r)
     -- outside of worktree
     return
   end
 
   if not has_abs_gd then
-    gitdir_r = assert(uv.fs_realpath(gitdir_r))
+    gitdir_r = assert(normalize_path(uv.fs_realpath(gitdir_r)))
   end
 
   if gitdir and not worktree and gitdir ~= gitdir_r then
@@ -648,7 +668,7 @@ function M.get_info(dir, gitdir, worktree)
     toplevel = toplevel_r,
     gitdir = gitdir_r,
     abbrev_head = process_abbrev_head(gitdir_r, stdout[3], toplevel_r),
-    detached = toplevel_r and gitdir_r ~= toplevel_r .. '/.git',
+    detached = gitdir_r ~= assert(normalize_path(Path.join(toplevel_r, '.git'))),
   }
 end
 

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -426,7 +426,7 @@ local has_cygpath --- @type boolean?
 
 --- @async
 --- @param path string
---- @param mode? 'unix'|'windows' (default: 'windows')
+--- @param mode? 'unix'|'windows'|'mixed' (default: 'windows')
 --- @return string
 function M.cygpath(path, mode)
   local async = require('gitsigns.async')

--- a/test/blame_spec.lua
+++ b/test/blame_spec.lua
@@ -67,4 +67,49 @@ describe('blame', function()
     eq({ 3, 0 }, helpers.api.nvim_win_get_cursor(0))
     eq('gitsigns-blame', exec_lua('return vim.bo.filetype'))
   end)
+
+  it('uses a repo-relative path when running blame', function()
+    local args = exec_lua(function()
+      local blame = require('gitsigns.git.blame')
+
+      local captured_args
+      local obj = {
+        file = 'C:/msys64/home/User/.dotfiles/.config/nvim/lua/mappings.lua',
+        relpath = '.config/nvim/lua/mappings.lua',
+        object_name = ('a'):rep(40),
+        repo = {
+          abbrev_head = 'main',
+          toplevel = 'C:/msys64/home/User/.dotfiles',
+          command = function(_, argv, spec)
+            captured_args = vim.deepcopy(argv)
+            spec.stdout(
+              nil,
+              table.concat({
+                ('a'):rep(40) .. ' 1 1 1',
+                'author tester',
+                'author-mail <tester@example.com>',
+                'author-time 0',
+                'author-tz +0000',
+                'committer tester',
+                'committer-mail <tester@example.com>',
+                'committer-time 0',
+                'committer-tz +0000',
+                'summary init',
+                'filename .config/nvim/lua/mappings.lua',
+                '',
+              }, '\n')
+            )
+            return {}, nil, 0
+          end,
+        },
+      }
+
+      blame.run_blame(obj, { 'line' }, 1, nil, {})
+
+      return captured_args
+    end)
+
+    eq('--', args[#args - 1])
+    eq('.config/nvim/lua/mappings.lua', args[#args])
+  end)
 end)

--- a/test/windows/gitsigns.lua
+++ b/test/windows/gitsigns.lua
@@ -1,0 +1,141 @@
+local H = require('windows.harness')
+local async = require('gitsigns.async')
+
+local M = {}
+
+local initialized = false
+
+local function pack_len(...)
+  return { n = select('#', ...), ... }
+end
+
+local function unpack_len(t, first)
+  return unpack(t, first or 1, t.n or table.maxn(t))
+end
+
+function M.setup()
+  if initialized then
+    return
+  end
+
+  require('gitsigns').setup({
+    _test_mode = true,
+    attach_to_untracked = true,
+    auto_attach = false,
+    debug_mode = true,
+    update_debounce = 5,
+  })
+
+  H.after_each(function()
+    pcall(function()
+      require('gitsigns').detach_all()
+    end)
+
+    vim.env.GIT_DIR = nil
+    vim.env.GIT_WORK_TREE = nil
+  end)
+
+  initialized = true
+end
+
+function M.setup_repo(opts)
+  opts = opts or {}
+
+  local root = H.tmpdir()
+  local gitdir = H.join(root, '.git')
+  local relpath = opts.relpath or 'test.txt'
+  local file = H.join(root, relpath)
+
+  H.system({ 'git', 'init', '-b', 'main' }, { cwd = root })
+  H.system({ 'git', 'config', 'user.email', 'tester@example.com' }, { cwd = root })
+  H.system({ 'git', 'config', 'user.name', 'tester' }, { cwd = root })
+
+  H.write_file(file, opts.lines or { 'hello', 'world' })
+
+  H.system({ 'git', 'add', relpath }, { cwd = root })
+  H.system({ 'git', 'commit', '-m', 'init' }, { cwd = root })
+
+  return {
+    file = file,
+    gitdir = gitdir,
+    relpath = relpath,
+    root = root,
+  }
+end
+
+function M.with_repo(fn, opts)
+  local repo = M.setup_repo(opts)
+  local result --- @type any[]?
+  local ok, err = xpcall(function()
+    result = pack_len(fn(repo))
+  end, debug.traceback)
+  H.cleanup(repo.root)
+  if not ok then
+    error(err, 0)
+  end
+  return unpack_len(result or { n = 0 })
+end
+
+function M.wait_for_attach(bufnr, timeout)
+  H.wait_for(function()
+    return require('gitsigns.cache').cache[bufnr] ~= nil
+  end, {
+    timeout = timeout or 5000,
+    msg = ('gitsigns did not attach to buffer %d'):format(bufnr),
+  })
+  return require('gitsigns.cache').cache[bufnr]
+end
+
+--- @param repo {file: string, gitdir: string, relpath: string, root: string}
+--- @param file? string
+--- @return Gitsigns.GitContext
+function M.context(repo, file)
+  return {
+    file = file or repo.file,
+    gitdir = repo.gitdir,
+    toplevel = repo.root,
+  }
+end
+
+--- @param bufnr integer
+--- @param ctx? Gitsigns.GitContext
+function M.attach(bufnr, ctx)
+  async.run(require('gitsigns.attach').attach, bufnr, ctx, 'windows-smoke'):wait(5000)
+
+  return M.wait_for_attach(bufnr, 5000)
+end
+
+--- @param bufnr integer
+--- @return Gitsigns.CacheEntry
+function M.update(bufnr)
+  async.run(require('gitsigns.manager').update, bufnr):wait(5000)
+  return assert(require('gitsigns.cache').cache[bufnr])
+end
+
+--- @param bufnr integer
+--- @return Gitsigns.CacheEntry
+function M.stage_hunks(bufnr)
+  local cache = assert(require('gitsigns.cache').cache[bufnr])
+  local Path = require('gitsigns.util').Path
+
+  if not Path.exists(cache.git_obj.file) then
+    error(('expected git_obj.file to exist: %s'):format(cache.git_obj.file), 2)
+  end
+
+  async
+    .run(function()
+      cache.git_obj:lock(function()
+        local hunks = cache.hunks
+        assert(hunks and #hunks > 0, 'expected hunks to stage')
+        local err = cache.git_obj:stage_hunks(hunks)
+        if err then
+          error(err)
+        end
+      end)
+    end)
+    :wait(5000)
+
+  return cache
+end
+
+return M

--- a/test/windows/harness.lua
+++ b/test/windows/harness.lua
@@ -1,0 +1,147 @@
+local M = {}
+
+local tests = {}
+local after_each_hooks = {}
+local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
+
+local function pack_len(...)
+  return { n = select('#', ...), ... }
+end
+
+local function unpack_len(t, first)
+  return unpack(t, first or 1, t.n or table.maxn(t))
+end
+
+local function format_cmd(cmd)
+  return table.concat(cmd, ' ')
+end
+
+function M.it(name, fn)
+  tests[#tests + 1] = { name = name, fn = fn }
+end
+
+function M.after_each(fn)
+  after_each_hooks[#after_each_hooks + 1] = fn
+end
+
+function M.eq(expected, actual, msg)
+  if not vim.deep_equal(expected, actual) then
+    error(msg or ('Expected %s, got %s'):format(vim.inspect(expected), vim.inspect(actual)), 2)
+  end
+end
+
+function M.ok(value, msg)
+  if not value then
+    error(msg or 'Expected a truthy value', 2)
+  end
+end
+
+function M.trim(value)
+  return vim.trim(value)
+end
+
+--- @param path string
+--- @param mode? 'unix'|'windows'|'mixed'
+--- @return string
+function M.cygpath(path, mode)
+  return M.trim(M.system({ 'cygpath', '--absolute', '--' .. (mode or 'windows'), path }).stdout)
+end
+
+function M.wait_for(predicate, opts)
+  opts = opts or {}
+  local timeout = opts.timeout or 2000
+  local interval = opts.interval or 10
+
+  local done = vim.wait(timeout, function()
+    local ok, result = pcall(predicate)
+    return ok and result
+  end, interval, true)
+
+  if not done then
+    error(opts.msg or ('Timed out after %dms'):format(timeout), 2)
+  end
+end
+
+function M.system(cmd, opts)
+  if not vim.system then
+    error('vim.system is required for the windows smoke harness', 2)
+  end
+
+  opts = vim.tbl_extend('force', { text = true }, opts or {})
+
+  local obj = vim.system(cmd, opts):wait(opts.timeout)
+  if obj.code ~= 0 then
+    error(
+      ('command failed (%d): %s\nstdout:\n%s\nstderr:\n%s'):format(
+        obj.code,
+        format_cmd(cmd),
+        obj.stdout or '',
+        obj.stderr or ''
+      ),
+      2
+    )
+  end
+
+  return obj
+end
+
+function M.join(...)
+  return vim.fs.joinpath(...)
+end
+
+function M.edit(path)
+  vim.cmd.edit(vim.fn.fnameescape(path))
+end
+
+function M.mkdir(path)
+  if vim.fn.isdirectory(path) == 1 then
+    return
+  end
+  local ok = vim.fn.mkdir(path, 'p')
+  M.ok(ok == 1, ('Failed to create directory %s'):format(path))
+end
+
+function M.write_file(path, lines)
+  local parent = vim.fs.dirname(path)
+  if parent then
+    M.mkdir(parent)
+  end
+  vim.fn.writefile(lines, path)
+end
+
+function M.cleanup(path)
+  if path and path ~= '' then
+    vim.fn.delete(path, 'rf')
+  end
+end
+
+function M.tmpdir()
+  local path = vim.fn.tempname()
+  M.cleanup(path)
+  M.mkdir(path)
+  return uv.fs_realpath(path) or path
+end
+
+function M.run()
+  local failures = 0
+
+  for _, test in ipairs(tests) do
+    local ok, err = xpcall(test.fn, debug.traceback)
+    if ok then
+      print(('ok - %s'):format(test.name))
+    else
+      failures = failures + 1
+      print(('not ok - %s'):format(test.name))
+      print(err)
+    end
+
+    for _, hook in ipairs(after_each_hooks) do
+      pcall(hook)
+    end
+    pcall(vim.cmd, 'silent! %bwipeout!')
+  end
+
+  return failures
+end
+
+return M

--- a/test/windows/init.lua
+++ b/test/windows/init.lua
@@ -1,0 +1,15 @@
+local root = vim.fn.getcwd()
+
+vim.opt.runtimepath:prepend(root)
+vim.opt.packpath = vim.opt.runtimepath:get()
+
+package.path = table.concat({
+  root .. '/lua/?.lua',
+  root .. '/lua/?/init.lua',
+  root .. '/test/?.lua',
+  root .. '/test/?/init.lua',
+  package.path,
+}, ';')
+
+vim.o.shadafile = 'NONE'
+vim.o.swapfile = false

--- a/test/windows/run.lua
+++ b/test/windows/run.lua
@@ -1,0 +1,11 @@
+require('windows.gitsigns').setup()
+
+require('windows.smoke')
+
+local failures = require('windows.harness').run()
+
+if failures > 0 then
+  vim.cmd.cquit(failures)
+else
+  vim.cmd.qa()
+end

--- a/test/windows/smoke.lua
+++ b/test/windows/smoke.lua
@@ -1,0 +1,219 @@
+local async = require('gitsigns.async')
+local h = require('windows.harness')
+local gs = require('windows.gitsigns')
+
+--- @param fn function
+--- @param name string
+--- @return integer, any
+local function find_upvalue(fn, name)
+  local i = 1
+  while true do
+    local upname, value = debug.getupvalue(fn, i)
+    if not upname then
+      error(('missing upvalue: %s'):format(name), 2)
+    end
+    if upname == name then
+      return i, value
+    end
+    i = i + 1
+  end
+end
+
+--- @param fn function
+--- @param replacements table<string, any>
+--- @param cb fun()
+local function with_upvalues(fn, replacements, cb)
+  local original = {} --- @type {index: integer, value: any}[]
+
+  for name, value in pairs(replacements) do
+    local index, old_value = find_upvalue(fn, name)
+    original[#original + 1] = { index = index, value = old_value }
+    debug.setupvalue(fn, index, value)
+  end
+
+  local ok, err = xpcall(cb, debug.traceback)
+
+  for i = #original, 1, -1 do
+    local entry = original[i]
+    debug.setupvalue(fn, entry.index, entry.value)
+  end
+
+  if not ok then
+    error(err, 0)
+  end
+end
+
+h.it('Repo.get_info normalizes mixed native and unix-style paths', function()
+  if vim.fn.has('win32') ~= 1 then
+    return
+  end
+  h.eq(1, vim.fn.executable('cygpath'), 'cygpath missing from PATH')
+
+  local Repo = require('gitsigns.git.repo')
+
+  gs.with_repo(function(repo)
+    local native_root = repo.root
+    local native_gitdir = repo.gitdir
+    local unix_root = h.cygpath(native_root, 'unix')
+    local unix_gitdir = h.cygpath(native_gitdir, 'unix')
+    local expected_root = vim.fs.normalize(h.cygpath(native_root, 'mixed'))
+    local expected_gitdir = vim.fs.normalize(h.cygpath(native_gitdir, 'mixed'))
+
+    with_upvalues(Repo.get_info, {
+      check_version = function()
+        return true
+      end,
+      git_command = function()
+        return { unix_root, unix_gitdir, 'main' }, nil, 0
+      end,
+    }, function()
+      local info, err = async.run(Repo.get_info, native_root):wait(5000)
+      h.eq(nil, err)
+      h.ok(info ~= nil, 'expected repo info for mixed-style paths')
+      h.eq(expected_root, info.toplevel)
+      h.eq(expected_gitdir, info.gitdir)
+      h.eq(false, info.detached)
+    end)
+  end)
+end)
+
+h.it('util.cygpath preserves native paths and converts unix paths', function()
+  if vim.fn.has('win32') ~= 1 then
+    return
+  end
+  h.eq(1, vim.fn.executable('cygpath'), 'cygpath missing from PATH')
+
+  local util = require('gitsigns.util')
+
+  gs.with_repo(function(repo)
+    local native_root = repo.root
+    local unix_root = h.cygpath(native_root, 'unix')
+    local mixed_root = h.cygpath(native_root, 'mixed')
+    local windows_root = h.cygpath(unix_root, 'windows')
+
+    h.eq(native_root, async.run(util.cygpath, native_root, 'mixed'):wait(5000))
+    h.eq(mixed_root, async.run(util.cygpath, unix_root, 'mixed'):wait(5000))
+    h.eq(windows_root, async.run(util.cygpath, unix_root, 'windows'):wait(5000))
+  end)
+end)
+
+h.it('Repo.get_info rejects native dirs outside a unix-style worktree', function()
+  if vim.fn.has('win32') ~= 1 then
+    return
+  end
+  h.eq(1, vim.fn.executable('cygpath'), 'cygpath missing from PATH')
+
+  local Repo = require('gitsigns.git.repo')
+
+  gs.with_repo(function(repo)
+    local outside = h.tmpdir()
+    local unix_root = h.cygpath(repo.root, 'unix')
+    local unix_gitdir = h.cygpath(repo.gitdir, 'unix')
+
+    local ok, err = pcall(function()
+      with_upvalues(Repo.get_info, {
+        check_version = function()
+          return true
+        end,
+        git_command = function()
+          return { unix_root, unix_gitdir, 'main' }, nil, 0
+        end,
+      }, function()
+        local info = async.run(Repo.get_info, outside):wait(5000)
+        h.eq(nil, info)
+      end)
+    end)
+    h.cleanup(outside)
+    if not ok then
+      error(err, 0)
+    end
+  end)
+end)
+
+h.it('gitsigns attaches to a tracked file in a subdirectory', function()
+  gs.with_repo(function(repo)
+    h.edit(repo.file)
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cache = gs.attach(bufnr, gs.context(repo))
+
+    h.eq(repo.relpath, cache.git_obj.relpath)
+    h.ok(cache.git_obj.object_name ~= nil, 'expected tracked file to have an object name')
+    h.ok(cache.git_obj.repo.toplevel ~= nil, 'expected repo to have a toplevel')
+  end, {
+    relpath = 'sub/test.txt',
+    lines = { 'hello', 'world' },
+  })
+end)
+
+h.it('gitsigns attaches with a relative file path in the git context', function()
+  gs.with_repo(function(repo)
+    h.edit(repo.file)
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cache = gs.attach(bufnr, gs.context(repo, repo.relpath))
+
+    h.eq(repo.relpath, cache.git_obj.relpath)
+    h.ok(cache.git_obj.object_name ~= nil, 'expected tracked file to have an object name')
+  end, {
+    relpath = 'sub/relative.txt',
+    lines = { 'hello', 'world' },
+  })
+end)
+
+h.it('gitsigns blames a tracked file in a nested path', function()
+  gs.with_repo(function(repo)
+    h.edit(repo.file)
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cache = gs.attach(bufnr, gs.context(repo))
+
+    h.eq(repo.relpath, cache.git_obj.relpath)
+    h.ok(cache.git_obj.file ~= cache.git_obj.relpath, 'expected an absolute file path for blame')
+
+    local blame_info = async
+      .run(function()
+        return cache:get_blame(1, {})
+      end)
+      :wait(5000)
+
+    h.ok(blame_info ~= nil, 'expected blame info for first line')
+    h.eq(repo.relpath, blame_info.filename)
+    h.ok(blame_info.commit.sha ~= nil, 'expected committed blame info')
+  end, {
+    relpath = '.config/nvim/lua/mappings.lua',
+    lines = { 'hello', 'world' },
+  })
+end)
+
+h.it('gitsigns stages tracked changes after attach', function()
+  gs.with_repo(function(repo)
+    h.edit(repo.file)
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cache = gs.attach(bufnr, gs.context(repo, repo.relpath))
+
+    vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, { 'changed' })
+    cache:invalidate(true)
+    cache = gs.update(bufnr)
+
+    h.wait_for(function()
+      return cache.hunks and #cache.hunks > 0
+    end, {
+      timeout = 5000,
+      msg = 'expected gitsigns to detect buffer hunks',
+    })
+
+    gs.stage_hunks(bufnr)
+
+    h.eq(
+      repo.relpath,
+      h.trim(h.system({ 'git', 'diff', '--cached', '--name-only' }, {
+        cwd = repo.root,
+      }).stdout)
+    )
+  end, {
+    relpath = 'sub/stage.txt',
+    lines = { 'hello', 'world' },
+  })
+end)


### PR DESCRIPTION
Keep path normalization scoped to repo path comparisons so file paths
used by the rest of the plugin remain unchanged.

Add a Windows smoke harness and CI job that exercise mixed native/MSYS
repo discovery and a tracked-file attach flow under headless Neovim.
