### PR TITLE
ci(release): use app token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ name: release-please
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -16,14 +17,19 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.GITSIGNS_BOT_ID || secrets.GITSIGNS_BOT_ID }}
+          private-key: ${{ secrets.GITSIGNS_BOT_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: tag stable versions
         if: ${{ steps.release.outputs.release_created }}
         run: |
@@ -54,13 +60,18 @@ jobs:
     if: ${{ ! needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.GITSIGNS_BOT_ID || secrets.GITSIGNS_BOT_ID }}
+          private-key: ${{ secrets.GITSIGNS_BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: release-please--branches--main
           # Fetch the last 2 commits instead of just 1. (Fetching just 1 commit would overwrite the whole history)
           fetch-depth: 2
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: leafo/gh-actions-lua@v10
         with:


### PR DESCRIPTION
Release Please was using a personal token so its pushes and PR updates
were attributed to a user account. That works, but it ties release
automation to a specific user and keeps a long-lived personal credential
in the repository secrets.

Generate a GitHub App installation token inside the workflow and use it
for both the release-please action and the follow-up checkout/push
steps. This keeps the automation attributed to the app, avoids a
personal PAT, and still allows release-please PR updates to trigger the
normal CI workflow.

Also add issues:write to match Release Please's required permissions and
support the configured app credentials.
