### PR TITLE
ci(commitlint): lint PR commits with gitlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,23 @@ concurrency:
 
 jobs:
   commit_lint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      # Check commit messages
-      - uses: webiny/action-conventional-commits@v1.3.0
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install gitlint
+        run: make gitlint
+
+      - name: Lint PR commits
+        run: make commitlint RANGE='${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}'
 
   test:
     runs-on: ubuntu-latest

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,11 @@
+[general]
+ignore=author-valid-email,body-is-missing,body-min-length
+
+[title-match-regex]
+regex=^(?:Revert ".+"|(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\([^)]+\))?(?:!)?: .+)$
+
+[title-max-length]
+line-length=72
+
+[body-max-line-length]
+line-length=72

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,37 @@ format: $(STYLUA)
 	$(STYLUA) $(LUA_FILES)
 
 ################################################################################
+# Gitlint
+################################################################################
+
+GITLINT_REF := 0.19.1
+GITLINT_DIR := deps/gitlint-$(GITLINT_REF)
+GITLINT_BIN := $(GITLINT_DIR)/bin/gitlint
+GITLINT_PIP_CACHE := $(PWD)/deps/.pip-cache
+COMMIT ?= HEAD
+RANGE ?=
+
+.PHONY: gitlint
+gitlint: $(GITLINT_BIN)
+
+$(GITLINT_BIN):
+	mkdir -p $(GITLINT_PIP_CACHE)
+	python3 -m venv $(GITLINT_DIR)
+	PIP_CACHE_DIR=$(GITLINT_PIP_CACHE) $(GITLINT_DIR)/bin/pip install gitlint==$(GITLINT_REF)
+
+.PHONY: commitlint
+commitlint: $(GITLINT_BIN)
+	@if [ -n "$(RANGE)" ]; then \
+		$(GITLINT_BIN) --commits "$(RANGE)"; \
+	else \
+		$(GITLINT_BIN) --commit "$(COMMIT)"; \
+	fi
+
+.PHONY: commitlint-hook
+commitlint-hook: $(GITLINT_BIN)
+	$(GITLINT_BIN) install-hook
+
+################################################################################
 # Emmylua
 ################################################################################
 
@@ -165,4 +196,3 @@ doc: $(NVIM_TEST) $(NVIM_TEST_RUNTIME) $(EMMYLUADOC_BIN)
 .PHONY: doc-check
 doc-check: doc
 	git diff --exit-code -- doc
-

--- a/etc/commit-message.md
+++ b/etc/commit-message.md
@@ -5,7 +5,10 @@ Read this file before creating or amending commits in this repo.
 - Use the subject format `<type>(<scope>): <verb phrase>`.
 - Keep the subject under 72 characters.
 - Include a detailed body that explains the problem and solution.
-- Wrap body lines at 72 characters.
+- Wrap body and footer lines at 72 characters.
+- Run `make commitlint COMMIT=HEAD` to lint your latest commit locally.
+- Run `make commitlint RANGE=origin/main..HEAD` to lint a commit range.
+- Run `make commitlint-hook` to install a local `commit-msg` hook.
 - When scripting `git commit`, use real newlines between paragraphs,
   such as separate `-m` flags or a message file.
 - Do not store literal `\n` sequences in the final commit message.


### PR DESCRIPTION
## Summary
- replace the GitHub-only conventional commits action with gitlint
- add repo-local Makefile targets for installing gitlint and linting commits
- run commit lint only for pull request commits

## Testing
- make commitlint COMMIT=HEAD
- make commitlint COMMIT=a462f41
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"
- git diff --check
