### PR TITLE
fix(ci): use release-please PR outputs for update-doc

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
+      pr: ${{ steps.release.outputs.pr }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
@@ -57,7 +59,7 @@ jobs:
 
   update-doc:
     needs: release-please
-    if: ${{ ! needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -68,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release-please--branches--main
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
- expose the release-please PR metadata as job outputs
- only run update-doc when a release PR was actually created or updated
- checkout the reported release-please PR branch instead of a stale hard-coded ref

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-please.yml')"