### PR TITLE
fix(statuscolumn): scope sign cache per buffer

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -50,23 +50,30 @@ function M.statuscolumn(bufnr, lnum)
 
   local res = {} --- @type string[]
   local res_len = 0
-  for _, signs in pairs({ signs_normal, signs_staged }) do
-    local marks = api.nvim_buf_get_extmarks(bufnr, signs.ns, { lnum - 1, 0 }, { lnum - 1, -1 }, {})
-    for _, mark in pairs(marks) do
-      local id = mark[1]
-      local s = signs.signs[id]
-      if s then
-        vim.list_extend(res, { '%#' .. s[2] .. '#', s[1], '%*' })
-        --- @diagnostic disable-next-line: missing-parameter
-        res_len = res_len + vim.str_utfindex(s[1])
+  for _, signs in ipairs({ signs_normal, signs_staged }) do
+    local buf_signs = signs.signs[bufnr]
+    if buf_signs and next(buf_signs) then
+      local marks = api.nvim_buf_get_extmarks(
+        bufnr,
+        signs.ns,
+        { lnum - 1, 0 },
+        { lnum - 1, -1 },
+        {}
+      )
+      for _, mark in ipairs(marks) do
+        local id = mark[1]
+        local s = buf_signs[id]
+        if s then
+          vim.list_extend(res, { '%#' .. s[2] .. '#', s[1], '%*' })
+          --- @diagnostic disable-next-line: missing-parameter
+          res_len = res_len + vim.str_utfindex(s[1])
+        end
       end
     end
   end
-
   local pad = math.max(0, 2 - res_len)
   return table.concat(res) .. string.rep(' ', pad)
 end
-
 --- @param bufnr integer
 --- @param signs Gitsigns.Signs
 --- @param hunks? Gitsigns.Hunk.Hunk[]

--- a/lua/gitsigns/signs.lua
+++ b/lua/gitsigns/signs.lua
@@ -20,7 +20,7 @@ end
 --- @field config table<Gitsigns.SignType,Gitsigns.SignConfig>
 --- @field staged boolean
 --- @field ns integer
---- @field signs table<integer,[string,string?]?>
+--- @field signs table<integer,table<integer,[string,string?]?>?>
 --- @field private _hl_cache table<Gitsigns.SignType,table<string,string>>
 local M = {}
 
@@ -66,13 +66,17 @@ end
 --- @param start_lnum? integer
 --- @param end_lnum? integer
 function M:remove(bufnr, start_lnum, end_lnum)
+  local buf_signs = self.signs[bufnr]
   if start_lnum then
     api.nvim_buf_clear_namespace(bufnr, self.ns, start_lnum - 1, end_lnum or start_lnum)
-    for i = start_lnum - 1, (end_lnum or start_lnum) - 1 do
-      self.signs[i] = nil
+    if not buf_signs then
+      return
+    end
+    for i = start_lnum, end_lnum or start_lnum do
+      buf_signs[i] = nil
     end
   else
-    self.signs = {}
+    self.signs[bufnr] = nil
     api.nvim_buf_clear_namespace(bufnr, self.ns, 0, -1)
   end
 end
@@ -90,6 +94,9 @@ function M:add(bufnr, signs, filter)
     -- Don't place signs if it won't show anything
     return
   end
+
+  local buf_signs = self.signs[bufnr] or {}
+  self.signs[bufnr] = buf_signs
 
   for _, sign in ipairs(signs) do
     if (not filter or filter(sign.lnum)) and not self:contains(bufnr, sign.lnum) then
@@ -115,7 +122,7 @@ function M:add(bufnr, signs, filter)
 
       if ok then
         --- @cast id_or_err integer
-        self.signs[id_or_err] = { text, sign_hl_group }
+        buf_signs[id_or_err] = { text, sign_hl_group }
       elseif config.debug_mode then
         vim.schedule(function()
           error(table.concat({

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -939,6 +939,43 @@ describe('gitsigns (with screen)', function()
     end
   end)
 
+  it('keeps statuscolumn signs scoped per buffer', function()
+    setup_test_repo()
+
+    local other = scratch .. '/other.txt'
+    write_to_file(other, { 'other' })
+    git('add', other)
+    git('commit', '-m', 'add other file')
+
+    setup_gitsigns(config)
+    exec_lua(function()
+      require('gitsigns').statuscolumn(0, 1)
+    end)
+
+    edit(test_file)
+    feed('x')
+    local test_buf = api.nvim_get_current_buf()
+    check({ signs = { changed = 1 } }, test_buf)
+
+    edit(other)
+    feed('ggO<esc>')
+    local other_buf = api.nvim_get_current_buf()
+    check({ signs = { added = 1 } }, other_buf)
+
+    eq(
+      {
+        '%#GitSignsChange#~%* ',
+        '%#GitSignsAdd#+%* ',
+      },
+      exec_lua(function(test_buf0, other_buf0)
+        return {
+          require('gitsigns').statuscolumn(test_buf0, 1),
+          require('gitsigns').statuscolumn(other_buf0, 1),
+        }
+      end, test_buf, other_buf)
+    )
+  end)
+
   it('handles filenames with unicode characters', function()
     screen:try_resize(20, 2)
     setup_test_repo()


### PR DESCRIPTION
Extmark ids are only unique within a buffer namespace, but the
statuscolumn rendering path cached sign text in a single table keyed
only by extmark id.

When multiple buffers had signs on the same line, the later update could
overwrite the earlier entry and cause the wrong sign to be rendered in
another window.

Store cached sign metadata per buffer and read it back using the buffer
being rendered. This keeps the statuscolumn output aligned with the
extmarks Neovim already tracks per buffer.

Fixes #1491
