### PR TITLE
fix(status): suppress redundant GitSignsUpdate events

### DIFF
--- a/lua/gitsigns/status.lua
+++ b/lua/gitsigns/status.lua
@@ -29,6 +29,11 @@ function M.update(bufnr, status)
   if bstatus then
     status = vim.tbl_extend('force', bstatus, status)
   end
+
+  if vim.deep_equal(bstatus, status) then
+    return
+  end
+
   vim.b[bufnr].gitsigns_head = status.head or ''
   vim.b[bufnr].gitsigns_status_dict = status
 
@@ -43,9 +48,16 @@ function M.clear(bufnr)
   if not api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  vim.b[bufnr].gitsigns_head = nil
-  vim.b[bufnr].gitsigns_status_dict = nil
-  vim.b[bufnr].gitsigns_status = nil
+
+  local b = vim.b[bufnr]
+
+  if b.gitsigns_head == nil and b.gitsigns_status_dict == nil and b.gitsigns_status == nil then
+    return
+  end
+
+  b.gitsigns_head = nil
+  b.gitsigns_status_dict = nil
+  b.gitsigns_status = nil
   autocmd_update(bufnr)
 end
 

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -198,6 +198,57 @@ describe('actions', function()
     })
   end)
 
+  it('does not emit duplicate GitSignsUpdate events for stage_hunk', function()
+    setup_test_repo()
+    edit(test_file)
+
+    feed('jjjccEDIT<esc>')
+    check({
+      status = { head = 'main', added = 0, changed = 1, removed = 0 },
+      signs = { changed = 1 },
+    })
+
+    exec_lua(function()
+      _G.test_gitsigns_update_events = {}
+
+      vim.api.nvim_create_autocmd('User', {
+        group = vim.api.nvim_create_augroup('GitsignsUpdateTest', { clear = true }),
+        pattern = 'GitSignsUpdate',
+        callback = function(args)
+          local bufnr = args.data and args.data.buffer
+          if bufnr ~= vim.api.nvim_get_current_buf() then
+            return
+          end
+
+          local status = vim.b[bufnr].gitsigns_status_dict
+          _G.test_gitsigns_update_events[#_G.test_gitsigns_update_events + 1] = {
+            added = status and status.added,
+            changed = status and status.changed,
+            removed = status and status.removed,
+            head = status and status.head,
+          }
+        end,
+      })
+    end)
+
+    command('Gitsigns stage_hunk')
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    helpers.sleep(500)
+
+    eq({
+      {
+        added = 0,
+        changed = 0,
+        removed = 0,
+        head = 'main',
+      },
+    }, exec_lua('return _G.test_gitsigns_update_events'))
+  end)
+
   it('preserves foldenable in diffthis windows after staging a hunk', function()
     command('silent! %bwipe!')
     setup_test_repo()


### PR DESCRIPTION
Stage and unstage operations can update buffer status directly and then
trigger another watcher refresh with the same status payload. Users who
listen for GitSignsUpdate and call redrawstatus end up redrawing
multiple times for one logical action, which makes those operations feel
slow and flickery.

Short-circuit status updates when the merged status dict is unchanged,
and skip clear notifications when the status variables are already
empty.

Fixes #1467
