### PR TITLE
feat(render): inspect rendered buffers for hunk previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 
 ## Testing Guidelines
 - Add or update tests for risky, non-obvious, or broad changes; see `etc/testing.md` for details.
+- Do not run multiple `make test` invocations in parallel against the same checkout. The functional tests share `scratch/` state via `test/gs_helpers.lua`, so parallel runs can interfere unless each run gets an isolated workspace/scratch path.
 
 ## Commit & Pull Request Guidelines
 - Read `etc/commit-message.md` before creating or amending commits.

--- a/lua/gitsigns/actions/blame_line.lua
+++ b/lua/gitsigns/actions/blame_line.lua
@@ -1,4 +1,6 @@
+local async = require('gitsigns.async')
 local Hunks = require('gitsigns.hunks')
+local HunkPreview = require('gitsigns.hunk_preview')
 local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
 local log = require('gitsigns.debug.log')
@@ -8,22 +10,34 @@ local util = require('gitsigns.util')
 
 local api = vim.api
 
+--- @class (exact) Gitsigns.BlameHunkPreview
+--- @field hunk Gitsigns.Hunk.Hunk
+--- @field index integer
+--- @field total integer
+--- @field removed_source string[]
+--- @field added_source string[]
+--- @field guess_offset? integer
+
+--- Diff the blamed line between the current commit and its parent and return
+--- the matching hunk preview. If blame metadata does not point at a diff hunk,
+--- fall back to the nearest hunk and record the guessed line offset.
 --- @async
 --- @param repo Gitsigns.Repo
 --- @param info Gitsigns.BlameInfoPublic
---- @return Gitsigns.Hunk.Hunk hunk
---- @return integer hunk_index
---- @return integer num_hunks
---- @return integer? guess_offset If the hunk was not found at the exact line,
----                               return the offset from the original line to the
----                               hunk start.
+--- @return Gitsigns.BlameHunkPreview
 local function get_blame_hunk(repo, info)
-  local a = repo:get_show_text(info.previous_sha .. ':' .. info.previous_filename)
-  local b = repo:get_show_text(info.sha .. ':' .. info.filename)
-  local hunks = run_diff(a, b, false)
+  local removed_source = repo:get_show_text(info.previous_sha .. ':' .. info.previous_filename)
+  local added_source = repo:get_show_text(info.sha .. ':' .. info.filename)
+  local hunks = run_diff(removed_source, added_source, false)
   local hunk, i = Hunks.find_hunk(info.orig_lnum, hunks)
   if hunk and i then
-    return hunk, i, #hunks
+    return {
+      hunk = hunk,
+      index = i,
+      total = #hunks,
+      removed_source = removed_source,
+      added_source = added_source,
+    }
   end
 
   -- git-blame output is not always correct (see #1332)
@@ -43,69 +57,69 @@ local function get_blame_hunk(repo, info)
   end
 
   hunk = assert(hunks[i])
-  return hunk, i, #hunks, hunk.added.start - info.orig_lnum
+  return {
+    hunk = hunk,
+    index = i,
+    total = #hunks,
+    guess_offset = hunk.added.start - info.orig_lnum,
+    removed_source = removed_source,
+    added_source = added_source,
+  }
+end
+
+--- @param result Gitsigns.BlameInfoPublic
+--- @return boolean
+local function is_committed(result)
+  return result.sha and tonumber('0x' .. result.sha) ~= 0
 end
 
 --- @async
---- @param repo Gitsigns.Repo
---- @param sha string
---- @return Gitsigns.LineSpec
-local function create_commit_msg_body_linespec(repo, sha)
-  local body0 = repo:command({ 'show', '-s', '--format=%B', sha }, { text = true })
-  local body = table.concat(body0, '\n')
-  return { { body, 'NormalFloat' } }
-end
-
---- @async
+--- @param bufnr integer
 --- @param info Gitsigns.BlameInfoPublic
 --- @param repo Gitsigns.Repo
---- @param fileformat string
 --- @return Gitsigns.LineSpec[]
-local function create_blame_hunk_linespec(repo, info, fileformat)
+local function create_blame_hunk_linespec(bufnr, repo, info)
   if not (info.previous_sha and info.previous_filename) then
     return { { { 'File added in commit', 'Title' } } }
   end
 
-  --- @type Gitsigns.LineSpec[]
-  local ret = {}
-  local hunk, hunk_no, num_hunks, guess_offset = get_blame_hunk(repo, info)
+  local preview = get_blame_hunk(repo, info)
+  async.schedule()
 
-  local hunk_title = {
-    { ('Hunk %d of %d'):format(hunk_no, num_hunks), 'Title' },
-    { ' ' .. hunk.head, 'LineNr' },
+  --- @type Gitsigns.LineSpec
+  local title = {
+    { ('Hunk %d of %d'):format(preview.index, preview.total), 'Title' },
+    { ' ' .. preview.hunk.head, 'LineNr' },
   }
 
-  if guess_offset then
-    hunk_title[#hunk_title + 1] = {
+  if preview.guess_offset then
+    title[#title + 1] = {
       (' (guessed: %s%d offset from original line)'):format(
-        guess_offset >= 0 and '+' or '',
-        guess_offset
+        preview.guess_offset >= 0 and '+' or '',
+        preview.guess_offset
       ),
       'WarningMsg',
     }
   end
 
-  ret[#ret + 1] = hunk_title
-  vim.list_extend(ret, Hunks.linespec_for_hunk(hunk, fileformat))
-  return ret
+  return vim.list_extend(
+    { title },
+    HunkPreview.linespec_for_hunk(
+      bufnr,
+      preview.hunk,
+      preview.removed_source,
+      preview.added_source,
+      preview.hunk.added
+    )
+  )
 end
 
 --- @async
---- @param full boolean? Whether to show the full commit message and hunk
 --- @param result Gitsigns.BlameInfoPublic
 --- @param repo Gitsigns.Repo
---- @param fileformat string
 --- @param with_gh boolean
---- @return Gitsigns.LineSpec[]
-local function create_blame_linespec(full, result, repo, fileformat, with_gh)
-  local is_committed = result.sha and tonumber('0x' .. result.sha) ~= 0
-
-  if not is_committed then
-    return {
-      { { result.author, 'Label' } },
-    }
-  end
-
+--- @return Gitsigns.LineSpec
+local function create_blame_title_linespec(result, repo, with_gh)
   local gh --- @module 'gitsigns.gh'?
   if config.gh and with_gh then
     gh = require('gitsigns.gh')
@@ -129,18 +143,20 @@ local function create_blame_linespec(full, result, repo, fileformat, with_gh)
     { ':', 'NormalFloat' },
   })
 
-  --- @type Gitsigns.LineSpec[]
-  local ret = { title }
+  return title
+end
 
-  if not full then
-    ret[#ret + 1] = { { result.summary, 'NormalFloat' } }
-    return ret
-  end
-
-  ret[#ret + 1] = create_commit_msg_body_linespec(repo, result.sha)
-  vim.list_extend(ret, create_blame_hunk_linespec(repo, result, fileformat))
-
-  return ret
+--- @async
+--- @param bufnr integer
+--- @param info Gitsigns.BlameInfoPublic
+--- @param repo Gitsigns.Repo
+--- @return Gitsigns.LineSpec[]
+local function build_full_blame_body(bufnr, info, repo)
+  local body0 = repo:command({ 'show', '-s', '--format=%B', info.sha }, { text = true })
+  local body = table.concat(body0, '\n')
+  return vim.list_extend({
+    { { body, 'NormalFloat' } },
+  }, create_blame_hunk_linespec(bufnr, repo, info))
 end
 
 --- @class (exact) Gitsigns.LineBlameOpts : Gitsigns.BlameOpts
@@ -169,7 +185,6 @@ return function(opts)
     return
   end
 
-  local fileformat = vim.bo[bufnr].fileformat
   local lnum = api.nvim_win_get_cursor(0)[1]
   local popup_winid, popup_bufnr
   ---@async
@@ -188,9 +203,19 @@ return function(opts)
   end
 
   local result = util.convert_blame_info(assert(info))
+  if not is_committed(result) then
+    if is_stale() then
+      return
+    end
+    popup.create({ { { result.author, 'Label' } } }, config.preview_config, 'blame')
+    return
+  end
 
-  local blame_linespec =
-    create_blame_linespec(opts.full, result, bcache.git_obj.repo, fileformat, false)
+  local repo = bcache.git_obj.repo
+  local body = opts.full and build_full_blame_body(bufnr, result, repo)
+    or { { { result.summary, 'NormalFloat' } } }
+  local blame_linespec = { create_blame_title_linespec(result, repo, false) }
+  vim.list_extend(blame_linespec, body)
 
   if is_stale() then
     return
@@ -198,7 +223,12 @@ return function(opts)
 
   popup_winid, popup_bufnr = popup.create(blame_linespec, config.preview_config, 'blame')
 
-  blame_linespec = create_blame_linespec(opts.full, result, bcache.git_obj.repo, fileformat, true)
+  if not config.gh then
+    return
+  end
+
+  blame_linespec = { create_blame_title_linespec(result, repo, true) }
+  vim.list_extend(blame_linespec, body)
 
   if is_stale() then
     return

--- a/lua/gitsigns/actions/preview.lua
+++ b/lua/gitsigns/actions/preview.lua
@@ -1,7 +1,10 @@
+local async = require('gitsigns.async')
 local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
-local popup = require('gitsigns.popup')
+local DeletedPreview = require('gitsigns.deleted_preview')
+local HunkPreview = require('gitsigns.hunk_preview')
 local Hunks = require('gitsigns.hunks')
+local popup = require('gitsigns.popup')
 
 local api = vim.api
 local current_buf = api.nvim_get_current_buf
@@ -10,6 +13,9 @@ local current_buf = api.nvim_get_current_buf
 local M = {}
 
 local ns_inline = api.nvim_create_namespace('gitsigns_preview_inline')
+local window_ns_supported = api.nvim__ns_set ~= nil
+local inline_bufnr --- @type integer?
+local inline_winid --- @type integer?
 
 --- @async
 --- @param bufnr integer
@@ -22,46 +28,85 @@ local function get_hunk_with_staged(bufnr, greedy)
     return
   end
 
-  local hunk = bcache:get_hunk(nil, greedy, false)
-  if hunk then
-    return hunk, false
+  local unstaged_hunk = bcache:get_hunk(nil, greedy, false)
+  if unstaged_hunk then
+    return unstaged_hunk, false
   end
 
-  hunk = bcache:get_hunk(nil, greedy, true)
-  if hunk then
-    return hunk, true
+  local staged_hunk = bcache:get_hunk(nil, greedy, true)
+  if staged_hunk then
+    return staged_hunk, true
   end
+end
+
+--- Get the greedy hunk at the cursor for popup preview. Prefer unstaged hunks
+--- and only fall back to staged hunks if no unstaged hunk matches. The
+--- returned index and total belong to the selected list.
+--- @param bcache Gitsigns.CacheEntry
+--- @async
+--- @return Gitsigns.Hunk.Hunk? hunk
+--- @return integer? index
+--- @return boolean? staged
+--- @return integer total
+local function get_hunk_at_cursor(bcache)
+  --- @type Gitsigns.Hunk.Hunk[]
+  local hunks = bcache:get_hunks(true, false) or {}
+  local hunk, index = bcache:get_cursor_hunk(hunks)
+  if hunk then
+    return hunk, index, false, #hunks
+  end
+
+  --- @type Gitsigns.Hunk.Hunk[]
+  local hunks_head = bcache:get_hunks(true, true) or {}
+  --- @type Gitsigns.Hunk.Hunk[]
+  local hunks_staged = Hunks.filter_common(hunks_head, hunks) or {}
+  hunk, index = bcache:get_cursor_hunk(hunks_staged)
+  if hunk then
+    return hunk, index, true, #hunks_staged
+  end
+
+  return nil, nil, nil, 0
 end
 
 local function clear_preview_inline(bufnr)
   api.nvim_buf_clear_namespace(bufnr, ns_inline, 0, -1)
+  if inline_bufnr == bufnr then
+    inline_bufnr = nil
+    inline_winid = nil
+    if window_ns_supported then
+      api.nvim__ns_set(ns_inline, { wins = {} })
+    end
+  end
 end
 
 --- @param keys string
 local function feedkeys(keys)
   local cy = api.nvim_replace_termcodes(keys, true, false, true)
-  api.nvim_feedkeys(cy, 'n', false)
+  api.nvim_feedkeys(cy, 'nx', false)
 end
 
---- @param win integer
---- @param lnum integer
---- @param width integer
---- @return string str
---- @return {group:string, start:integer}[]? highlights
-local function build_lno_str(win, lnum, width)
-  local has_col, statuscol =
-    pcall(api.nvim_get_option_value, 'statuscolumn', { win = win, scope = 'local' })
-  if has_col and type(statuscol) == 'string' and statuscol ~= '' then
-    local ok, data = pcall(api.nvim_eval_statusline, statuscol, {
-      winid = win,
-      use_statuscol_lnum = lnum,
-      highlights = true,
-    })
-    if ok then
-      return data.str, data.highlights
+--- Translate a staged hunk's added node from current-buffer coordinates into
+--- index coordinates by subtracting the line deltas introduced by unstaged
+--- hunks above it.
+--- @param bufnr integer
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @return Gitsigns.Hunk.Node
+local function index_added_node_for_staged_hunk(bufnr, hunk)
+  local top = hunk.added.start
+
+  for _, unstaged in ipairs(assert(cache[bufnr]).hunks or {}) do
+    local delta = (unstaged.added.count - unstaged.removed.count) --[[@as integer]]
+    if delta ~= 0 and top > unstaged.vend then
+      top = top - delta
     end
   end
-  return string.format('%' .. width .. 'd', lnum)
+
+  return {
+    start = top,
+    count = hunk.added.count,
+    lines = hunk.added.lines,
+    no_nl_at_eof = hunk.added.no_nl_at_eof,
+  }
 end
 
 --- @param bufnr integer
@@ -101,138 +146,64 @@ local function show_added(bufnr, nsw, hunk)
   end
 end
 
---- @param bufnr integer
---- @param nsd integer
---- @param hunk Gitsigns.Hunk.Hunk
---- @param staged boolean?
---- @return integer winid
-local function show_deleted_in_float(bufnr, nsd, hunk, staged)
-  local cwin = api.nvim_get_current_win()
-  local virt_lines = {} --- @type [string, string][][]
-  local textoff = assert(vim.fn.getwininfo(cwin)[1]).textoff --[[@as integer]]
-  for i = 1, hunk.removed.count do
-    local sc = build_lno_str(cwin, hunk.removed.start + i, textoff - 1)
-    virt_lines[i] = { { sc, 'LineNr' } }
-  end
-
-  local topdelete = hunk.added.start == 0 and hunk.type == 'delete'
-  local virt_lines_above = hunk.type ~= 'delete' or topdelete
-
-  local row = topdelete and 0 or hunk.added.start - 1
-  api.nvim_buf_set_extmark(bufnr, nsd, row, -1, {
-    virt_lines = virt_lines,
-    -- TODO(lewis6991): Note virt_lines_above doesn't work on row 0 neovim/neovim#16166
-    virt_lines_above = virt_lines_above,
-    virt_lines_leftcol = true,
-  })
-
-  local bcache = assert(cache[bufnr])
-  local pbufnr = api.nvim_create_buf(false, true)
-  local text = staged and bcache.compare_text_head or bcache.compare_text
-  api.nvim_buf_set_lines(pbufnr, 0, -1, false, assert(text))
-
-  local width = api.nvim_win_get_width(0)
-
-  local bufpos_offset = virt_lines_above and not topdelete and 1 or 0
-
-  local pwinid = api.nvim_open_win(pbufnr, false, {
-    relative = 'win',
-    win = cwin,
-    width = width - textoff,
-    height = hunk.removed.count,
-    anchor = 'SW',
-    bufpos = { hunk.added.start - bufpos_offset, 0 },
-    style = 'minimal',
-    border = 'none',
-  })
-
-  vim.bo[pbufnr].filetype = vim.bo[bufnr].filetype
-  vim.bo[pbufnr].bufhidden = 'wipe'
-  vim.wo[pwinid].scrolloff = 0
-
-  api.nvim_win_call(pwinid, function()
-    -- Disable folds
-    vim.wo.foldenable = false
-
-    -- Navigate to hunk
-    vim.cmd('normal! ' .. tostring(hunk.removed.start) .. 'gg')
-    vim.cmd('normal! ' .. api.nvim_replace_termcodes('z<CR>', true, false, true))
-  end)
-
-  -- Apply highlights
-
-  for i = hunk.removed.start, hunk.removed.start + hunk.removed.count - 1 do
-    api.nvim_buf_set_extmark(pbufnr, nsd, i - 1, 0, {
-      hl_group = 'GitSignsDeleteVirtLn',
-      hl_eol = true,
-      end_row = i,
-      priority = 1000,
-    })
-  end
-
-  local removed_regions =
-    require('gitsigns.diff_int').run_word_diff(hunk.removed.lines, hunk.added.lines)
-
-  for _, region in ipairs(removed_regions) do
-    local start_row = (hunk.removed.start - 1) + (region[1] - 1)
-    local start_col = region[3] - 1
-    local end_col = region[4] - 1
-    api.nvim_buf_set_extmark(pbufnr, nsd, start_row, start_col, {
-      hl_group = 'GitSignsDeleteVirtLnInline',
-      end_col = end_col,
-      end_row = start_row,
-      priority = 1001,
-    })
-  end
-
-  return pwinid
-end
-
-local function noautocmd(f)
-  return function()
-    local ei = vim.o.eventignore
-    vim.o.eventignore = 'all'
-    f()
-    vim.o.eventignore = ei
-  end
-end
-
 --- Preview the hunk at the cursor position in a floating
 --- window. If the preview is already open, calling this
 --- will cause the window to get focus.
-M.preview_hunk = noautocmd(function()
-  -- Wrap in noautocmd so vim-repeat continues to work
-
-  if popup.focus_open('hunk') then
+function M.preview_hunk()
+  if popup.is_open('hunk') then
+    popup.focus_open('hunk')
     return
   end
 
-  local bufnr = current_buf()
-  local bcache = cache[bufnr]
+  local bcache = cache[current_buf()]
   if not bcache then
     return
   end
 
-  local hunk, index = bcache:get_cursor_hunk()
+  local hunk, index, staged, total = async.run(get_hunk_at_cursor, bcache):wait()
 
-  if not hunk then
+  if not hunk or not index then
     return
   end
 
   --- @type Gitsigns.LineSpec[]
-  local preview_linespec = {
-    { { ('Hunk %d of %d'):format(index, #bcache.hunks), 'Title' } },
+  local linespec = {
+    { { ('Hunk %d of %d'):format(index, total), 'Title' } },
   }
-  vim.list_extend(preview_linespec, Hunks.linespec_for_hunk(hunk, vim.bo[bufnr].fileformat))
 
-  popup.create(preview_linespec, config.preview_config, 'hunk')
-end)
+  if staged then
+    vim.list_extend(
+      linespec,
+      HunkPreview.linespec_for_hunk(
+        bcache.bufnr,
+        hunk,
+        assert(bcache.compare_text_head),
+        assert(bcache.compare_text),
+        index_added_node_for_staged_hunk(bcache.bufnr, hunk)
+      )
+    )
+  else
+    vim.list_extend(
+      linespec,
+      HunkPreview.linespec_for_hunk(
+        bcache.bufnr,
+        hunk,
+        assert(bcache.compare_text),
+        bcache.bufnr,
+        hunk.added
+      )
+    )
+  end
+
+  popup.create(linespec, config.preview_config, 'hunk')
+end
 
 --- Preview the hunk at the cursor position inline in the buffer.
 --- @async
---- @return integer? winid
+--- @return integer? markid
 function M.preview_hunk_inline()
   local bufnr = current_buf()
+  local winid = api.nvim_get_current_win()
 
   local hunk, staged = get_hunk_with_staged(bufnr, true)
 
@@ -240,21 +211,34 @@ function M.preview_hunk_inline()
     return
   end
 
+  if inline_bufnr and (inline_bufnr ~= bufnr or inline_winid ~= winid) then
+    api.nvim_buf_clear_namespace(inline_bufnr, ns_inline, 0, -1)
+  end
+
   clear_preview_inline(bufnr)
 
-  local winid --- @type integer
+  if window_ns_supported then
+    api.nvim__ns_set(ns_inline, { wins = { winid } })
+  end
+
+  inline_bufnr = bufnr
+  inline_winid = winid
+
+  local preview_id --- @type integer?
   show_added(bufnr, ns_inline, hunk)
   if hunk.removed.count > 0 then
-    winid = show_deleted_in_float(bufnr, ns_inline, hunk, staged)
+    preview_id = DeletedPreview.place_inline_preview_lines(bufnr, ns_inline, hunk, staged, {
+      win = winid,
+      lno_hl = true,
+      leftcol = true,
+      word_diff = true,
+    })
   end
 
   api.nvim_create_autocmd({ 'CursorMoved', 'InsertEnter', 'BufLeave' }, {
     buffer = bufnr,
     desc = 'Clear gitsigns inline preview',
     callback = function()
-      if winid then
-        pcall(api.nvim_win_close, winid, true)
-      end
       clear_preview_inline(bufnr)
     end,
     once = true,
@@ -262,16 +246,24 @@ function M.preview_hunk_inline()
 
   -- Virtual lines will be hidden if they are placed on the top row, so
   -- automatically scroll the viewport.
-  if hunk.added.start <= 1 then
+  if hunk.removed.count > 0 and hunk.added.start <= 1 then
     feedkeys(hunk.removed.count .. '<C-y>')
   end
 
-  return winid
+  return preview_id
 end
 
 --- @param bufnr integer
 --- @return boolean
 function M.has_preview_inline(bufnr)
+  if inline_bufnr ~= bufnr then
+    return false
+  end
+
+  if window_ns_supported and inline_winid ~= api.nvim_get_current_win() then
+    return false
+  end
+
   return #api.nvim_buf_get_extmarks(bufnr, ns_inline, 0, -1, { limit = 1 }) > 0
 end
 

--- a/lua/gitsigns/deleted_preview.lua
+++ b/lua/gitsigns/deleted_preview.lua
@@ -1,0 +1,498 @@
+local cache = require('gitsigns.cache').cache
+local config = require('gitsigns.config').config
+local HunkPreview = require('gitsigns.hunk_preview')
+local Virt = require('gitsigns.render.virt')
+local Inspect = require('gitsigns.inspect')
+local util = require('gitsigns.util')
+
+local api = vim.api
+
+local M = {}
+local window_ns_supported = api.nvim__ns_set ~= nil
+local ns_removed = api.nvim_create_namespace('gitsigns_removed')
+
+local VIRT_LINE_LEN = 300
+local REMOVED_VIRT_LINE_HL = 'GitSignsDeleteVirtLn'
+local REMOVED_INLINE_HL = 'GitSignsDeleteVirtLnInLine'
+local win_ns = {} --- @type table<integer, {ns: integer, bufnr?: integer}>
+local states = {} --- @type table<integer, {hunks: Gitsigns.Hunk.Hunk[], lines: table<Gitsigns.Hunk.Hunk, Gitsigns.CapturedLine[]>, source_bufs: table<string, Gitsigns.HunkPreview.SourceBuf>, pending?: table<Gitsigns.Hunk.Hunk, true>, scheduled?: boolean}>
+
+--- @param str string
+--- @param highlights {group?:string, groups?:string[], start:integer}[]
+--- @return Gitsigns.VirtTextChunk[]
+local function chunks_from_statusline(str, highlights)
+  local chunks = {} --- @type Gitsigns.VirtTextChunk[]
+
+  if #highlights == 0 then
+    Virt.add_chunk(chunks, str, 'LineNr')
+    return chunks
+  end
+
+  local last_start = 0
+  for i, hl in ipairs(highlights) do
+    local start = hl.start
+    local next_start = highlights[i + 1] and highlights[i + 1].start or #str
+
+    if start > last_start then
+      Virt.add_chunk(chunks, str:sub(last_start + 1, start), 'Normal')
+    end
+
+    local groups = hl.groups or (hl.group and { hl.group }) or { 'Normal' }
+    Virt.add_chunk(chunks, str:sub(start + 1, next_start), groups)
+    last_start = next_start
+  end
+
+  if last_start < #str then
+    Virt.add_chunk(chunks, str:sub(last_start + 1), 'Normal')
+  end
+
+  return chunks
+end
+
+--- @param win integer
+--- @param lnum integer
+--- @param width integer
+--- @return Gitsigns.VirtTextChunk[]
+local function fallback_lno_chunks(win, lnum, width)
+  if width <= 0 then
+    return {}
+  end
+
+  local cursor_lnum = assert(api.nvim_win_get_cursor(win)[1])
+  local number = vim.wo[win].number
+  local relativenumber = vim.wo[win].relativenumber
+
+  local display_lnum = lnum
+  if relativenumber and (not number or lnum ~= cursor_lnum) then
+    display_lnum = math.abs(cursor_lnum - lnum)
+  end
+
+  local hl = 'LineNr'
+  if relativenumber and lnum ~= cursor_lnum then
+    hl = lnum < cursor_lnum and 'LineNrAbove' or 'LineNrBelow'
+    if vim.fn.hlexists(hl) == 0 then
+      hl = 'LineNr'
+    end
+  end
+
+  local lno_width = math.max(width - 1, 1)
+  local current_hybrid = number and relativenumber and lnum == cursor_lnum
+  local lno_fmt = current_hybrid and '%-' .. lno_width .. 'd' or '%' .. lno_width .. 'd'
+  local lno_str = string.format(lno_fmt, display_lnum)
+  if width > lno_width then
+    lno_str = lno_str .. ' '
+  end
+  return chunks_from_statusline(lno_str, { { start = 0, groups = { hl } } })
+end
+
+--- @param win integer
+--- @return integer
+local function lno_width(win)
+  local number = vim.wo[win].number
+  local relativenumber = vim.wo[win].relativenumber
+  if not number and not relativenumber then
+    return 0
+  end
+
+  local line_count = api.nvim_buf_line_count(api.nvim_win_get_buf(win))
+
+  local digits = 1
+  if number then
+    digits = math.max(digits, #tostring(line_count))
+  end
+  if relativenumber then
+    local cursor_lnum = assert(api.nvim_win_get_cursor(win)[1])
+    digits = math.max(digits, #tostring(math.max(cursor_lnum - 1, line_count - cursor_lnum)))
+  end
+
+  return math.max(vim.wo[win].numberwidth - 1, digits) + 1
+end
+
+--- @param fmt string
+--- @param win integer
+--- @param lnum integer
+--- @return Gitsigns.VirtTextChunk[]?
+local function eval_statusline_chunks(fmt, win, lnum)
+  local ok, data = pcall(api.nvim_eval_statusline, fmt, {
+    winid = win,
+    use_statuscol_lnum = lnum,
+    highlights = true,
+  })
+  if not ok then
+    return nil
+  end
+
+  return chunks_from_statusline(data.str --[[@as string]], data.highlights or {})
+end
+
+--- Build virtual-text chunks matching the window's statuscolumn/number columns.
+--- @param win integer
+--- @param lnum integer
+--- @param opts? {extra_hl?: Gitsigns.HlName|Gitsigns.HlStack}
+--- @return Gitsigns.VirtTextChunk[]
+local function build_prefix(win, lnum, opts)
+  opts = opts or {}
+  local width = assert(vim.fn.getwininfo(win)[1]).textoff
+
+  local has_col, statuscol = pcall(function()
+    return vim.wo[win].statuscolumn
+  end)
+
+  local chunks = {} --- @type Gitsigns.VirtTextChunk[]
+  if has_col and statuscol and statuscol ~= '' then
+    --- @cast statuscol string
+    chunks = eval_statusline_chunks(statuscol, win, lnum) or fallback_lno_chunks(win, lnum, width)
+  else
+    local number_col_width = math.min(lno_width(win), width)
+    local prefix_width = math.max(width - number_col_width, 0)
+    if prefix_width > 0 then
+      chunks = { { string.rep(' ', prefix_width), 'Normal' } }
+    end
+
+    local body_chunks = fallback_lno_chunks(win, lnum, number_col_width)
+    vim.list_extend(chunks, body_chunks)
+  end
+
+  local extra_hl = opts.extra_hl
+  if extra_hl then
+    for _, chunk in ipairs(chunks) do
+      local groups = {} --- @type Gitsigns.HlStack
+      Inspect.append_hl_group(groups, chunk[2])
+      Inspect.append_hl_group(groups, extra_hl)
+      chunk[2] = Inspect.normalize_hl_groups(groups)
+    end
+  end
+
+  return chunks
+end
+
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @return integer row
+--- @return boolean above
+local function show_deleted_placement(hunk)
+  local topdelete = hunk.added.start == 0 and hunk.type == 'delete'
+  local row = topdelete and 0 or hunk.added.start - 1
+  local above = hunk.type ~= 'delete' or topdelete
+  if above and row > 0 then
+    return row - 1, false
+  end
+  return row, above
+end
+
+--- @param bufnr integer
+local function clear_global_preview(bufnr)
+  api.nvim_buf_clear_namespace(bufnr, ns_removed, 0, -1)
+end
+
+--- @param entry {ns: integer, bufnr?: integer}
+local function clear_win_entry(entry)
+  if entry.bufnr and api.nvim_buf_is_valid(entry.bufnr) then
+    api.nvim_buf_clear_namespace(entry.bufnr, entry.ns, 0, -1)
+  end
+  if window_ns_supported then
+    api.nvim__ns_set(entry.ns, { wins = {} })
+  end
+  entry.bufnr = nil
+end
+
+--- @param bufnr integer
+local function clear_buf_entries(bufnr)
+  for winid, entry in pairs(win_ns) do
+    if entry.bufnr == bufnr then
+      clear_win_entry(entry)
+      win_ns[winid] = nil
+    end
+  end
+end
+
+--- @param winid integer
+--- @param bufnr integer
+--- @return integer
+local function get_win_ns(winid, bufnr)
+  local entry = win_ns[winid]
+  if not entry then
+    entry = {
+      ns = api.nvim_create_namespace(('gitsigns_removed_win_%d'):format(winid)),
+    }
+    win_ns[winid] = entry
+  elseif entry.bufnr and entry.bufnr ~= bufnr and api.nvim_buf_is_valid(entry.bufnr) then
+    api.nvim_buf_clear_namespace(entry.bufnr, entry.ns, 0, -1)
+  end
+
+  entry.bufnr = bufnr
+  api.nvim__ns_set(entry.ns, { wins = { winid } })
+  return entry.ns
+end
+
+--- @param lines Gitsigns.CapturedLine[]
+--- @param start_lnum integer
+--- @param opts? {win?:integer, lno_hl?:boolean}
+--- @return Gitsigns.VirtTextChunk[][]
+local function render_virt_lines(lines, start_lnum, opts)
+  opts = opts or {}
+
+  local prefix --- @type fun(line_index: integer, line: Gitsigns.CapturedLine): Gitsigns.VirtTextChunk[]?
+  if opts.lno_hl then
+    local win = assert(opts.win)
+    prefix = function(line_index)
+      return build_prefix(win, start_lnum + line_index - 1, {
+        extra_hl = 'GitSignsVirtLnum',
+      })
+    end
+  end
+
+  return Virt.render(lines, {
+    pad_width = VIRT_LINE_LEN,
+    pad_with_eol_hl = true,
+    prefix = prefix,
+  })
+end
+
+--- @param bufnr integer
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @param staged boolean?
+--- @param opts? {win?:integer, lno_hl?:boolean, word_diff?:boolean}
+--- @return Gitsigns.VirtTextChunk[][]
+local function build_virt_lines(bufnr, hunk, staged, opts)
+  opts = opts or {}
+  local source_cache = states[bufnr] and states[bufnr].source_bufs or nil
+  local lines = assert(HunkPreview.prepare_removed_hunks(bufnr, { hunk }, staged, {
+    line_hl = REMOVED_VIRT_LINE_HL,
+    word_diff = opts.word_diff,
+    word_diff_hl = REMOVED_INLINE_HL,
+    source_cache = source_cache,
+  })[1])
+  return render_virt_lines(lines, hunk.removed.start, opts)
+end
+
+--- @param bufnr integer
+--- @param hunks Gitsigns.Hunk.Hunk[]
+--- @param captured Gitsigns.CapturedLine[][]
+local function render_global_previews(bufnr, hunks, captured)
+  clear_global_preview(bufnr)
+
+  for i, hunk in ipairs(hunks) do
+    local row, above = show_deleted_placement(hunk)
+    api.nvim_buf_set_extmark(bufnr, ns_removed, row, -1, {
+      priority = 1000,
+      virt_lines = render_virt_lines(assert(captured[i]), hunk.removed.start),
+      virt_lines_above = above,
+    })
+  end
+end
+
+--- @param source_bufs table<string, Gitsigns.HunkPreview.SourceBuf>?
+local function clear_source_bufs(source_bufs)
+  if not source_bufs then
+    return
+  end
+
+  for _, source_buf in pairs(source_bufs) do
+    pcall(api.nvim_buf_delete, source_buf.bufnr, { force = true })
+  end
+end
+
+--- @param bufnr integer
+--- @param state {hunks: Gitsigns.Hunk.Hunk[], lines: table<Gitsigns.Hunk.Hunk, Gitsigns.CapturedLine[]>, source_bufs: table<string, Gitsigns.HunkPreview.SourceBuf>, pending?: table<Gitsigns.Hunk.Hunk, true>, scheduled?: boolean}
+local function flush_pending_entries(bufnr, state)
+  if states[bufnr] ~= state then
+    return
+  end
+  state.scheduled = nil
+
+  local pending = state.pending
+  state.pending = nil
+  if not pending then
+    return
+  end
+
+  local missing = {} --- @type Gitsigns.Hunk.Hunk[]
+  for _, hunk in ipairs(state.hunks) do
+    if pending[hunk] and not state.lines[hunk] then
+      missing[#missing + 1] = hunk
+    end
+  end
+
+  if #missing == 0 then
+    return
+  end
+
+  local captured = HunkPreview.prepare_removed_hunks(bufnr, missing, false, {
+    line_hl = REMOVED_VIRT_LINE_HL,
+    word_diff = config.word_diff,
+    word_diff_hl = REMOVED_INLINE_HL,
+    source_cache = state.source_bufs,
+  })
+
+  if states[bufnr] ~= state then
+    return
+  end
+
+  for i, hunk in ipairs(missing) do
+    state.lines[hunk] = captured[i]
+  end
+
+  if api.nvim_buf_is_valid(bufnr) then
+    util.redraw({ buf = bufnr, range = { 0, api.nvim_buf_line_count(bufnr) } })
+  end
+end
+
+--- Shared with preview_hunk_inline() so removed lines use the same capture path
+--- and highlighting as show_deleted.
+--- @param bufnr integer
+--- @param ns integer
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @param staged boolean?
+--- @param opts? {win?:integer, lno_hl?:boolean, leftcol?:boolean, word_diff?:boolean}
+--- @return integer markid
+function M.place_inline_preview_lines(bufnr, ns, hunk, staged, opts)
+  opts = opts or {}
+  local topdelete = hunk.added.start == 0 and hunk.type == 'delete'
+  local row = topdelete and 0 or hunk.added.start - 1
+  local above = hunk.type ~= 'delete' or topdelete
+  return api.nvim_buf_set_extmark(bufnr, ns, row, -1, {
+    virt_lines = build_virt_lines(bufnr, hunk, staged, opts),
+    virt_lines_above = above,
+    virt_lines_leftcol = opts.leftcol == true,
+  })
+end
+
+--- @param bufnr integer
+function M.detach(bufnr)
+  local state = states[bufnr]
+  states[bufnr] = nil
+
+  clear_global_preview(bufnr)
+  clear_buf_entries(bufnr)
+
+  clear_source_bufs(state and state.source_bufs)
+end
+
+--- @param bufnr integer
+function M.prepare(bufnr)
+  local prev = states[bufnr]
+
+  if not config.show_deleted then
+    states[bufnr] = nil
+    clear_global_preview(bufnr)
+    clear_buf_entries(bufnr)
+    clear_source_bufs(prev and prev.source_bufs)
+    return
+  end
+
+  local bcache = cache[bufnr]
+  if not bcache or not bcache.hunks or #bcache.hunks == 0 then
+    states[bufnr] = nil
+    clear_global_preview(bufnr)
+    clear_buf_entries(bufnr)
+    clear_source_bufs(prev and prev.source_bufs)
+    return
+  end
+
+  local state = {
+    hunks = bcache.hunks,
+    lines = {},
+    source_bufs = prev and prev.source_bufs or {},
+  }
+  states[bufnr] = state
+
+  if not window_ns_supported then
+    local captured = HunkPreview.prepare_removed_hunks(bufnr, bcache.hunks, false, {
+      line_hl = REMOVED_VIRT_LINE_HL,
+      word_diff = config.word_diff,
+      word_diff_hl = REMOVED_INLINE_HL,
+      source_cache = state.source_bufs,
+    })
+
+    for i, hunk in ipairs(bcache.hunks) do
+      state.lines[hunk] = captured[i]
+    end
+
+    render_global_previews(bufnr, bcache.hunks, captured)
+  end
+end
+
+--- @param winid integer
+function M.clear_win(winid)
+  local entry = win_ns[winid]
+  if not entry then
+    return
+  end
+
+  clear_win_entry(entry)
+  win_ns[winid] = nil
+end
+
+--- @param winid integer
+--- @param bufnr integer
+--- @param topline integer
+--- @param botline integer
+--- @return boolean
+function M.on_win(winid, bufnr, topline, botline)
+  if not window_ns_supported then
+    return false
+  end
+
+  local render_ns = get_win_ns(winid, bufnr)
+  local state = states[bufnr]
+  if not state or #state.hunks == 0 then
+    api.nvim_buf_clear_namespace(bufnr, render_ns, 0, -1)
+    return false
+  end
+
+  local visible = {} --- @type {row: integer, above: boolean, start_lnum: integer, lines: Gitsigns.CapturedLine[]}[]
+  local missing = {} --- @type Gitsigns.Hunk.Hunk[]
+  for _, hunk in ipairs(state.hunks) do
+    local row, above = show_deleted_placement(hunk)
+    if row >= topline - 1 and row < botline then
+      local lines = state.lines[hunk]
+      if lines then
+        visible[#visible + 1] = {
+          row = row,
+          above = above,
+          start_lnum = hunk.removed.start,
+          lines = lines,
+        }
+      else
+        missing[#missing + 1] = hunk
+      end
+    end
+  end
+
+  if #missing > 0 then
+    state.pending = state.pending or {}
+    for _, hunk in ipairs(missing) do
+      state.pending[hunk] = true
+    end
+
+    if not state.scheduled then
+      state.scheduled = true
+
+      -- This path is entered from the decoration provider on_win callback.
+      -- Capturing removed lines updates scratch source buffers before capture,
+      -- which is not allowed while the buffer is being drawn, so defer the flush.
+      vim.schedule(function()
+        flush_pending_entries(bufnr, state)
+      end)
+    end
+    return #visible > 0
+  end
+
+  api.nvim_buf_clear_namespace(bufnr, render_ns, 0, -1)
+
+  for _, entry in ipairs(visible) do
+    api.nvim_buf_set_extmark(bufnr, render_ns, entry.row, -1, {
+      priority = 1000,
+      virt_lines = render_virt_lines(entry.lines, entry.start_lnum, {
+        win = winid,
+        lno_hl = true,
+      }),
+      virt_lines_above = entry.above,
+      virt_lines_leftcol = true,
+    })
+  end
+
+  return #visible > 0
+end
+
+return M

--- a/lua/gitsigns/hunk_preview.lua
+++ b/lua/gitsigns/hunk_preview.lua
@@ -1,0 +1,375 @@
+local cache = require('gitsigns.cache').cache
+local Capture = require('gitsigns.render.capture')
+local Overlay = require('gitsigns.render.overlay')
+local config = require('gitsigns.config').config
+local util = require('gitsigns.util')
+
+local api = vim.api
+
+local M = {}
+
+--- @class (exact) Gitsigns.HunkPreview.SourceBuf
+--- @field bufnr integer
+--- @field version any
+
+local NO_NL_TEXT = '\\ No newline at end of file'
+local preview_hls = {
+  removed = {
+    prefix = '-',
+    line = 'GitSignsDeletePreview',
+  },
+  added = {
+    prefix = '+',
+    line = 'GitSignsAddPreview',
+  },
+}
+
+--- @param pbufnr integer
+--- @param source_buf integer
+local function sync_source_buf_options(pbufnr, source_buf)
+  vim.bo[pbufnr].filetype = vim.bo[source_buf].filetype
+  vim.bo[pbufnr].tabstop = vim.bo[source_buf].tabstop
+  vim.bo[pbufnr].syntax = vim.bo[source_buf].syntax
+end
+
+local function wait_for_source_render()
+  -- Flush one event-loop turn so delayed FileType/syntax/treesitter work on
+  -- the scratch source buffer is visible before we capture highlights from it.
+  -- This is still synchronous.
+  vim.wait(0)
+end
+
+--- @param bufnr integer
+--- @param lines string[]
+--- @return integer source_bufnr
+local function create_scratch_source_buf(bufnr, lines)
+  local pbufnr = api.nvim_create_buf(false, true)
+  vim.bo[pbufnr].bufhidden = 'wipe'
+  api.nvim_buf_set_lines(pbufnr, 0, -1, false, lines)
+  sync_source_buf_options(pbufnr, bufnr)
+  return pbufnr
+end
+
+--- @param source_cache? table<string, Gitsigns.HunkPreview.SourceBuf>
+--- @param bufnr integer
+--- @param lines string[]
+--- @param cache_key string
+--- @return integer source_bufnr
+local function ensure_cached_source_buf(source_cache, bufnr, lines, cache_key)
+  if not source_cache then
+    return create_scratch_source_buf(bufnr, lines)
+  end
+
+  local source_buf = source_cache[cache_key] --- @type Gitsigns.HunkPreview.SourceBuf?
+  if source_buf and api.nvim_buf_is_valid(source_buf.bufnr) and source_buf.version ~= lines then
+    -- Recreate the cached scratch buffer when the source text changes so any
+    -- extmarks/highlights derived from the old contents are discarded.
+    pcall(api.nvim_buf_delete, source_buf.bufnr, { force = true })
+    source_buf = nil
+  end
+
+  if not (source_buf and api.nvim_buf_is_valid(source_buf.bufnr)) then
+    local source_bufnr = api.nvim_create_buf(false, true)
+    source_buf = {
+      bufnr = source_bufnr,
+      version = lines,
+    }
+    api.nvim_buf_set_lines(source_bufnr, 0, -1, false, lines)
+    source_cache[cache_key] = source_buf
+  end
+
+  local source_bufnr = assert(source_buf).bufnr
+  -- Cached scratch sources are reused across captures, so keep them hidden
+  -- instead of wiping them when they are no longer displayed.
+  vim.bo[source_bufnr].bufhidden = 'hide'
+  sync_source_buf_options(source_bufnr, bufnr)
+  return source_bufnr
+end
+
+--- Prepare a source buffer for capture. This is the only step that waits for
+--- delayed FileType/syntax/Treesitter work to settle.
+--- @param bufnr integer
+--- @param source integer|string[]
+--- @param opts? {source_cache?: table<string, Gitsigns.HunkPreview.SourceBuf>, cache_key?: string}
+--- @return integer source_bufnr
+--- @return fun() cleanup
+local function prepare_source(bufnr, source, opts)
+  opts = opts or {}
+
+  if type(source) == 'number' then
+    return source, function() end
+  end
+
+  local lines = source
+  if vim.bo[bufnr].fileformat == 'dos' then
+    lines = util.strip_cr(lines)
+  end
+
+  if opts.source_cache then
+    local source_bufnr =
+      ensure_cached_source_buf(opts.source_cache, bufnr, lines, assert(opts.cache_key))
+    wait_for_source_render()
+    return source_bufnr, function() end
+  end
+
+  local source_bufnr = create_scratch_source_buf(bufnr, lines)
+  wait_for_source_render()
+  return source_bufnr,
+    function()
+      pcall(api.nvim_buf_delete, source_bufnr, { force = true })
+    end
+end
+
+--- @param bufnr integer
+--- @param staged boolean?
+--- @param source_cache? table<string, Gitsigns.HunkPreview.SourceBuf>
+--- @return integer source_bufnr
+--- @return fun() cleanup
+function M.prepare_removed_source(bufnr, staged, source_cache)
+  local bcache = assert(cache[bufnr])
+  local lines = assert(staged and bcache.compare_text_head or bcache.compare_text) --[[@as string[] ]]
+  local cache_key = staged and 'removed:staged' or 'removed:unstaged'
+  return prepare_source(bufnr, lines, {
+    source_cache = source_cache,
+    cache_key = cache_key,
+  })
+end
+
+--- @param lines Gitsigns.CapturedLine[]
+--- @param line_hl? Gitsigns.HlName|Gitsigns.HlStack
+--- @param word_diff? [integer, string, integer, integer][]
+--- @param word_diff_hl Gitsigns.HlName|fun(region_type: string, region: [integer, string, integer, integer]): Gitsigns.HlName?
+--- @param line_priority? integer
+--- @param word_diff_priority? integer
+--- @return Gitsigns.CapturedLine[]
+local function apply_capture_layers(
+  lines,
+  line_hl,
+  word_diff,
+  word_diff_hl,
+  line_priority,
+  word_diff_priority
+)
+  if line_hl then
+    Overlay.add_full_line_layer(lines, line_hl, line_priority or 1000)
+  end
+  if word_diff then
+    Overlay.add_word_diff_layers(lines, word_diff, word_diff_hl, word_diff_priority or 1001)
+  end
+
+  return lines
+end
+
+--- @param removed string[]
+--- @param added string[]
+--- @param kind 'removed'|'added'
+--- @return {[1]:integer, [2]:string, [3]:integer, [4]:integer}[]
+local function word_diff_regions(removed, added, kind)
+  local removed_regions, added_regions = require('gitsigns.diff_int').run_word_diff(removed, added)
+  return kind == 'removed' and removed_regions or added_regions
+end
+
+--- @param bufnr integer
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @return [integer, string, integer, integer][]
+local function removed_word_diff_regions(bufnr, hunk)
+  local removed = hunk.removed.lines
+  local added = hunk.added.lines
+
+  if vim.bo[bufnr].fileformat == 'dos' then
+    removed = util.strip_cr(removed)
+    added = util.strip_cr(added)
+  end
+
+  local removed_regions = require('gitsigns.diff_int').run_word_diff(removed, added)
+  return removed_regions
+end
+
+--- @param bufnr integer
+--- @param source_bufnr integer
+--- @param hunks Gitsigns.Hunk.Hunk[]
+--- @param opts {line_hl: Gitsigns.HlName|Gitsigns.HlStack, word_diff?: boolean, word_diff_hl: Gitsigns.HlName|fun(region_type: string, region: [integer, string, integer, integer]): Gitsigns.HlName?}
+--- @return Gitsigns.CapturedLine[][]
+function M.capture_removed_hunks_from_source(bufnr, source_bufnr, hunks, opts)
+  local ret = {} --- @type Gitsigns.CapturedLine[][]
+  for i, hunk in ipairs(hunks) do
+    ret[i] = apply_capture_layers(
+      Capture.capture_node(source_bufnr, hunk.removed),
+      opts.line_hl,
+      opts.word_diff and removed_word_diff_regions(bufnr, hunk) or nil,
+      opts.word_diff_hl
+    )
+  end
+  return ret
+end
+
+--- Prepare the removed source as needed and return captured removed lines.
+--- May allocate scratch buffers and wait for source rendering before capture.
+--- @param bufnr integer
+--- @param hunks Gitsigns.Hunk.Hunk[]
+--- @param staged boolean?
+--- @param opts {source_cache?: table<string, Gitsigns.HunkPreview.SourceBuf>, line_hl: Gitsigns.HlName|Gitsigns.HlStack, word_diff?: boolean, word_diff_hl: Gitsigns.HlName|fun(region_type: string, region: [integer, string, integer, integer]): Gitsigns.HlName?}
+--- @return Gitsigns.CapturedLine[][]
+function M.prepare_removed_hunks(bufnr, hunks, staged, opts)
+  local source_bufnr, cleanup = M.prepare_removed_source(bufnr, staged, opts.source_cache)
+  local captured = M.capture_removed_hunks_from_source(bufnr, source_bufnr, hunks, {
+    line_hl = opts.line_hl,
+    word_diff = opts.word_diff ~= false,
+    word_diff_hl = opts.word_diff_hl,
+  })
+  cleanup()
+  return captured
+end
+
+--- @param layer Gitsigns.RenderLayer
+--- @param text_len integer
+--- @return Gitsigns.HlMark?
+local function layer_to_mark(layer, text_len)
+  local start_col = math.max(layer.start_col, 0)
+  local end_col = math.max(layer.end_col, start_col)
+
+  if end_col <= start_col then
+    return
+  end
+
+  -- Popup line highlights are added as 0 .. #text + 1 so the buffer extmark
+  -- can span to the start of the next row and cover the visible EOL padding.
+  local extends_to_eol = start_col == 0 and end_col > text_len
+
+  return {
+    hl_group = layer.hl_group,
+    start_row = 0,
+    start_col = start_col,
+    end_row = extends_to_eol and 1 or 0,
+    end_col = extends_to_eol and 0 or math.min(end_col, text_len),
+    priority = layer.priority,
+  }
+end
+
+--- @param lines Gitsigns.CapturedLine[]
+--- @param opts? {no_nl_at_eof?: boolean}
+--- @return Gitsigns.LineSpec[]
+local function render_popup_lines(lines, opts)
+  opts = opts or {}
+
+  local ret = {} --- @type Gitsigns.LineSpec[]
+  for i, line in ipairs(lines) do
+    local marks = {} --- @type Gitsigns.HlMark[]
+    for _, layer in ipairs(line.layers or {}) do
+      marks[#marks + 1] = layer_to_mark(layer, #line.text)
+    end
+    ret[i] = { { line.text, marks } }
+  end
+
+  if opts.no_nl_at_eof then
+    ret[#ret + 1] = {
+      {
+        NO_NL_TEXT,
+        {
+          {
+            start_row = 0,
+            end_row = 1,
+            hl_group = 'GitSignsNoEOLPreview',
+          },
+        },
+      },
+    }
+  end
+
+  return ret
+end
+
+--- @param _bufnr integer
+--- @param kind 'removed'|'added'
+--- @param source_bufnr integer
+--- @param node Gitsigns.Hunk.Node
+--- @param removed string[]
+--- @param added string[]
+--- @return Gitsigns.CapturedLine[]
+local function capture_popup_lines(_bufnr, kind, source_bufnr, node, removed, added)
+  local captured = apply_capture_layers(
+    Capture.capture_node(source_bufnr, node),
+    nil,
+    config.diff_opts.internal and word_diff_regions(removed, added, kind) or nil,
+    function(region_type)
+      return kind == 'removed' and 'GitSignsDeleteInline'
+        or region_type == 'add' and 'GitSignsAddInline'
+        or region_type == 'change' and 'GitSignsChangeInline'
+        or 'GitSignsDeleteInline'
+    end
+  )
+
+  local prefix = preview_hls[kind].prefix
+  local prefix_len = #prefix
+  local line_hl = preview_hls[kind].line
+  for _, line in ipairs(captured) do
+    if prefix_len > 0 then
+      for _, layer in ipairs(line.layers) do
+        layer.start_col = layer.start_col + prefix_len
+        layer.end_col = layer.end_col + prefix_len
+      end
+      line.text = prefix .. line.text
+    end
+
+    Overlay.add_layer(line, 0, #line.text + 1, line_hl, 1000)
+  end
+
+  return captured
+end
+
+--- Return popup lines for a hunk.
+--- May allocate scratch buffers and wait for source rendering before capture.
+--- @param bufnr integer
+--- @param hunk Gitsigns.Hunk.Hunk
+--- @param removed_source integer|string[]
+--- @param added_source integer|string[]
+--- @param added_node Gitsigns.Hunk.Node
+--- @return Gitsigns.LineSpec[]
+function M.linespec_for_hunk(bufnr, hunk, removed_source, added_source, added_node)
+  local removed_source_bufnr, cleanup_removed = prepare_source(bufnr, removed_source)
+  local added_source_bufnr, cleanup_added = prepare_source(bufnr, added_source)
+
+  local removed = hunk.removed.lines
+  local added = hunk.added.lines
+
+  if vim.bo[bufnr].fileformat == 'dos' then
+    removed = util.strip_cr(removed)
+    added = util.strip_cr(added)
+  end
+
+  local ret = {} --- @type Gitsigns.LineSpec[]
+  if hunk.removed.count > 0 then
+    vim.list_extend(
+      ret,
+      render_popup_lines(
+        capture_popup_lines(bufnr, 'removed', removed_source_bufnr, hunk.removed, removed, added),
+        {
+          no_nl_at_eof = config.diff_opts.internal
+            and hunk.removed.no_nl_at_eof
+            and not hunk.added.no_nl_at_eof,
+        }
+      )
+    )
+  end
+
+  if added_node.count > 0 then
+    vim.list_extend(
+      ret,
+      render_popup_lines(
+        capture_popup_lines(bufnr, 'added', added_source_bufnr, added_node, removed, added),
+        {
+          no_nl_at_eof = config.diff_opts.internal
+            and added_node.no_nl_at_eof
+            and not hunk.removed.no_nl_at_eof,
+        }
+      )
+    )
+  end
+
+  cleanup_added()
+  cleanup_removed()
+
+  return ret
+end
+
+return M

--- a/lua/gitsigns/inspect.lua
+++ b/lua/gitsigns/inspect.lua
@@ -1,0 +1,318 @@
+local InspectPos = require('gitsigns.inspect.compat')
+
+local M = {}
+
+--- @alias Gitsigns.HlName string|integer
+--- @alias Gitsigns.HlStack Gitsigns.HlName[]
+
+--- @class Gitsigns.InspectPosItem
+--- @field hl_group? Gitsigns.HlName|Gitsigns.HlStack highlight group name
+--- @field hl_group_link string resolved highlight group (after following links)
+--- @field row? integer start row (0-based)
+--- @field col? integer start column (0-based)
+--- @field end_row? integer end row (0-based, exclusive)
+--- @field end_col? integer end column (0-based, exclusive)
+
+--- @class Gitsigns.InspectPosTSItem : Gitsigns.InspectPosItem
+--- @field capture string treesitter capture name
+--- @field lang string parser language
+--- @field metadata vim.treesitter.query.TSMetadata capture metadata
+--- @field id integer capture id
+--- @field pattern_id integer pattern id
+
+--- @class Gitsigns.InspectPosExtmarkItem : Gitsigns.InspectPosItem
+--- @field id integer extmark id
+--- @field ns_id integer namespace id
+--- @field ns string namespace name
+--- Note: `opts.hl_group_link` is deprecated; use the top-level `hl_group_link` field.
+--- @field opts vim.api.keyset.extmark_details raw extmark details from |nvim_buf_get_extmarks()|.
+
+--- @class Gitsigns.InspectPosResult
+--- @inlinedoc
+--- @field buffer integer buffer number
+--- @field row integer queried start row (0-based)
+--- @field col integer queried start column (0-based)
+--- @field end_row? integer queried end row (only set for range queries)
+--- @field end_col? integer queried end column (only set for range queries)
+--- @field treesitter Gitsigns.InspectPosTSItem[]
+--- @field syntax Gitsigns.InspectPosItem[]
+--- @field extmarks Gitsigns.InspectPosExtmarkItem[]
+--- @field semantic_tokens Gitsigns.InspectPosExtmarkItem[]
+
+--- @class Gitsigns.InspectItem : Gitsigns.InspectPosItem
+--- @field priority integer
+--- @field order integer
+--- @field hl_group? Gitsigns.HlName|Gitsigns.HlStack
+--- @field hl_group_link? string
+--- @field capture? string
+--- @field lang? string
+--- @field metadata? vim.treesitter.query.TSMetadata
+--- @field pattern_id? integer
+--- @field id? integer
+--- @field ns? string
+--- @field ns_id? integer
+--- @field opts? {hl_group?:Gitsigns.HlName|Gitsigns.HlStack, hl_group_link?:string, priority?:integer, ns_id?:integer, end_row?:integer, end_col?:integer}
+
+--- @class Gitsigns.InspectRange
+--- @field buffer integer
+--- @field row integer
+--- @field start_col integer
+--- @field end_col integer
+--- @field items Gitsigns.InspectItem[]
+
+--- @class Gitsigns.HlSegment
+--- @field start_col integer
+--- @field end_col integer
+--- @field hl Gitsigns.HlStack
+
+--- @param groups Gitsigns.HlStack
+--- @return Gitsigns.HlName|Gitsigns.HlStack
+function M.normalize_hl_groups(groups)
+  if #groups == 1 and groups[1] ~= nil then
+    return groups[1]
+  end
+  return groups
+end
+
+--- @param hl Gitsigns.HlName|Gitsigns.HlStack
+--- @return Gitsigns.HlName|Gitsigns.HlStack
+function M.normalize_hl(hl)
+  if type(hl) == 'table' then
+    return M.normalize_hl_groups(hl)
+  end
+  return hl
+end
+
+--- @param a Gitsigns.HlName|Gitsigns.HlStack
+--- @param b Gitsigns.HlName|Gitsigns.HlStack
+--- @return boolean
+function M.same_hl(a, b)
+  local ta, tb = type(a), type(b)
+  if ta ~= tb then
+    return false
+  end
+  if ta ~= 'table' then
+    return a == b
+  end
+
+  --- @cast a Gitsigns.HlStack
+  --- @cast b Gitsigns.HlStack
+  if #a ~= #b then
+    return false
+  end
+  for i = 1, #a do
+    if a[i] ~= b[i] then
+      return false
+    end
+  end
+  return true
+end
+
+--- @param dest Gitsigns.HlStack
+--- @param group Gitsigns.HlName|Gitsigns.HlStack|nil
+function M.append_hl_group(dest, group)
+  if not group or group == '' then
+    return
+  end
+  if type(group) == 'table' then
+    --- @cast group Gitsigns.HlStack
+    for _, hl in ipairs(group) do
+      if hl ~= '' then
+        dest[#dest + 1] = hl
+      end
+    end
+    return
+  end
+  dest[#dest + 1] = group
+end
+
+--- @param item {row?:integer, col?:integer, end_row?:integer, end_col?:integer}
+--- @param row integer
+--- @param col integer
+--- @return boolean
+local function item_overlaps_pos(item, row, col)
+  local start_row = item.row or row
+  local start_col = item.col or col
+  local end_row = item.end_row or start_row
+  local end_col = item.end_col or start_col
+
+  if row < start_row or row > end_row then
+    return false
+  elseif row == start_row and col < start_col then
+    return false
+  elseif row == end_row and col >= end_col then
+    return false
+  end
+  return true
+end
+
+--- Resolve the effective Treesitter priority for a capture item.
+--- @param capture Gitsigns.InspectPosTSItem
+--- @return integer
+local function treesitter_priority(capture)
+  local metadata = capture.metadata
+  local capture_metadata = metadata[capture.id]
+  local priority = metadata.priority
+  if type(priority) == 'number' then
+    --- @cast priority integer
+    return priority
+  end
+
+  priority = type(capture_metadata) == 'table' and capture_metadata.priority or nil
+  if type(priority) == 'number' then
+    --- @cast priority integer
+    return priority
+  end
+
+  local default_priority = vim.hl.priorities.treesitter
+  --- @cast default_priority integer
+  return default_priority
+end
+
+--- Collect byte-column boundaries where the active highlight stack can change.
+--- @param inspected Gitsigns.InspectRange
+--- @return integer[]
+function M.boundaries(inspected)
+  local cols = {
+    [inspected.start_col] = true,
+    [inspected.end_col] = true,
+  }
+
+  for _, item in ipairs(inspected.items) do
+    local start_col = item.col or inspected.start_col
+    local end_col = item.end_col or start_col
+
+    if start_col > inspected.start_col and start_col < inspected.end_col then
+      cols[start_col] = true
+    end
+    if end_col > inspected.start_col and end_col < inspected.end_col then
+      cols[end_col] = true
+    end
+  end
+
+  local ret = {} --- @type integer[]
+  for col in pairs(cols) do
+    ret[#ret + 1] = col
+  end
+  table.sort(ret)
+  return ret
+end
+
+--- Return the highlight stack active at a byte column.
+--- @param inspected Gitsigns.InspectRange
+--- @param col integer
+--- @return Gitsigns.HlStack
+function M.hl_stack_at(inspected, col)
+  local stack = {} --- @type Gitsigns.HlStack
+
+  for _, item in ipairs(inspected.items) do
+    if item.hl_group and item_overlaps_pos(item, inspected.row, col) then
+      M.append_hl_group(stack, item.hl_group)
+    end
+  end
+
+  return stack
+end
+
+--- Inspect a single-line range and normalize its highlights into ordered items.
+--- @param bufnr integer
+--- @param row integer
+--- @param start_col integer
+--- @param end_col integer
+--- @return Gitsigns.InspectRange
+function M.inspect_range(bufnr, row, start_col, end_col)
+  assert(end_col >= start_col, 'end_col must be greater than or equal to start_col')
+
+  local result = InspectPos.inspect_pos(bufnr, row, start_col, {
+    end_row = row,
+    -- UTF-8 codepoints are at most 4 bytes, so this always reaches at least
+    -- the next byte boundary after end_col.
+    end_col = end_col + 4,
+  })
+
+  --- @type Gitsigns.InspectRange
+  local ret = {
+    buffer = result.buffer,
+    row = result.row,
+    start_col = start_col,
+    end_col = end_col,
+    items = {},
+  }
+
+  --- Append a normalized item while preserving insertion order for equal priorities.
+  --- @param items Gitsigns.InspectItem[]
+  --- @param item Gitsigns.InspectPosItem
+  --- @param priority integer
+  local function add_item(items, item, priority)
+    --- @cast item Gitsigns.InspectItem
+    item.priority = priority
+    item.order = #items + 1
+    items[#items + 1] = item
+  end
+
+  for _, item in ipairs(result.syntax) do
+    add_item(ret.items, item, 0)
+  end
+  for _, item in ipairs(result.treesitter) do
+    add_item(ret.items, item, treesitter_priority(item))
+  end
+  for _, item in ipairs(result.semantic_tokens) do
+    add_item(ret.items, item, item.opts.priority or 0)
+  end
+  for _, item in ipairs(result.extmarks) do
+    add_item(ret.items, item, item.opts.priority or 0)
+  end
+
+  table.sort(ret.items, function(a, b)
+    if a.priority == b.priority then
+      return a.order < b.order
+    end
+    return a.priority < b.priority
+  end)
+
+  return ret
+end
+
+--- Split a single-line range into contiguous segments with identical highlight stacks.
+--- @param bufnr integer
+--- @param row integer
+--- @param start_col integer
+--- @param end_col integer
+--- @return Gitsigns.InspectRange
+--- @return Gitsigns.HlSegment[]
+function M.hl_segments(bufnr, row, start_col, end_col)
+  local inspected = M.inspect_range(bufnr, row, start_col, end_col)
+  local segments = {} --- @type Gitsigns.HlSegment[]
+  local current_hl --- @type Gitsigns.HlStack?
+  local current_start = inspected.start_col
+  local cols = M.boundaries(inspected)
+
+  for i = 1, #cols - 1 do
+    local col = assert(cols[i])
+    local hl = M.hl_stack_at(inspected, col)
+    if current_hl == nil then
+      current_start = col
+      current_hl = hl
+    elseif not M.same_hl(current_hl, hl) then
+      segments[#segments + 1] = {
+        start_col = current_start,
+        end_col = col,
+        hl = current_hl,
+      }
+      current_start = col
+      current_hl = hl
+    end
+  end
+
+  if current_hl then
+    segments[#segments + 1] = {
+      start_col = current_start,
+      end_col = end_col,
+      hl = current_hl,
+    }
+  end
+
+  return inspected, segments
+end
+
+return M

--- a/lua/gitsigns/inspect/compat.lua
+++ b/lua/gitsigns/inspect/compat.lua
@@ -1,0 +1,375 @@
+local api = vim.api
+
+-- Vendored from vim._inspector with minimal changes to support single-row
+-- ranges.
+
+local M = {}
+
+local defaults = {
+  syntax = true,
+  treesitter = true,
+  extmarks = true,
+  semantic_tokens = true,
+}
+
+--- @class Gitsigns.InspectCompatFilter
+--- @field syntax? boolean
+--- @field treesitter? boolean
+--- @field extmarks? boolean|'all'
+--- @field semantic_tokens? boolean
+--- @field end_row? integer
+--- @field end_col? integer
+
+--- @class Gitsigns.InspectCompatCapture
+--- @field capture string
+--- @field lang string
+--- @field metadata vim.treesitter.query.TSMetadata
+--- @field id integer
+--- @field pattern_id integer
+
+--- @param line string
+--- @param col integer
+--- @return integer
+local function next_boundary(line, col)
+  local nchars = vim.str_utfindex(line, 'utf-32')
+  for i = 0, nchars do
+    local byte_col = vim.str_byteindex(line, 'utf-32', i)
+    if byte_col > col then
+      return byte_col
+    end
+  end
+  return col + 1
+end
+
+--- @param line string
+--- @param start_col integer
+--- @param end_col integer
+--- @return integer[]
+local function range_columns(line, start_col, end_col)
+  local cols = {
+    [start_col] = true,
+    [end_col] = true,
+  }
+
+  local nchars = vim.str_utfindex(line, 'utf-32')
+  for i = 0, nchars do
+    local col = vim.str_byteindex(line, 'utf-32', i)
+    if col >= start_col and col <= end_col then
+      cols[col] = true
+    end
+  end
+
+  local ret = {} --- @type integer[]
+  for col in pairs(cols) do
+    ret[#ret + 1] = col
+  end
+  table.sort(ret)
+  return ret
+end
+
+--- @param hl Gitsigns.HlName|Gitsigns.HlStack
+--- @return Gitsigns.HlName|Gitsigns.HlStack|nil
+--- @return string?
+local function resolve_hl_group(hl)
+  if hl == nil or hl == '' then
+    return nil, nil
+  end
+
+  if type(hl) == 'table' then
+    local groups = {} --- @type Gitsigns.HlStack
+    for _, group in ipairs(hl) do
+      local resolved = select(1, resolve_hl_group(group))
+      if resolved and resolved ~= '' then
+        if type(resolved) == 'table' then
+          vim.list_extend(groups, resolved)
+        else
+          groups[#groups + 1] = resolved
+        end
+      end
+    end
+    return #groups > 0 and groups or nil, nil
+  end
+
+  local hlid --- @type integer?
+  if type(hl) == 'number' then
+    hlid = hl --[[@as integer]]
+  elseif type(hl) == 'string' then
+    hlid = api.nvim_get_hl_id_by_name(hl)
+  end
+
+  if not hlid then
+    return nil, nil
+  end
+
+  local name = vim.fn.synIDattr(hlid, 'name')
+  if name == '' then
+    return nil, nil
+  end
+
+  local link = vim.fn.synIDattr(vim.fn.synIDtrans(hlid), 'name')
+  return name, link
+end
+
+--- @param data table
+--- @return table
+local function resolve_hl(data)
+  local resolved, link = resolve_hl_group(data.hl_group)
+  data.hl_group = resolved
+  data.hl_group_link = link or ''
+  return data
+end
+
+--- @return table<integer, string>
+local function namespace_map()
+  local nsmap = {} --- @type table<integer, string>
+  for name, id in pairs(api.nvim_get_namespaces()) do
+    nsmap[id] = name
+  end
+  return nsmap
+end
+
+--- @param extmark vim.api.keyset.get_extmark_item
+--- @param nsmap table<integer, string>
+--- @return Gitsigns.InspectPosExtmarkItem
+local function extmark_to_map(extmark, nsmap)
+  local details = (extmark[4] or {}) --[[@as vim.api.keyset.extmark_details]]
+  local end_row = details.end_row
+  local end_col = details.end_col
+  if details.hl_eol and end_row == nil and end_col == nil then
+    end_row = extmark[2] + 1
+    end_col = 0
+  end
+
+  local item = {
+    id = extmark[1],
+    row = extmark[2],
+    col = extmark[3],
+    end_row = end_row or extmark[2],
+    end_col = end_col or extmark[3],
+    hl_group = details.hl_group,
+    hl_group_link = '',
+    opts = details,
+    ns_id = details.ns_id,
+    ns = details.ns_id and nsmap[details.ns_id] or '',
+  } --- @type Gitsigns.InspectPosExtmarkItem
+
+  return resolve_hl(item) --[[@as Gitsigns.InspectPosExtmarkItem]]
+end
+
+--- @param extmark table
+--- @param row integer
+--- @param col integer
+--- @return boolean
+local function overlaps_single_pos(extmark, row, col)
+  if row < extmark.row or row > extmark.end_row then
+    return false
+  end
+  if row == extmark.row and col < extmark.col then
+    return false
+  end
+  return row < extmark.end_row or col < extmark.end_col
+end
+
+--- @param capture table
+--- @return string
+local function capture_key(capture)
+  local metadata = capture.metadata or {}
+  local capture_metadata = metadata[capture.id]
+  local priority = metadata.priority
+    or (type(capture_metadata) == 'table' and capture_metadata.priority or nil)
+    or ''
+  return table.concat({
+    capture.capture,
+    capture.lang,
+    tostring(capture.id),
+    tostring(capture.pattern_id or ''),
+    tostring(priority),
+  }, '\0')
+end
+
+--- @param bufnr integer
+--- @param row integer
+--- @param cols integer[]
+--- @return Gitsigns.InspectPosTSItem[]
+local function collect_treesitter(bufnr, row, cols)
+  local items = {} --- @type Gitsigns.InspectPosTSItem[]
+  local previous = {} --- @type table<string, Gitsigns.InspectPosTSItem>
+
+  for i = 1, #cols - 1 do
+    local col = assert(cols[i])
+    local next_col = assert(cols[i + 1])
+    local active = {} --- @type table<string, Gitsigns.InspectPosTSItem>
+
+    for _, capture in pairs(vim.treesitter.get_captures_at_pos(bufnr, row, col)) do
+      --- @cast capture Gitsigns.InspectCompatCapture
+      local key = capture_key(capture)
+      local item = previous[key]
+
+      if item and item.end_col == col then
+        item.end_col = next_col
+        active[key] = item
+      else
+        local new_item = resolve_hl({
+          capture = capture.capture,
+          lang = capture.lang,
+          metadata = capture.metadata,
+          id = capture.id,
+          pattern_id = capture.pattern_id,
+          hl_group = '@' .. capture.capture .. '.' .. capture.lang,
+          row = row,
+          col = col,
+          end_row = row,
+          end_col = next_col,
+        }) --[[@as Gitsigns.InspectPosTSItem]]
+        items[#items + 1] = new_item
+        active[key] = new_item
+      end
+    end
+
+    previous = active
+  end
+
+  return items
+end
+
+--- @param a integer[]
+--- @param b integer[]
+--- @return boolean
+local function same_stack(a, b)
+  if #a ~= #b then
+    return false
+  end
+  for i = 1, #a do
+    if a[i] ~= b[i] then
+      return false
+    end
+  end
+  return true
+end
+
+--- @param bufnr integer
+--- @param row integer
+--- @param cols integer[]
+--- @return Gitsigns.InspectPosItem[]
+local function collect_syntax(bufnr, row, cols)
+  return api.nvim_buf_call(bufnr, function()
+    local items = {} --- @type Gitsigns.InspectPosItem[]
+    local previous = {} --- @type integer[]
+    local open = {} --- @type Gitsigns.InspectPosItem[]
+
+    for i = 1, #cols - 1 do
+      local col = assert(cols[i])
+      local next_col = assert(cols[i + 1])
+      local stack = vim.fn.synstack(row + 1, col + 1)
+
+      if same_stack(stack, previous) then
+        for _, item in ipairs(open) do
+          item.end_col = next_col
+        end
+      else
+        open = {}
+        for _, syn_id in ipairs(stack) do
+          local item = resolve_hl({
+            hl_group = vim.fn.synIDattr(syn_id, 'name'),
+            row = row,
+            col = col,
+            end_row = row,
+            end_col = next_col,
+          }) --[[@as Gitsigns.InspectPosItem]]
+          items[#items + 1] = item
+          open[#open + 1] = item
+        end
+        previous = stack
+      end
+    end
+
+    return items
+  end)
+end
+
+--- @param bufnr integer
+--- @param row integer
+--- @param col integer
+--- @param opts? Gitsigns.InspectCompatFilter
+--- @return Gitsigns.InspectPosResult
+function M.inspect_pos(bufnr, row, col, opts)
+  opts = vim.tbl_deep_extend('force', defaults, opts or {}) --[[@as Gitsigns.InspectCompatFilter]]
+
+  local has_range = opts.end_row ~= nil and opts.end_col ~= nil
+  if has_range and opts.end_row ~= row then
+    error('gitsigns inspect backend only supports single-row ranges')
+  end
+
+  local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ''
+  local stop_col = has_range and assert(opts.end_col) or next_boundary(line, col)
+
+  if stop_col < col then
+    error('end_col must be greater than or equal to col')
+  end
+
+  local cols = range_columns(line, col, stop_col)
+
+  --- @type Gitsigns.InspectPosResult
+  local result = {
+    treesitter = {}, --- @type Gitsigns.InspectPosTSItem[]
+    syntax = {}, --- @type Gitsigns.InspectPosItem[]
+    extmarks = {}, --- @type Gitsigns.InspectPosExtmarkItem[]
+    semantic_tokens = {}, --- @type Gitsigns.InspectPosExtmarkItem[]
+    buffer = bufnr,
+    row = row,
+    col = col,
+  }
+
+  if has_range then
+    result.end_row = row
+    result.end_col = stop_col
+  end
+
+  if opts.treesitter then
+    result.treesitter = collect_treesitter(bufnr, row, cols)
+  end
+
+  if opts.syntax and api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].syntax ~= '' then
+    result.syntax = collect_syntax(bufnr, row, cols)
+  end
+
+  if opts.extmarks or opts.semantic_tokens then
+    local raw_extmarks = api.nvim_buf_get_extmarks(
+      bufnr,
+      -1,
+      { row, col },
+      { row, has_range and math.max(stop_col - 1, 0) or col },
+      {
+        details = true,
+        overlap = true,
+      }
+    )
+    local nsmap = namespace_map()
+    local extmarks = vim.tbl_map(function(extmark)
+      return extmark_to_map(extmark, nsmap)
+    end, raw_extmarks)
+
+    if not has_range and opts.extmarks ~= 'all' then
+      extmarks = vim.tbl_filter(function(extmark)
+        return overlaps_single_pos(extmark, row, col)
+      end, extmarks)
+    end
+
+    if opts.semantic_tokens then
+      result.semantic_tokens = vim.tbl_filter(function(extmark)
+        return vim.startswith(extmark.ns, 'nvim.lsp.semantic_tokens')
+      end, extmarks)
+    end
+
+    if opts.extmarks then
+      result.extmarks = vim.tbl_filter(function(extmark)
+        return not vim.startswith(extmark.ns, 'nvim.lsp.semantic_tokens')
+          and (opts.extmarks == 'all' or extmark.hl_group ~= nil)
+      end, extmarks)
+    end
+  end
+
+  return result
+end
+
+return M

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -1,5 +1,6 @@
 local async = require('gitsigns.async')
 local log = require('gitsigns.debug.log')
+local DeletedPreview = require('gitsigns.deleted_preview')
 local util = require('gitsigns.util')
 local run_diff = require('gitsigns.diff')
 local Hunks = require('gitsigns.hunks')
@@ -278,77 +279,6 @@ local function apply_word_diff(bufnr, row)
   end
 end
 
-local ns_rm = api.nvim_create_namespace('gitsigns_removed')
-
-local VIRT_LINE_LEN = 300
-
---- @param bufnr integer
-local function clear_deleted(bufnr)
-  local marks = api.nvim_buf_get_extmarks(bufnr, ns_rm, 0, -1, {})
-  for _, mark in ipairs(marks) do
-    api.nvim_buf_del_extmark(bufnr, ns_rm, mark[1])
-  end
-end
-
---- @param bufnr integer
---- @param nsd integer
---- @param hunk Gitsigns.Hunk.Hunk
-local function show_deleted(bufnr, nsd, hunk)
-  local virt_lines = {} --- @type [string, string][][]
-
-  for i, line in ipairs(hunk.removed.lines) do
-    local vline = {} --- @type [string, string][]
-    local last_ecol = 1
-
-    if config.word_diff then
-      local regions = require('gitsigns.diff_int').run_word_diff(
-        { hunk.removed.lines[i] },
-        { hunk.added.lines[i] }
-      )
-
-      for _, region in ipairs(regions) do
-        local rline, scol, ecol = region[1], region[3], region[4]
-        if rline > 1 then
-          break
-        end
-        vline[#vline + 1] = { line:sub(last_ecol, scol - 1), 'GitSignsDeleteVirtLn' }
-        vline[#vline + 1] = { line:sub(scol, ecol - 1), 'GitSignsDeleteVirtLnInline' }
-        last_ecol = ecol
-      end
-    end
-
-    if #line > 0 then
-      vline[#vline + 1] = { line:sub(last_ecol, -1), 'GitSignsDeleteVirtLn' }
-    end
-
-    -- Add extra padding so the entire line is highlighted
-    local padding = string.rep(' ', VIRT_LINE_LEN - #line)
-    vline[#vline + 1] = { padding, 'GitSignsDeleteVirtLn' }
-
-    virt_lines[i] = vline
-  end
-
-  local topdelete = hunk.added.start == 0 and hunk.type == 'delete'
-
-  local row = topdelete and 0 or hunk.added.start - 1
-  api.nvim_buf_set_extmark(bufnr, nsd, row, -1, {
-    virt_lines = virt_lines,
-    -- TODO(lewis6991): Note virt_lines_above doesn't work on row 0 neovim/neovim#16166
-    virt_lines_above = hunk.type ~= 'delete' or topdelete,
-  })
-end
-
---- @param bufnr integer
---- @param hunks? Gitsigns.Hunk.Hunk[]
-local function update_show_deleted(bufnr, hunks)
-  clear_deleted(bufnr)
-  if config.show_deleted then
-    for _, hunk in ipairs(hunks or {}) do
-      show_deleted(bufnr, ns_rm, hunk)
-    end
-  end
-end
-
 --- @param bufnr integer
 --- @return boolean
 local function buf_in_view(bufnr)
@@ -447,21 +377,23 @@ M.update = throttle_async({ hash = 1, schedule = true }, function(bufnr)
 
     -- Note the decoration provider may have invalidated bcache.hunks at this
     -- point
-    if
-      bcache.force_next_update
-      or Hunks.compare_heads(bcache.hunks, old_hunks)
-      or Hunks.compare_heads(bcache.hunks_staged, old_hunks_staged)
-    then
+    local hunks_changed = bcache.force_next_update or Hunks.compare_heads(bcache.hunks, old_hunks)
+    local hunks_staged_changed = Hunks.compare_heads(bcache.hunks_staged, old_hunks_staged)
+
+    if hunks_changed or hunks_staged_changed then
       -- Apply signs to the window. Other signs will be added by the decoration
       -- provider as they are drawn.
       apply_win_signs(bufnr, vim.fn.line('w0'), vim.fn.line('w$'), true)
 
-      update_show_deleted(bufnr, bcache.hunks)
       bcache.force_next_update = false
 
       local summary = Hunks.get_summary(bcache.hunks)
       summary.head = git_obj.repo.abbrev_head
       Status.update(bufnr, summary)
+    end
+
+    if hunks_changed then
+      DeletedPreview.prepare(bufnr)
     end
   end)
 end)
@@ -478,6 +410,8 @@ end)
 --- @param bufnr integer
 --- @param keep_signs? boolean
 function M.detach(bufnr, keep_signs)
+  DeletedPreview.detach(bufnr)
+
   if not keep_signs then
     -- Remove all signs
     signs_normal:remove(bufnr)
@@ -494,37 +428,46 @@ function M.reset_signs()
   signs_staged:reset()
 end
 
+--- @param winid integer
 --- @param bufnr integer
 --- @param topline integer
 --- @param botline_guess integer
---- @return false?
-local function on_win(bufnr, topline, botline_guess)
+--- @return boolean
+local function on_win(winid, bufnr, topline, botline_guess)
   local bcache = cache[bufnr]
   if not bcache or not bcache.hunks then
+    DeletedPreview.clear_win(winid)
     return false
   end
   local botline = math.min(botline_guess, api.nvim_buf_line_count(bufnr))
 
   apply_win_signs(bufnr, topline + 1, botline + 1)
 
-  if not (config.word_diff and config.diff_opts.internal) then
-    return false
+  local wants_on_line = false
+  if config.word_diff and config.diff_opts.internal then
+    wants_on_line = true
   end
+
+  DeletedPreview.on_win(winid, bufnr, topline, botline)
+
+  return wants_on_line or false
 end
 
 function M.setup()
   -- Calling this before any await calls will stop nvim's intro messages being
   -- displayed
   api.nvim_set_decoration_provider(ns, {
-    on_win = function(_, _winid, bufnr, topline, botline)
-      return on_win(bufnr, topline, botline)
+    on_win = function(_, winid, bufnr, topline, botline)
+      return on_win(winid, bufnr, topline, botline)
     end,
     on_line = function(_, _winid, bufnr, row)
-      apply_word_diff(bufnr, row)
+      if config.word_diff and config.diff_opts.internal then
+        apply_word_diff(bufnr, row)
+      end
     end,
   })
 
-  Config.subscribe({ 'signcolumn', 'numhl', 'linehl', 'show_deleted' }, function()
+  Config.subscribe({ 'signcolumn', 'numhl', 'linehl', 'show_deleted', 'word_diff' }, function()
     -- Remove all signs
     M.reset_signs()
 
@@ -545,6 +488,17 @@ function M.setup()
       end
       bcache:invalidate(true)
       M.update_sync_debounced(buf)
+    end,
+  })
+
+  api.nvim_create_autocmd('WinClosed', {
+    group = 'gitsigns',
+    callback = function(args)
+      local winid = tonumber(args.match)
+      if winid then
+        --- @cast winid integer
+        DeletedPreview.clear_win(winid)
+      end
     end,
   })
 

--- a/lua/gitsigns/popup.lua
+++ b/lua/gitsigns/popup.lua
@@ -51,24 +51,33 @@ local function expand_height(winid, nlines, border)
 end
 
 --- @class (exact) Gitsigns.HlMark
---- @field hl_group string
+--- @field hl_group Gitsigns.HlName|Gitsigns.HlStack
 --- @field start_row integer
 --- @field start_col? integer
 --- @field end_row? integer
 --- @field end_col? integer
+--- @field priority? integer
 --- @field url? string
+
+--- @alias Gitsigns.VirtTextChunk [string, Gitsigns.HlName|Gitsigns.HlStack]
 
 --- Each element represents a multi-line segment
 --- @alias Gitsigns.LineSpec [string, string|Gitsigns.HlMark[], string?][]
 
+--- @param ret Gitsigns.HlMark[]
 --- @param hlmarks Gitsigns.HlMark[]
 --- @param row_offset integer
-local function offset_hlmarks(hlmarks, row_offset)
+local function extend_hlmarks(ret, hlmarks, row_offset)
   for _, h in ipairs(hlmarks) do
-    h.start_row = h.start_row + row_offset
-    if h.end_row then
-      h.end_row = h.end_row + row_offset
-    end
+    ret[#ret + 1] = {
+      url = h.url,
+      hl_group = h.hl_group,
+      start_row = h.start_row + row_offset,
+      start_col = h.start_col,
+      end_row = h.end_row and h.end_row + row_offset or nil,
+      end_col = h.end_col,
+      priority = h.priority,
+    }
   end
 end
 
@@ -103,8 +112,7 @@ local function partition_linesspec(fmt)
           end_col = end_col,
         }
       else -- hl is Gitsigns.HlMark[]
-        offset_hlmarks(hls, row)
-        vim.list_extend(ret, hls)
+        extend_hlmarks(ret, hls, row)
       end
 
       row = end_row
@@ -148,6 +156,7 @@ local function update_buf(bufnr, lines_spec)
   vim.bo[bufnr].modifiable = true
   api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
   vim.bo[bufnr].modifiable = false
+  api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
   for _, hl in ipairs(highlights) do
     local ok, err = pcall(api.nvim_buf_set_extmark, bufnr, ns, hl.start_row, hl.start_col or 0, {
@@ -156,6 +165,7 @@ local function update_buf(bufnr, lines_spec)
       end_row = hl.end_row,
       end_col = hl.end_col,
       hl_eol = true,
+      priority = hl.priority,
     })
     if not ok then
       error(vim.inspect(hl) .. '\n' .. err)

--- a/lua/gitsigns/render/capture.lua
+++ b/lua/gitsigns/render/capture.lua
@@ -1,0 +1,208 @@
+local api = vim.api
+
+local Inspect = require('gitsigns.inspect')
+
+local M = {}
+local source_hls_supported = vim.fn.has('nvim-0.12') == 1
+
+--- @class Gitsigns.CapturedSegment
+--- @field start_col integer
+--- @field end_col integer
+--- @field hl Gitsigns.HlStack
+
+--- @param value integer
+--- @param lower integer
+--- @param upper integer
+--- @return integer
+local function clamp(value, lower, upper)
+  return math.min(math.max(value, lower), upper)
+end
+
+--- Compute an item's effective byte range on a single row.
+--- @param item Gitsigns.InspectItem
+--- @param row integer
+--- @param start_col integer
+--- @param end_col integer
+--- @return integer? start_col
+--- @return integer? end_col
+local function layer_bounds_on_row(item, row, start_col, end_col)
+  local item_row = item.row or row
+  local item_end_row = item.end_row or item_row
+  if row < item_row or row > item_end_row then
+    return
+  end
+
+  local s = start_col
+  if item_row == row then
+    s = math.max(item.col or start_col, start_col)
+  end
+
+  local e
+  if item_end_row > row then
+    -- Multi-row highlights cover the rest of this row.
+    e = end_col + 1
+  else
+    e = math.min(item.end_col or end_col, end_col)
+  end
+
+  if e <= s then
+    return
+  end
+
+  return s, e
+end
+
+--- @param inspected Gitsigns.InspectRange
+--- @return Gitsigns.RenderLayer[]
+local function layers_from_inspected(inspected)
+  local layers = {} --- @type Gitsigns.RenderLayer[]
+  local row = inspected.row
+  local start_col = inspected.start_col
+  local end_col = inspected.end_col
+
+  for _, item in ipairs(inspected.items) do
+    local hl = item.hl_group
+    if hl ~= nil and hl ~= '' then
+      local s, e = layer_bounds_on_row(item, row, start_col, end_col)
+      if s and e then
+        layers[#layers + 1] = {
+          start_col = s - start_col,
+          end_col = e - start_col,
+          priority = item.priority,
+          hl_group = hl,
+        }
+      end
+    end
+  end
+
+  return layers
+end
+
+--- @param bufnr integer
+--- @param row integer
+--- @param start_col? integer
+--- @param end_col? integer
+--- @return Gitsigns.CapturedLine
+function M.capture_line(bufnr, row, start_col, end_col)
+  local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ''
+  local line_len = #line
+
+  --- @type integer
+  local start_col0 = start_col or 0
+  --- @type integer
+  local end_col0 = end_col or line_len
+  local s = clamp(start_col0, 0, line_len)
+  local e = clamp(end_col0, s, line_len)
+  if not source_hls_supported then
+    return {
+      text = line:sub(s + 1, e),
+      layers = {},
+    }
+  end
+  local inspected = Inspect.inspect_range(bufnr, row, s, e)
+
+  return {
+    text = line:sub(s + 1, e),
+    layers = layers_from_inspected(inspected),
+  }
+end
+
+--- @param bufnr integer
+--- @param start_row integer
+--- @param count integer
+--- @param opts? {start_col?:integer, end_col?:integer}
+--- @return Gitsigns.CapturedLine[]
+function M.capture_lines(bufnr, start_row, count, opts)
+  opts = opts or {}
+  local lines = {} --- @type Gitsigns.CapturedLine[]
+  for i = 1, math.max(count, 0) do
+    local row = start_row + i - 1
+    lines[i] = M.capture_line(bufnr, row, opts.start_col, opts.end_col)
+  end
+  return lines
+end
+
+--- @param bufnr integer
+--- @param node Gitsigns.Hunk.Node
+--- @param opts? {start_col?:integer, end_col?:integer}
+--- @return Gitsigns.CapturedLine[]
+function M.capture_node(bufnr, node, opts)
+  return M.capture_lines(bufnr, node.start - 1, node.count, opts)
+end
+
+--- @param line Gitsigns.CapturedLine
+--- @return integer[]
+function M.boundaries(line)
+  local line_len = #line.text
+  local cols = {
+    [0] = true,
+    [line_len] = true,
+  }
+
+  for _, layer in ipairs(line.layers) do
+    if layer.start_col > 0 and layer.start_col < line_len then
+      cols[layer.start_col] = true
+    end
+    if layer.end_col > 0 and layer.end_col < line_len then
+      cols[layer.end_col] = true
+    end
+  end
+
+  local ret = {} --- @type integer[]
+  for col in pairs(cols) do
+    ret[#ret + 1] = col
+  end
+  table.sort(ret)
+  return ret
+end
+
+--- @param line Gitsigns.CapturedLine
+--- @param col integer
+--- @return Gitsigns.HlStack
+function M.hl_stack_at(line, col)
+  local stack = {} --- @type Gitsigns.HlStack
+  for _, layer in ipairs(line.layers) do
+    if col >= layer.start_col and col < layer.end_col then
+      Inspect.append_hl_group(stack, layer.hl_group)
+    end
+  end
+  return stack
+end
+
+--- @param line Gitsigns.CapturedLine
+--- @return Gitsigns.CapturedSegment[]
+function M.segments(line)
+  local segments = {} --- @type Gitsigns.CapturedSegment[]
+  local cols = M.boundaries(line)
+  local current_hl --- @type Gitsigns.HlStack?
+  local current_start = 0
+
+  for i = 1, #cols - 1 do
+    local col = assert(cols[i])
+    local hl = M.hl_stack_at(line, col)
+    if current_hl == nil then
+      current_hl = hl
+      current_start = col
+    elseif not Inspect.same_hl(current_hl, hl) then
+      segments[#segments + 1] = {
+        start_col = current_start,
+        end_col = col,
+        hl = current_hl,
+      }
+      current_hl = hl
+      current_start = col
+    end
+  end
+
+  if current_hl then
+    segments[#segments + 1] = {
+      start_col = current_start,
+      end_col = #line.text,
+      hl = current_hl,
+    }
+  end
+
+  return segments
+end
+
+return M

--- a/lua/gitsigns/render/overlay.lua
+++ b/lua/gitsigns/render/overlay.lua
@@ -1,0 +1,106 @@
+local Inspect = require('gitsigns.inspect')
+
+local M = {}
+
+--- @param layers Gitsigns.RenderLayer[]
+--- @param layer Gitsigns.RenderLayer
+local function insert_layer(layers, layer)
+  if layer.end_col <= layer.start_col then
+    return
+  end
+
+  local index = #layers + 1
+  for i = 1, #layers do
+    if layer.priority < layers[i].priority then
+      index = i
+      break
+    end
+  end
+
+  local prev = layers[index - 1]
+  if
+    prev
+    and prev.end_col == layer.start_col
+    and prev.priority == layer.priority
+    and Inspect.same_hl(prev.hl_group, layer.hl_group)
+  then
+    prev.end_col = layer.end_col
+    return
+  end
+
+  table.insert(layers, index, layer)
+end
+
+--- @param line Gitsigns.CapturedLine
+--- @param start_col integer
+--- @param end_col integer
+--- @param hl_group Gitsigns.HlName|Gitsigns.HlStack
+--- @param priority integer
+--- @return Gitsigns.CapturedLine
+function M.add_layer(line, start_col, end_col, hl_group, priority)
+  line.layers = line.layers or {}
+  local line_len = #line.text
+  local s = math.max(start_col, 0)
+  local e = math.max(end_col, s)
+  if s > line_len then
+    s = line_len
+  end
+
+  insert_layer(line.layers, {
+    start_col = s,
+    end_col = e,
+    hl_group = Inspect.normalize_hl(hl_group),
+    priority = priority,
+  })
+
+  return line
+end
+
+--- @param lines Gitsigns.CapturedLine[]
+--- @param hl_group Gitsigns.HlName|Gitsigns.HlStack
+--- @param priority integer
+--- @param first_line? integer
+--- @param last_line? integer
+--- @return Gitsigns.CapturedLine[]
+function M.add_full_line_layer(lines, hl_group, priority, first_line, last_line)
+  first_line = first_line or 1
+  last_line = last_line or #lines
+
+  for i = first_line, last_line do
+    local line = lines[i]
+    if line then
+      M.add_layer(line, 0, #line.text + 1, hl_group, priority)
+    end
+  end
+
+  return lines
+end
+
+--- @param lines Gitsigns.CapturedLine[]
+--- @param regions [integer, string, integer, integer][]
+--- @param region_hl Gitsigns.HlName|fun(region_type:string, region:[integer,string,integer,integer]):Gitsigns.HlName?
+--- @param priority integer
+--- @param opts? {ensure_min_width?:boolean}
+--- @return Gitsigns.CapturedLine[]
+function M.add_word_diff_layers(lines, regions, region_hl, priority, opts)
+  opts = opts or {}
+
+  for _, region in ipairs(regions) do
+    local line = lines[region[1]]
+    if line then
+      local hl = type(region_hl) == 'function' and region_hl(region[2], region) or region_hl
+      if hl and hl ~= '' then
+        local s = math.max(region[3] - 1, 0)
+        local e = math.max(region[4] - 1, s)
+        if opts.ensure_min_width and e == s then
+          e = s + 1
+        end
+        M.add_layer(line, s, e, hl, priority)
+      end
+    end
+  end
+
+  return lines
+end
+
+return M

--- a/lua/gitsigns/render/virt.lua
+++ b/lua/gitsigns/render/virt.lua
@@ -1,0 +1,129 @@
+local Capture = require('gitsigns.render.capture')
+local Inspect = require('gitsigns.inspect')
+
+local M = {}
+
+--- @class Gitsigns.RenderLayer
+--- @field start_col integer
+--- @field end_col integer
+--- @field priority integer
+--- @field hl_group Gitsigns.HlName|Gitsigns.HlStack
+
+--- @class Gitsigns.CapturedLine
+--- @field text string
+--- @field layers Gitsigns.RenderLayer[]
+
+--- @class Gitsigns.RenderVirtOpts
+--- @field pad_width? integer
+--- @field pad_hl? Gitsigns.HlName|Gitsigns.HlStack
+--- @field default_hl? Gitsigns.HlName|Gitsigns.HlStack
+--- @field pad_with_eol_hl? boolean
+--- @field prefix? Gitsigns.VirtTextChunk[][]|fun(line_index: integer, line: Gitsigns.CapturedLine): Gitsigns.VirtTextChunk[]?
+
+--- @param chunks Gitsigns.VirtTextChunk[]
+--- @param text string
+--- @param hl Gitsigns.HlName|Gitsigns.HlStack
+local function add_chunk(chunks, text, hl)
+  if text == '' then
+    return
+  end
+
+  hl = Inspect.normalize_hl(hl)
+
+  local prev = chunks[#chunks]
+  if prev and Inspect.same_hl(prev[2], hl) then
+    prev[1] = prev[1] .. text
+    return
+  end
+
+  chunks[#chunks + 1] = { text, hl }
+end
+
+M.add_chunk = add_chunk
+
+--- @param chunks Gitsigns.VirtTextChunk[]?
+--- @return Gitsigns.VirtTextChunk[]
+local function copy_chunks(chunks)
+  local ret = {} --- @type Gitsigns.VirtTextChunk[]
+  for _, chunk in ipairs(chunks or {}) do
+    ret[#ret + 1] = { chunk[1], chunk[2] }
+  end
+  return ret
+end
+
+--- @param opts Gitsigns.RenderVirtOpts
+--- @param line_index integer
+--- @param line Gitsigns.CapturedLine
+--- @return Gitsigns.VirtTextChunk[]
+local function line_prefix(opts, line_index, line)
+  local prefix = opts.prefix
+  if not prefix then
+    return {}
+  end
+
+  if type(prefix) == 'function' then
+    return copy_chunks(prefix(line_index, line))
+  end
+
+  --- @cast prefix Gitsigns.VirtTextChunk[][]
+  return copy_chunks(prefix[line_index])
+end
+
+--- @param line Gitsigns.CapturedLine
+--- @param opts Gitsigns.RenderVirtOpts
+--- @return Gitsigns.VirtTextChunk[]
+local function render_line(line, opts)
+  local text = line.text
+  local text_len = #text
+  local chunks = {} --- @type Gitsigns.VirtTextChunk[]
+
+  local cols = Capture.boundaries(line)
+  for i = 1, #cols - 1 do
+    local start_col = assert(cols[i])
+    local end_col = assert(cols[i + 1])
+    if end_col > start_col then
+      local segment_hl = Capture.hl_stack_at(line, start_col)
+      local hl = #segment_hl > 0 and Inspect.normalize_hl(segment_hl)
+        or (opts.default_hl or 'Normal')
+      add_chunk(chunks, text:sub(start_col + 1, end_col), hl)
+    end
+  end
+
+  local pad_width = opts.pad_width
+  if pad_width then
+    local display_width = vim.fn.strdisplaywidth(text)
+    local padding_width = math.max(pad_width - display_width, 0)
+    if padding_width > 0 then
+      local hl = opts.pad_hl
+      if not hl and opts.pad_with_eol_hl ~= false then
+        local sample_col = text_len > 0 and text_len - 1 or 0
+        local eol_hl = Capture.hl_stack_at(line, sample_col)
+        if #eol_hl > 0 then
+          hl = Inspect.normalize_hl(eol_hl)
+        end
+      end
+      add_chunk(chunks, string.rep(' ', padding_width), hl or opts.default_hl or 'Normal')
+    end
+  end
+
+  return chunks
+end
+
+--- Render captured lines to extmark `virt_lines`.
+--- @param lines Gitsigns.CapturedLine[]
+--- @param opts? Gitsigns.RenderVirtOpts
+--- @return Gitsigns.VirtTextChunk[][]
+function M.render(lines, opts)
+  opts = opts or {}
+  local virt_lines = {} --- @type Gitsigns.VirtTextChunk[][]
+
+  for i, line in ipairs(lines) do
+    local vline = line_prefix(opts, i, line)
+    vim.list_extend(vline, render_line(line, opts))
+    virt_lines[i] = vline
+  end
+
+  return virt_lines
+end
+
+return M

--- a/test/blame_spec.lua
+++ b/test/blame_spec.lua
@@ -4,12 +4,13 @@ local setup_gitsigns = helpers.setup_gitsigns
 local feed = helpers.feed
 local edit = helpers.edit
 local exec_lua = helpers.exec_lua
+local fn = helpers.fn
 local test_config = helpers.test_config
 local clear = helpers.clear
+local expectf = helpers.expectf
 local setup_test_repo = helpers.setup_test_repo
 local eq = helpers.eq
 local check = helpers.check
-local expectf = helpers.expectf
 local git = helpers.git
 local write_to_file = helpers.write_to_file
 local scratch --- @type string
@@ -22,15 +23,41 @@ local function refresh_paths()
   test_file = helpers.test_file
 end
 
+local function require_source_hls()
+  if fn.has('nvim-0.12') == 0 then
+    pending('requires Neovim 0.12+')
+  end
+end
+
+local function enable_lua_treesitter_on_filetype()
+  exec_lua(function()
+    vim.api.nvim_create_autocmd('FileType', {
+      group = vim.api.nvim_create_augroup('gitsigns_blame_treesitter', { clear = true }),
+      pattern = 'lua',
+      callback = function(args)
+        pcall(vim.treesitter.start, args.buf, 'lua')
+        local ok, parser = pcall(vim.treesitter.get_parser, args.buf, 'lua')
+        if ok and parser then
+          pcall(parser.parse, parser, true)
+        end
+      end,
+    })
+
+    vim.cmd('syntax on')
+    vim.bo.filetype = 'lua'
+  end)
+end
+
 describe('blame', function()
   before_each(function()
     clear()
     refresh_paths()
     helpers.chdir_tmp()
-    setup_gitsigns(test_config)
+    helpers.setup_path()
   end)
 
   it('keeps cursor line on reblame', function()
+    setup_gitsigns(test_config)
     setup_test_repo({
       test_file_text = { 'one', 'two', 'three', 'four', 'five' },
     })
@@ -123,6 +150,7 @@ describe('blame', function()
 
   it('blames a tracked file in a nested path', function()
     helpers.git_init_scratch()
+    setup_gitsigns(test_config)
 
     local relpath = '.config/nvim/lua/mappings.lua'
     local file = scratch .. '/' .. relpath
@@ -168,5 +196,245 @@ describe('blame', function()
     eq(false, result.file == result.relpath)
     eq(relpath, result.filename)
     eq(false, result.sha == '')
+  end)
+
+  it('reuses source highlight stacks in the full blame popup hunk', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'local foo = 1',
+      },
+    })
+
+    helpers.write_to_file(test_file, {
+      'local bar = 1',
+    })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'rename foo')
+
+    local config = vim.deepcopy(test_config)
+    config.gh = true
+    setup_gitsigns(config)
+    edit(test_file)
+    enable_lua_treesitter_on_filetype()
+
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function()
+      local async = require('gitsigns.async')
+
+      package.loaded['gitsigns.gh'] = {
+        commit_url = function()
+          return 'https://example.test/commit'
+        end,
+        create_pr_linespec = function()
+          return { { '#1 ', 'Title', 'https://example.test/pr/1' } }
+        end,
+      }
+
+      async.run(require('gitsigns.actions.blame_line'), { full = true }):wait()
+    end)
+
+    expectf(function()
+      local result = exec_lua(function()
+        local function expected_line_hls(line, line_hl, inline_hl, region)
+          local preview_buf = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_buf_set_lines(preview_buf, 0, -1, false, { line })
+          vim.bo[preview_buf].filetype = vim.bo.filetype
+          vim.bo[preview_buf].tabstop = vim.bo.tabstop
+          if vim.bo.syntax ~= '' then
+            vim.bo[preview_buf].syntax = vim.bo.syntax
+          end
+          local ok, parser = pcall(vim.treesitter.get_parser, preview_buf, 'lua')
+          assert(ok and parser)
+          pcall(parser.parse, parser, true)
+
+          local ns_preview = vim.api.nvim_create_namespace('gitsigns_test_blame_expected')
+          vim.api.nvim_buf_set_extmark(preview_buf, ns_preview, 0, 0, {
+            hl_group = line_hl,
+            hl_eol = true,
+            end_row = 1,
+            priority = 1000,
+          })
+          vim.api.nvim_buf_set_extmark(preview_buf, ns_preview, 0, region[3] - 1, {
+            hl_group = inline_hl,
+            end_col = region[4] - 1,
+            end_row = 0,
+            priority = 1001,
+          })
+
+          local diff_col = region[3] - 1
+          local inspected = require('gitsigns.inspect').inspect_range(preview_buf, 0, 0, #line)
+          local keyword = require('gitsigns.inspect').hl_stack_at(inspected, 0)
+          local diff = require('gitsigns.inspect').hl_stack_at(inspected, diff_col)
+
+          vim.api.nvim_buf_delete(preview_buf, { force = true })
+
+          return keyword, diff, diff_col
+        end
+
+        local popup_win = require('gitsigns.popup').is_open('blame')
+        if not popup_win then
+          return
+        end
+
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local lines = vim.api.nvim_buf_get_lines(popup_buf, 0, -1, false)
+        local deleted_row, added_row
+
+        for i, line in ipairs(lines) do
+          if line == '-local foo = 1' then
+            deleted_row = i - 1
+          elseif line == '+local bar = 1' then
+            added_row = i - 1
+          end
+        end
+
+        if deleted_row == nil or added_row == nil then
+          return
+        end
+
+        local Inspect = require('gitsigns.inspect')
+        local removed_regions, added_regions = require('gitsigns.diff_int').run_word_diff(
+          { 'local foo = 1' },
+          { 'local bar = 1' }
+        )
+        local expected_deleted_keyword, expected_deleted_diff, deleted_diff_col = expected_line_hls(
+          'local foo = 1',
+          'GitSignsDeletePreview',
+          'GitSignsDeleteInline',
+          removed_regions[1]
+        )
+        local expected_added_keyword, expected_added_diff, added_diff_col = expected_line_hls(
+          'local bar = 1',
+          'GitSignsAddPreview',
+          added_regions[1][2] == 'add' and 'GitSignsAddInline'
+            or added_regions[1][2] == 'change' and 'GitSignsChangeInline'
+            or 'GitSignsDeleteInline',
+          added_regions[1]
+        )
+        local deleted = Inspect.inspect_range(popup_buf, deleted_row, 0, #'-local foo = 1')
+        local added = Inspect.inspect_range(popup_buf, added_row, 0, #'+local bar = 1')
+
+        return {
+          title = lines[1],
+          expected_deleted_keyword = expected_deleted_keyword,
+          actual_deleted_keyword = Inspect.hl_stack_at(deleted, 1),
+          expected_deleted_diff = expected_deleted_diff,
+          actual_deleted_diff = Inspect.hl_stack_at(deleted, deleted_diff_col + 1),
+          expected_added_keyword = expected_added_keyword,
+          actual_added_keyword = Inspect.hl_stack_at(added, 1),
+          expected_added_diff = expected_added_diff,
+          actual_added_diff = Inspect.hl_stack_at(added, added_diff_col + 1),
+        }
+      end)
+
+      assert(result)
+      eq(result.expected_deleted_keyword, result.actual_deleted_keyword)
+      eq(result.expected_deleted_diff, result.actual_deleted_diff)
+      eq(result.expected_added_keyword, result.actual_added_keyword)
+      eq(result.expected_added_diff, result.actual_added_diff)
+      assert(result.title:find('#1', 1, true))
+    end)
+  end)
+
+  it('extends full blame popup line highlights to the end of the line', function()
+    setup_test_repo({
+      test_file_text = {
+        'local foo = 1',
+      },
+    })
+
+    helpers.write_to_file(test_file, {
+      'local bar = 1',
+    })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'rename foo')
+
+    local config = vim.deepcopy(test_config)
+    config.gh = true
+    setup_gitsigns(config)
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function()
+      local async = require('gitsigns.async')
+
+      package.loaded['gitsigns.gh'] = {
+        commit_url = function()
+          return 'https://example.test/commit'
+        end,
+        create_pr_linespec = function()
+          return { { '#1 ', 'Title', 'https://example.test/pr/1' } }
+        end,
+      }
+
+      async.run(require('gitsigns.actions.blame_line'), { full = true }):wait()
+    end)
+
+    local result
+    expectf(function()
+      result = exec_lua(function()
+        local popup_win = require('gitsigns.popup').is_open('blame')
+        if not popup_win then
+          return
+        end
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local lines = vim.api.nvim_buf_get_lines(popup_buf, 0, -1, false)
+        local ns = assert(vim.api.nvim_get_namespaces().gitsigns_popup)
+        local marks = vim.api.nvim_buf_get_extmarks(popup_buf, ns, 0, -1, { details = true })
+
+        local deleted_row, added_row
+        for i, line in ipairs(lines) do
+          if line == '-local foo = 1' then
+            deleted_row = i - 1
+          elseif line == '+local bar = 1' then
+            added_row = i - 1
+          end
+        end
+
+        if deleted_row == nil or added_row == nil then
+          return
+        end
+
+        local deleted_eol0, added_eol0 = false, false
+        for _, mark in ipairs(marks) do
+          local row = mark[2]
+          local col = mark[3]
+          local details = assert(mark[4])
+          if
+            details.hl_group == 'GitSignsDeletePreview'
+            and row == deleted_row
+            and col == 0
+            and details.end_row == deleted_row + 1
+            and details.end_col == 0
+          then
+            deleted_eol0 = true
+          elseif
+            details.hl_group == 'GitSignsAddPreview'
+            and row == added_row
+            and col == 0
+            and details.end_row == added_row + 1
+            and details.end_col == 0
+          then
+            added_eol0 = true
+          end
+        end
+
+        return {
+          deleted_eol = deleted_eol0,
+          added_eol = added_eol0,
+        }
+      end)
+
+      assert(result and result.deleted_eol and result.added_eol)
+    end)
   end)
 end)

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -492,7 +492,7 @@ end
 
 --- @param path string
 function M.edit(path)
-  helpers.api.nvim_command('edit ' .. M.fn.fnameescape(path))
+  helpers.api.nvim_command('edit! ' .. M.fn.fnameescape(path))
 end
 
 --- @param path string

--- a/test/render_capture_spec.lua
+++ b/test/render_capture_spec.lua
@@ -1,0 +1,126 @@
+local helpers = require('test.gs_helpers')
+
+local clear = helpers.clear
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+local setup_path = helpers.setup_path
+
+helpers.env()
+
+local function source_hls_supported()
+  return helpers.fn.has('nvim-0.12') == 1
+end
+
+describe('render capture', function()
+  before_each(function()
+    clear()
+    setup_path()
+  end)
+
+  it('captures overlapping extmark highlights with priority order', function()
+    local text, layers, stack = exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'abcdef' })
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_capture')
+
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 1, {
+        end_col = 4,
+        hl_group = 'DiffAdd',
+        priority = 90,
+      })
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 2, {
+        end_col = 4,
+        hl_group = 'Search',
+        priority = 95,
+      })
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 2, {
+        end_col = 5,
+        hl_group = 'Error',
+        priority = 100,
+      })
+
+      local Capture = require('gitsigns.render.capture')
+      local line = Capture.capture_line(0, 0)
+      return line.text, line.layers, Capture.hl_stack_at(line, 2)
+    end)
+
+    eq('abcdef', text)
+
+    if not source_hls_supported() then
+      eq(0, #layers)
+      eq({}, stack)
+      return
+    end
+
+    eq(3, #layers)
+
+    local add_priority
+    local search_priority
+    local error_priority
+    for _, layer in ipairs(layers) do
+      local hl = layer.hl_group
+      if hl == 'Error' then
+        error_priority = layer.priority
+      elseif hl == 'DiffAdd' then
+        add_priority = layer.priority
+      elseif hl == 'Search' then
+        search_priority = layer.priority
+      end
+    end
+
+    assert(add_priority ~= nil)
+    assert(search_priority ~= nil)
+    assert(error_priority ~= nil)
+    eq(true, add_priority <= search_priority)
+    eq(true, search_priority <= error_priority)
+    eq({ 'DiffAdd', 'Search', 'Error' }, stack)
+  end)
+
+  it('keeps hl_eol extmarks in the captured line stack', function()
+    local layers, stack = exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'foo' })
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_capture_eol')
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {
+        hl_group = 'ErrorMsg',
+        hl_eol = true,
+      })
+
+      local Capture = require('gitsigns.render.capture')
+      local line = Capture.capture_line(0, 0)
+      return line.layers, Capture.hl_stack_at(line, 2)
+    end)
+
+    if not source_hls_supported() then
+      eq(0, #layers)
+      eq({}, stack)
+      return
+    end
+
+    eq(1, #layers)
+    eq({ 'ErrorMsg' }, stack)
+  end)
+
+  it('applies full-line and word-diff overlays without rendering', function()
+    local full_stack, diff_stack, plain_stack = exec_lua(function()
+      local Capture = require('gitsigns.render.capture')
+      local Overlay = require('gitsigns.render.overlay')
+
+      local lines = {
+        { text = 'abc', layers = {} },
+      }
+
+      Overlay.add_full_line_layer(lines, 'GitSignsDeleteVirtLn', 1000)
+      Overlay.add_word_diff_layers(lines, { { 1, 'change', 2, 3 } }, function(region_type)
+        return region_type == 'change' and 'GitSignsChangeInline' or nil
+      end, 1001, { ensure_min_width = true })
+
+      local line = lines[1]
+      return Capture.hl_stack_at(line, 3),
+        Capture.hl_stack_at(line, 1),
+        Capture.hl_stack_at(line, 0)
+    end)
+
+    eq({ 'GitSignsDeleteVirtLn' }, full_stack)
+    eq({ 'GitSignsDeleteVirtLn', 'GitSignsChangeInline' }, diff_stack)
+    eq({ 'GitSignsDeleteVirtLn' }, plain_stack)
+  end)
+end)

--- a/test/render_virt_spec.lua
+++ b/test/render_virt_spec.lua
@@ -1,0 +1,104 @@
+local helpers = require('test.gs_helpers')
+
+local clear = helpers.clear
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+
+helpers.env()
+
+local function contains_hl(hl, group)
+  if type(hl) == 'table' then
+    return vim.tbl_contains(hl, group)
+  end
+  return hl == group
+end
+
+local function virt_hl_at_col(vline, col)
+  local byte_col = 0
+  for _, chunk in ipairs(vline) do
+    local text, hl = chunk[1], chunk[2]
+    local next_col = byte_col + #text
+    if col < next_col then
+      return hl
+    end
+    byte_col = next_col
+  end
+end
+
+describe('render.virt', function()
+  before_each(function()
+    clear()
+    helpers.setup_path()
+  end)
+
+  it('renders layered captured lines and extends eol fill with padding', function()
+    local vline, width = exec_lua(function()
+      local Virt = require('gitsigns.render.virt')
+      local text = 'local foo = 1'
+      local lines = {
+        {
+          text = text,
+          layers = {
+            {
+              start_col = 0,
+              end_col = #text,
+              priority = 1000,
+              hl_group = 'GitSignsDeleteVirtLn',
+            },
+            {
+              start_col = 6,
+              end_col = 9,
+              priority = 1001,
+              hl_group = 'GitSignsDeleteVirtLnInLine',
+            },
+          },
+        },
+      }
+
+      local rendered = Virt.render(lines, { pad_width = 24 })
+      local row = assert(rendered[1])
+      local text0 = {}
+      for _, chunk in ipairs(row) do
+        text0[#text0 + 1] = chunk[1]
+      end
+
+      return row, vim.fn.strdisplaywidth(table.concat(text0))
+    end)
+
+    eq(24, width)
+    assert(contains_hl(virt_hl_at_col(vline, 0), 'GitSignsDeleteVirtLn'))
+    assert(contains_hl(virt_hl_at_col(vline, 7), 'GitSignsDeleteVirtLnInLine'))
+    assert(contains_hl(virt_hl_at_col(vline, 20), 'GitSignsDeleteVirtLn'))
+  end)
+
+  it('prepends per-line virtual prefixes without mutating input', function()
+    local out_first, out_second, prefix_first = exec_lua(function()
+      local Virt = require('gitsigns.render.virt')
+      local lines = {
+        {
+          text = 'alpha',
+          layers = {
+            { start_col = 0, end_col = 5, priority = 1000, hl_group = 'GitSignsDeleteVirtLn' },
+          },
+        },
+        {
+          text = 'beta',
+          layers = {
+            { start_col = 0, end_col = 4, priority = 1000, hl_group = 'GitSignsDeleteVirtLn' },
+          },
+        },
+      }
+
+      local prefixes = {
+        { { '1 ', 'LineNr' } },
+        { { '2 ', 'LineNr' } },
+      }
+      local rendered = Virt.render(lines, { prefix = prefixes })
+      return rendered[1][1][1], rendered[2][1][1], prefixes[1][1][1]
+    end)
+
+    eq('1 ', out_first)
+    eq('2 ', out_second)
+    eq('1 ', prefix_first)
+  end)
+end)

--- a/test/word_diff_spec.lua
+++ b/test/word_diff_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.gs_helpers')
 
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
+local git = helpers.git
 local setup_test_repo = helpers.setup_test_repo
 local setup_gitsigns = helpers.setup_gitsigns
 local test_config = helpers.test_config
@@ -9,6 +10,7 @@ local edit = helpers.edit
 local clear = helpers.clear
 local cleanup = helpers.cleanup
 local expectf = helpers.expectf
+local check = helpers.check
 local test_file --- @type string
 
 helpers.env()
@@ -17,6 +19,107 @@ local function refresh_paths()
   test_file = helpers.test_file
 end
 
+local function require_source_hls()
+  if helpers.fn.has('nvim-0.12') == 0 then
+    pending('requires Neovim 0.12+')
+  end
+end
+
+local function require_window_scoped_deleted_preview()
+  if helpers.fn.has('nvim-0.11') == 0 then
+    pending('requires window-scoped deleted preview support')
+  end
+end
+
+local function enable_lua_treesitter_on_filetype()
+  exec_lua(function()
+    vim.api.nvim_create_autocmd('FileType', {
+      group = vim.api.nvim_create_augroup('gitsigns_word_diff_treesitter', { clear = true }),
+      pattern = 'lua',
+      callback = function(args)
+        pcall(vim.treesitter.start, args.buf, 'lua')
+        local ok, parser = pcall(vim.treesitter.get_parser, args.buf, 'lua')
+        if ok and parser then
+          pcall(parser.parse, parser, true)
+        end
+      end,
+    })
+
+    vim.cmd('syntax on')
+    vim.bo.filetype = 'lua'
+  end)
+end
+
+local function contains_hl(hl, group)
+  if type(hl) == 'table' then
+    return vim.tbl_contains(hl, group)
+  end
+  return hl == group
+end
+
+local function virt_hl_at_col(vline, col)
+  local byte_col = 0
+  for _, chunk in ipairs(vline) do
+    local text, hl = chunk[1], chunk[2]
+    if contains_hl(hl, 'GitSignsDeleteVirtLn') then
+      local next_col = byte_col + #text
+      if col < next_col then
+        return hl
+      end
+      byte_col = next_col
+    end
+  end
+end
+
+local function deleted_preview_has_hl(group, bufnr)
+  return exec_lua(function(target, source_bufnr)
+    source_bufnr = source_bufnr or 0
+    for _, ns in pairs(vim.api.nvim_get_namespaces()) do
+      for _, mark in
+        ipairs(vim.api.nvim_buf_get_extmarks(source_bufnr, ns, 0, -1, { details = true }))
+      do
+        local details = mark[4]
+        if details and details.virt_lines and details.virt_lines_leftcol then
+          for _, vline in ipairs(details.virt_lines) do
+            for _, chunk in ipairs(vline) do
+              local hl = chunk[2]
+              if type(hl) == 'table' then
+                if vim.tbl_contains(hl, target) then
+                  return true
+                end
+              elseif hl == target then
+                return true
+              end
+            end
+          end
+        end
+      end
+    end
+    return false
+  end, group, bufnr)
+end
+
+local function count_deleted_preview_marks(bufnr)
+  return exec_lua(function(source_bufnr)
+    source_bufnr = source_bufnr or 0
+    local count = 0
+    for _, ns in pairs(vim.api.nvim_get_namespaces()) do
+      for _, mark in
+        ipairs(vim.api.nvim_buf_get_extmarks(source_bufnr, ns, 0, -1, { details = true }))
+      do
+        local details = mark[4]
+        if details and details.virt_lines and details.virt_lines_leftcol then
+          count = count + 1
+        end
+      end
+    end
+    return count
+  end, bufnr)
+end
+
+--- @param rows string[]
+--- @param text string
+--- @return boolean
 describe('word diff', function()
   before_each(function()
     clear()
@@ -78,14 +181,15 @@ describe('inline preview', function()
     if helpers.fn.has('nvim-0.11') == 0 then
       pending('requires Neovim 0.11+')
     end
-    setup_test_repo({ test_file_text = { 'éx' } })
+    setup_test_repo({ test_file_text = { 'unchanged', 'éx' } })
     local config = vim.deepcopy(test_config)
     config.word_diff = true
     setup_gitsigns(config)
     edit(test_file)
 
     exec_lua(function()
-      vim.api.nvim_buf_set_lines(0, 0, 1, false, { 'éy' })
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'éy' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
     end)
 
     exec_lua(function()
@@ -97,30 +201,31 @@ describe('inline preview', function()
       eq(1, #hunks)
     end)
 
-    exec_lua(function()
-      require('gitsigns').preview_hunk_inline()
-    end)
-
-    local start_col, end_col = exec_lua(function()
-      local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
-      local marks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
-      local start_col0, end_col0 --- @type integer?, integer?
-      for _, mark in ipairs(marks) do
-        local details = mark[4]
-        if details and details.hl_group == 'GitSignsChangeInline' then
-          start_col0 = mark[3]
-          end_col0 = details.end_col
-          break
-        end
-      end
-      return start_col0, end_col0
-    end)
-
     local expected_start, expected_end = exec_lua(function()
-      local line = assert(vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      local line = assert(vim.api.nvim_buf_get_lines(0, 1, 2, false)[1])
       -- Use UTF-32 indexes so we can count characters.
       return vim.str_byteindex(line, 'utf-32', 1), vim.str_byteindex(line, 'utf-32', 2)
     end)
+
+    local start_col, end_col = exec_lua(function()
+      require('gitsigns.async').run(require('gitsigns.actions.preview').preview_hunk_inline):wait()
+
+      local start_col0, end_col0 --- @type integer?, integer?
+      vim.wait(1000, function()
+        local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
+        local marks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
+        for _, mark in ipairs(marks) do
+          local details = mark[4]
+          if details and details.hl_group == 'GitSignsChangeInline' then
+            start_col0 = mark[3]
+            end_col0 = details.end_col
+            return true
+          end
+        end
+      end)
+      return start_col0, end_col0
+    end)
+
     eq(expected_start, start_col)
     eq(expected_end, end_col)
   end)
@@ -145,19 +250,1575 @@ describe('inline preview', function()
       assert(hunk and hunk.removed.count == 2)
     end)
 
-    local deleted_marks = exec_lua(function()
-      local async = require('gitsigns.async')
-      local winid = async
-        .run(function()
-          return require('gitsigns.actions.preview').preview_hunk_inline()
-        end)
+    local wins_before, wins_after, virt_line_count, leftcol = exec_lua(function()
+      local wins0 = #vim.api.nvim_list_wins()
+      local markid = require('gitsigns.async')
+        .run(require('gitsigns.actions.preview').preview_hunk_inline)
         :wait()
-      assert(winid, 'preview window not found')
-      local buf = vim.api.nvim_win_get_buf(winid)
+      assert(markid, 'preview mark not found')
       local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
-      return #vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })
+      local marks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
+      local details --- @type vim.api.keyset.get_extmark_item[4]?
+      for _, mark in ipairs(marks) do
+        if mark[1] == markid then
+          details = mark[4]
+          break
+        end
+      end
+      assert(details and details.virt_lines, 'preview virtual lines not found')
+      return wins0, #vim.api.nvim_list_wins(), #details.virt_lines, details.virt_lines_leftcol
     end)
 
-    eq(2, deleted_marks)
+    eq(wins_before, wins_after)
+    eq(2, virt_line_count)
+    eq(true, leftcol)
+  end)
+
+  it('shows top-of-file deletions with virtual lines', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'bravo',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, 1, false, {})
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.type == 'delete' and hunk.added.start == 0)
+    end)
+
+    local wins_before, wins_after, virt_line_count, leftcol, top_row = exec_lua(function()
+      local wins0 = #vim.api.nvim_list_wins()
+      local markid = require('gitsigns.async')
+        .run(require('gitsigns.actions.preview').preview_hunk_inline)
+        :wait()
+      assert(markid, 'preview mark not found')
+
+      local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
+      local marks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
+      local details --- @type vim.api.keyset.get_extmark_item[4]?
+      for _, mark in ipairs(marks) do
+        if mark[1] == markid then
+          details = mark[4]
+          break
+        end
+      end
+      assert(details and details.virt_lines, 'preview virtual lines not found')
+
+      local function screenline(row, width)
+        local chars = {} --- @type string[]
+        for col = 1, width do
+          chars[#chars + 1] = vim.fn.screenstring(row, col)
+        end
+        return table.concat(chars)
+      end
+
+      local top_row0 --- @type string?
+      vim.wait(1000, function()
+        vim.cmd('redraw!')
+        local row = screenline(1, 24)
+        if row:find('alpha', 1, true) then
+          top_row0 = row
+          return true
+        end
+      end)
+
+      return wins0,
+        #vim.api.nvim_list_wins(),
+        #details.virt_lines,
+        details.virt_lines_leftcol,
+        top_row0
+    end)
+
+    eq(wins_before, wins_after)
+    eq(1, virt_line_count)
+    eq(true, leftcol)
+    assert(top_row)
+  end)
+
+  it('respects empty statuscolumn output', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'local foo = 1',
+        'omega',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.wo.statuscolumn = "%{''}"
+      vim.wo.signcolumn = 'no'
+      vim.wo.number = true
+      vim.wo.relativenumber = true
+      vim.wo.wrap = false
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1)
+    end)
+
+    local rendered = exec_lua(function()
+      local markid = require('gitsigns.async')
+        .run(require('gitsigns.actions.preview').preview_hunk_inline)
+        :wait()
+      assert(markid)
+
+      local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
+      local marks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
+      for _, mark in ipairs(marks) do
+        if mark[1] == markid then
+          local chunks = assert(mark[4].virt_lines)[1]
+          local text = {} --- @type string[]
+          for _, chunk in ipairs(chunks) do
+            text[#text + 1] = chunk[1]
+          end
+          return table.concat(text)
+        end
+      end
+    end)
+
+    assert(rendered)
+    eq('local foo = 1', rendered:sub(1, #'local foo = 1'))
+  end)
+
+  it('replicates deleted highlight stacks in virtual lines', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+    enable_lua_treesitter_on_filetype()
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1 and hunk.added.count == 1)
+    end)
+
+    local expected_keyword, expected_diff, virt_line, diff_col = exec_lua(function()
+      local Inspect = require('gitsigns.inspect')
+
+      local removed = { 'unchanged', 'local foo = 1' }
+      local added = { 'unchanged', 'local bar = 1' }
+      local removed_regions = require('gitsigns.diff_int').run_word_diff(
+        { removed[2] },
+        { added[2] }
+      )
+      local diff_col = removed_regions[1][3] - 1
+
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_preview')
+      local preview_buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(preview_buf, 0, -1, false, removed)
+      vim.bo[preview_buf].filetype = vim.bo.filetype
+      vim.bo[preview_buf].tabstop = vim.bo.tabstop
+      if vim.bo.syntax ~= '' then
+        vim.bo[preview_buf].syntax = vim.bo.syntax
+      end
+      local ok, parser = pcall(vim.treesitter.get_parser, preview_buf, 'lua')
+      assert(ok and parser)
+      pcall(parser.parse, parser, true)
+
+      vim.api.nvim_buf_set_extmark(preview_buf, ns, 1, 0, {
+        hl_group = 'GitSignsDeleteVirtLn',
+        hl_eol = true,
+        end_row = 2,
+        priority = 1000,
+      })
+      vim.api.nvim_buf_set_extmark(preview_buf, ns, 1, diff_col, {
+        hl_group = 'GitSignsDeleteVirtLnInLine',
+        end_col = removed_regions[1][4] - 1,
+        end_row = 1,
+        priority = 1001,
+      })
+
+      local inspected = Inspect.inspect_range(preview_buf, 1, 0, #removed[2])
+      local expected_keyword0 = Inspect.hl_stack_at(inspected, 0)
+      local expected_diff0 = Inspect.hl_stack_at(inspected, diff_col)
+
+      local markid = require('gitsigns.async')
+        .run(require('gitsigns.actions.preview').preview_hunk_inline)
+        :wait()
+      assert(markid)
+
+      local ns_preview_inline = vim.api.nvim_get_namespaces().gitsigns_preview_inline
+      local marks = vim.api.nvim_buf_get_extmarks(0, ns_preview_inline, 0, -1, { details = true })
+      local virt_lines --- @type Gitsigns.VirtTextChunk[][]?
+      for _, mark in ipairs(marks) do
+        if mark[1] == markid then
+          virt_lines = assert(mark[4]).virt_lines
+          break
+        end
+      end
+      assert(virt_lines)
+
+      vim.api.nvim_buf_delete(preview_buf, { force = true })
+
+      return expected_keyword0, expected_diff0, virt_lines[1], diff_col
+    end)
+
+    local actual_keyword = virt_hl_at_col(virt_line, 0)
+    local actual_diff = virt_hl_at_col(virt_line, diff_col)
+
+    assert(contains_hl(expected_keyword, '@keyword.lua'))
+    assert(contains_hl(actual_keyword, '@keyword.lua'))
+    eq(expected_keyword, actual_keyword)
+    eq(expected_diff, actual_diff)
+  end)
+
+  it('aligns deleted text with signcolumn and relative numbers', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'local foo = 1',
+        'omega',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.cmd('set number relativenumber signcolumn=auto:3 nowrap')
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.cmd('normal! 2G')
+    end)
+
+    expectf(function()
+      local deleted_row, changed_row = exec_lua(function()
+        require('gitsigns.async')
+          .run(require('gitsigns.actions.preview').preview_hunk_inline)
+          :wait()
+        vim.cmd('redraw!')
+
+        local function screenline(row, width)
+          local chars = {} --- @type string[]
+          for col = 1, width do
+            chars[#chars + 1] = vim.fn.screenstring(row, col)
+          end
+          return table.concat(chars)
+        end
+
+        return screenline(2, 24), screenline(3, 24)
+      end)
+
+      local deleted_col = assert(
+        deleted_row:find('local', 1, true),
+        ('deleted=%q changed=%q'):format(deleted_row, changed_row)
+      )
+      local changed_col = assert(
+        changed_row:find('local', 1, true),
+        ('deleted=%q changed=%q'):format(deleted_row, changed_row)
+      )
+      eq(deleted_col, changed_col)
+      eq('  ', deleted_row:sub(1, 2))
+      assert(not deleted_row:find('_', 1, true))
+      eq(changed_row:sub(3, changed_col - 1), deleted_row:sub(3, deleted_col - 1))
+    end)
+  end)
+
+  it('scopes inline preview rendering to the active window', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'local foo = 1',
+        'omega',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.cmd('vsplit')
+
+      local wins = vim.api.nvim_tabpage_list_wins(0)
+      local left_win, right_win = wins[1], wins[2]
+      assert(left_win and right_win)
+
+      vim.api.nvim_set_current_win(left_win)
+      vim.cmd('setlocal nowrap')
+      vim.api.nvim_win_set_cursor(left_win, { 2, 0 })
+
+      vim.api.nvim_set_current_win(right_win)
+      vim.cmd('setlocal nowrap')
+    end)
+
+    expectf(function()
+      local left_has_preview, right_has_preview, scoped_wins, preview_marks, left_win = exec_lua(
+        function()
+          local wins = vim.api.nvim_tabpage_list_wins(0)
+          local left_win, right_win = wins[1], wins[2]
+          local bufnr = vim.api.nvim_get_current_buf()
+          local ns = vim.api.nvim_get_namespaces().gitsigns_preview_inline
+          local preview = require('gitsigns.actions.preview')
+
+          vim.api.nvim_set_current_win(left_win)
+          require('gitsigns.async').run(preview.preview_hunk_inline):wait()
+
+          local preview_marks0 = 0
+          for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })) do
+            if assert(mark[4]).virt_lines then
+              preview_marks0 = preview_marks0 + 1
+            end
+          end
+
+          return vim.api.nvim_win_call(left_win, function()
+            return preview.has_preview_inline(bufnr)
+          end),
+            vim.api.nvim_win_call(right_win, function()
+              return preview.has_preview_inline(bufnr)
+            end),
+            vim.api.nvim__ns_get(ns).wins,
+            preview_marks0,
+            left_win
+        end
+      )
+
+      eq(true, left_has_preview)
+      eq(false, right_has_preview)
+      eq(1, preview_marks)
+      eq({ left_win }, scoped_wins)
+    end)
+  end)
+end)
+
+describe('popup preview', function()
+  before_each(function()
+    clear()
+    refresh_paths()
+  end)
+
+  after_each(function()
+    cleanup()
+  end)
+
+  it('preserves original highlight priorities in popup lines', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+    enable_lua_treesitter_on_filetype()
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1 and hunk.added.count == 1)
+    end)
+
+    local expected_keyword_priority, actual_keyword_priority, line_priority, diff_priority = exec_lua(
+      function()
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local ns = vim.api.nvim_get_namespaces().gitsigns_popup
+        local marks = vim.api.nvim_buf_get_extmarks(popup_buf, ns, 0, -1, { details = true })
+
+        local function mark_contains_hl(hl, group)
+          if type(hl) == 'table' then
+            return vim.tbl_contains(hl, group)
+          end
+          return hl == group
+        end
+
+        local keyword_priority, line_priority0, diff_priority0
+        for _, mark in ipairs(marks) do
+          if mark[2] ~= 1 then
+            goto continue
+          end
+
+          local details = assert(mark[4])
+          local start_col = mark[3]
+          local end_col = details.end_col or math.huge
+
+          if
+            mark_contains_hl(details.hl_group, '@keyword.lua')
+            and start_col <= 1
+            and end_col > 1
+          then
+            keyword_priority = details.priority
+          elseif details.hl_group == 'GitSignsDeletePreview' then
+            line_priority0 = details.priority
+          elseif details.hl_group == 'GitSignsDeleteInline' then
+            diff_priority0 = details.priority
+          end
+
+          ::continue::
+        end
+
+        vim.api.nvim_win_close(popup_win, true)
+
+        assert(keyword_priority ~= nil)
+        assert(line_priority0 ~= nil)
+        assert(diff_priority0 ~= nil)
+
+        return vim.hl.priorities.treesitter, keyword_priority, line_priority0, diff_priority0
+      end
+    )
+
+    eq(expected_keyword_priority, actual_keyword_priority)
+    eq(1000, line_priority)
+    eq(1001, diff_priority)
+  end)
+
+  it('reuses deleted and added highlight stacks in preview_hunk', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+    enable_lua_treesitter_on_filetype()
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    check({
+      status = { head = 'main', added = 0, changed = 1, removed = 0 },
+      signs = { changed = 1 },
+    })
+
+    local result
+    expectf(function()
+      result = exec_lua(function()
+        local Inspect = require('gitsigns.inspect')
+
+        local function expected_line_hls(line, line_hl, inline_hl, region)
+          local preview_buf = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_buf_set_lines(preview_buf, 0, -1, false, { line })
+          vim.bo[preview_buf].filetype = vim.bo.filetype
+          vim.bo[preview_buf].tabstop = vim.bo.tabstop
+          if vim.bo.syntax ~= '' then
+            vim.bo[preview_buf].syntax = vim.bo.syntax
+          end
+          local ok, parser = pcall(vim.treesitter.get_parser, preview_buf, 'lua')
+          assert(ok and parser)
+          pcall(parser.parse, parser, true)
+
+          local ns_preview = vim.api.nvim_create_namespace('gitsigns_test_popup_preview_expected')
+          vim.api.nvim_buf_set_extmark(preview_buf, ns_preview, 0, 0, {
+            hl_group = line_hl,
+            hl_eol = true,
+            end_row = 1,
+            priority = 1000,
+          })
+          vim.api.nvim_buf_set_extmark(preview_buf, ns_preview, 0, region[3] - 1, {
+            hl_group = inline_hl,
+            end_col = region[4] - 1,
+            end_row = 0,
+            priority = 1001,
+          })
+
+          local diff_col = region[3] - 1
+          local inspected = Inspect.inspect_range(preview_buf, 0, 0, #line)
+          local keyword = Inspect.hl_stack_at(inspected, 0)
+          local diff = Inspect.hl_stack_at(inspected, diff_col)
+
+          vim.api.nvim_buf_delete(preview_buf, { force = true })
+
+          return keyword, diff, diff_col
+        end
+
+        local removed_line = 'local foo = 1'
+        local added_line = 'local bar = 1'
+        local removed_regions, added_regions = require('gitsigns.diff_int').run_word_diff(
+          { removed_line },
+          { added_line }
+        )
+
+        local expected_deleted_keyword0, expected_deleted_diff0, deleted_diff_col =
+          expected_line_hls(
+            removed_line,
+            'GitSignsDeletePreview',
+            'GitSignsDeleteInline',
+            removed_regions[1]
+          )
+        local expected_added_keyword0, expected_added_diff0, added_diff_col = expected_line_hls(
+          added_line,
+          'GitSignsAddPreview',
+          added_regions[1][2] == 'add' and 'GitSignsAddInline'
+            or added_regions[1][2] == 'change' and 'GitSignsChangeInline'
+            or 'GitSignsDeleteInline',
+          added_regions[1]
+        )
+
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = require('gitsigns.popup').is_open('hunk')
+        if not popup_win then
+          return
+        end
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local lines = vim.api.nvim_buf_get_lines(popup_buf, 0, -1, false)
+        local deleted_line = lines[2]
+        local added_line0 = lines[3]
+        if not deleted_line or not added_line0 then
+          return
+        end
+        assert(deleted_line == '-' .. removed_line, deleted_line)
+        assert(added_line0 == '+' .. added_line, added_line0)
+
+        local deleted_actual = Inspect.inspect_range(popup_buf, 1, 0, #removed_line + 1)
+        local added_actual = Inspect.inspect_range(popup_buf, 2, 0, #added_line + 1)
+
+        vim.api.nvim_win_close(popup_win, true)
+
+        return {
+          expected_deleted_keyword = expected_deleted_keyword0,
+          actual_deleted_keyword = Inspect.hl_stack_at(deleted_actual, 1),
+          expected_deleted_diff = expected_deleted_diff0,
+          actual_deleted_diff = Inspect.hl_stack_at(deleted_actual, deleted_diff_col + 1),
+          expected_added_keyword = expected_added_keyword0,
+          actual_added_keyword = Inspect.hl_stack_at(added_actual, 1),
+          expected_added_diff = expected_added_diff0,
+          actual_added_diff = Inspect.hl_stack_at(added_actual, added_diff_col + 1),
+        }
+      end)
+      assert(result)
+    end)
+
+    assert(contains_hl(result.expected_deleted_keyword, '@keyword.lua'))
+    assert(contains_hl(result.actual_deleted_keyword, '@keyword.lua'))
+    assert(contains_hl(result.expected_added_keyword, '@keyword.lua'))
+    assert(contains_hl(result.actual_added_keyword, '@keyword.lua'))
+    eq(result.expected_deleted_keyword, result.actual_deleted_keyword)
+    eq(result.expected_deleted_diff, result.actual_deleted_diff)
+    eq(result.expected_added_keyword, result.actual_added_keyword)
+    eq(result.expected_added_diff, result.actual_added_diff)
+  end)
+
+  it('extends preview_hunk line highlights to the end of the line', function()
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local deleted_eol, added_eol = exec_lua(function()
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local ns = assert(vim.api.nvim_get_namespaces().gitsigns_popup)
+        local marks = vim.api.nvim_buf_get_extmarks(popup_buf, ns, 0, -1, { details = true })
+        vim.api.nvim_win_close(popup_win, true)
+
+        local deleted_eol0, added_eol0 = false, false
+        for _, mark in ipairs(marks) do
+          local row = mark[2]
+          local col = mark[3]
+          local details = assert(mark[4])
+          if
+            details.hl_group == 'GitSignsDeletePreview'
+            and row == 1
+            and col == 0
+            and details.end_row == 2
+            and details.end_col == 0
+          then
+            deleted_eol0 = true
+          elseif
+            details.hl_group == 'GitSignsAddPreview'
+            and row == 2
+            and col == 0
+            and details.end_row == 3
+            and details.end_col == 0
+          then
+            added_eol0 = true
+          end
+        end
+
+        return deleted_eol0, added_eol0
+      end)
+
+      eq(true, deleted_eol)
+      eq(true, added_eol)
+    end)
+  end)
+
+  it('keeps delayed source highlights stable across repeated preview_hunk calls', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    exec_lua(function()
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_popup_repeat')
+      vim.api.nvim_create_autocmd('FileType', {
+        group = vim.api.nvim_create_augroup('gitsigns_test_popup_repeat', { clear = true }),
+        pattern = 'lua',
+        callback = function(args)
+          vim.schedule(function()
+            if vim.api.nvim_buf_is_valid(args.buf) then
+              local row = math.min(1, vim.api.nvim_buf_line_count(args.buf) - 1)
+              vim.api.nvim_buf_set_extmark(args.buf, ns, row, 0, {
+                end_col = 5,
+                end_row = row,
+                hl_group = 'ErrorMsg',
+                priority = 150,
+              })
+            end
+          end)
+        end,
+      })
+
+      vim.cmd('syntax on')
+      vim.bo.filetype = 'lua'
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1 and hunk.added.count == 1)
+    end)
+
+    local first_deleted, second_deleted, first_added, second_added = exec_lua(function()
+      local Inspect = require('gitsigns.inspect')
+
+      local function popup_stacks()
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local deleted = Inspect.inspect_range(popup_buf, 1, 0, #'-local foo = 1')
+        local added = Inspect.inspect_range(popup_buf, 2, 0, #'+local bar = 1')
+        vim.api.nvim_win_close(popup_win, true)
+        return Inspect.hl_stack_at(deleted, 1), Inspect.hl_stack_at(added, 1)
+      end
+
+      local first_deleted0, first_added0 = popup_stacks()
+      local second_deleted0, second_added0 = popup_stacks()
+      return first_deleted0, second_deleted0, first_added0, second_added0
+    end)
+
+    assert(contains_hl(first_deleted, 'GitSignsDeletePreview'))
+    assert(contains_hl(first_deleted, 'ErrorMsg'))
+    assert(contains_hl(second_deleted, 'GitSignsDeletePreview'))
+    assert(contains_hl(second_deleted, 'ErrorMsg'))
+    assert(contains_hl(first_added, 'GitSignsAddPreview'))
+    assert(contains_hl(first_added, 'ErrorMsg'))
+    assert(contains_hl(second_added, 'GitSignsAddPreview'))
+    assert(contains_hl(second_added, 'ErrorMsg'))
+    eq(first_deleted, second_deleted)
+    eq(first_added, second_added)
+  end)
+
+  it('keeps source full-line highlights off the synthetic prefix', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        '-- foo',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_popup_prefix')
+      vim.api.nvim_create_autocmd('FileType', {
+        group = vim.api.nvim_create_augroup('gitsigns_test_popup_prefix', { clear = true }),
+        pattern = 'lua',
+        callback = function(args)
+          vim.api.nvim_buf_set_extmark(args.buf, ns, 1, 0, {
+            hl_group = 'ErrorMsg',
+            hl_eol = true,
+            priority = 150,
+          })
+        end,
+      })
+
+      vim.cmd('syntax on')
+      vim.bo.filetype = 'lua'
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { '-- bar' })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1 and hunk.added.count == 1)
+    end)
+
+    local prefix_stack, text_stack = exec_lua(function()
+      local Inspect = require('gitsigns.inspect')
+
+      require('gitsigns.popup').close('hunk')
+      require('gitsigns').preview_hunk()
+      local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+      local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+      local deleted = Inspect.inspect_range(popup_buf, 1, 0, #'--- foo')
+      vim.api.nvim_win_close(popup_win, true)
+
+      return Inspect.hl_stack_at(deleted, 0), Inspect.hl_stack_at(deleted, 1)
+    end)
+
+    assert(contains_hl(prefix_stack, 'GitSignsDeletePreview'))
+    assert(not contains_hl(prefix_stack, 'ErrorMsg'))
+    assert(contains_hl(text_stack, 'ErrorMsg'))
+  end)
+
+  it('renders staged added lines from the index after unstaged edits above', function()
+    setup_test_repo({
+      test_file_text = {
+        'a',
+        'b',
+        'c',
+        'd',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 2, 3, false, { 'C' })
+      vim.cmd('write')
+    end)
+    git('add', test_file)
+    exec_lua(function()
+      require('gitsigns').refresh()
+    end)
+
+    expectf(function()
+      local staged = exec_lua(function()
+        local cache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+        return cache and cache.hunks_staged and #cache.hunks_staged or 0
+      end)
+      eq(1, staged)
+    end)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, 0, false, { 'X' })
+      vim.api.nvim_win_set_cursor(0, { 4, 0 })
+    end)
+
+    expectf(function()
+      local title, lines = exec_lua(function()
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local title0 = assert(vim.api.nvim_buf_get_lines(popup_buf, 0, 1, false)[1])
+        local lines0 = vim.api.nvim_buf_get_lines(popup_buf, 1, 3, false)
+        vim.api.nvim_win_close(popup_win, true)
+        return title0, lines0
+      end)
+
+      eq('Hunk 1 of 1', title)
+      eq({ '-c', '+C' }, lines)
+    end)
+  end)
+
+  it('uses unstaged numbering independently from staged hunks', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'bravo',
+        'charlie',
+        'delta',
+      },
+    })
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'BRAVO' })
+      vim.cmd('write')
+    end)
+    git('add', test_file)
+    exec_lua(function()
+      require('gitsigns').refresh()
+    end)
+
+    expectf(function()
+      local unstaged, staged = exec_lua(function()
+        local cache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+        return cache and #cache.hunks or 0,
+          cache and cache.hunks_staged and #cache.hunks_staged or 0
+      end)
+      eq(0, unstaged)
+      eq(1, staged)
+    end)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 3, 4, false, { 'DELTA' })
+      vim.api.nvim_win_set_cursor(0, { 4, 0 })
+    end)
+
+    expectf(function()
+      local unstaged, staged, title = exec_lua(function()
+        local cache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+
+        require('gitsigns.popup').close('hunk')
+        require('gitsigns').preview_hunk()
+        local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+        local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+        local line = assert(vim.api.nvim_buf_get_lines(popup_buf, 0, 1, false)[1])
+        vim.api.nvim_win_close(popup_win, true)
+
+        return cache and #cache.hunks or 0,
+          cache and cache.hunks_staged and #cache.hunks_staged or 0,
+          line
+      end)
+
+      eq(1, unstaged)
+      eq(1, staged)
+      eq('Hunk 1 of 1', title)
+    end)
+  end)
+
+  it('uses greedy hunks for preview_hunk under linematch', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'bravo',
+        'charlie',
+        'delta',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.word_diff = false
+    config.diff_opts = { linematch = 60 }
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, 4, false, {
+        'BRAVO',
+        'CHARLIE',
+        'delta',
+        'alpha',
+      })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    end)
+
+    expectf(function()
+      local regular_count, greedy_count = exec_lua(function()
+        local async = require('gitsigns.async')
+        local bcache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+        local regular, greedy
+
+        async
+          .run(function()
+            regular = bcache:get_hunks(false, false)
+            greedy = bcache:get_hunks(true, false)
+          end)
+          :wait()
+
+        return regular and #regular or 0, greedy and #greedy or 0
+      end)
+
+      eq(4, regular_count)
+      eq(2, greedy_count)
+    end)
+
+    local lines = exec_lua(function()
+      require('gitsigns.popup').close('hunk')
+      require('gitsigns').preview_hunk()
+      local popup_win = assert(require('gitsigns.popup').is_open('hunk'))
+      local popup_buf = vim.api.nvim_win_get_buf(popup_win)
+      local lines0 = vim.api.nvim_buf_get_lines(popup_buf, 0, -1, false)
+      vim.api.nvim_win_close(popup_win, true)
+      return lines0
+    end)
+
+    eq({
+      'Hunk 1 of 2',
+      '-alpha',
+      '-bravo',
+      '-charlie',
+      '+BRAVO',
+      '+CHARLIE',
+    }, lines)
+  end)
+end)
+
+describe('show_deleted', function()
+  before_each(function()
+    clear()
+    refresh_paths()
+  end)
+
+  after_each(function()
+    cleanup()
+  end)
+
+  it('prepares deleted preview metadata without eager capture', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    expectf(function()
+      local hunk = exec_lua(function()
+        return require('gitsigns').get_hunks()[1]
+      end)
+      assert(hunk and hunk.removed.count == 1)
+    end)
+
+    local calls = exec_lua(function()
+      local bufnr = vim.api.nvim_get_current_buf()
+      local DeletedPreview = require('gitsigns.deleted_preview')
+      local HunkPreview = require('gitsigns.hunk_preview')
+      local orig = HunkPreview.prepare_removed_source
+      local count = 0
+
+      HunkPreview.prepare_removed_source = function(...)
+        count = count + 1
+        return orig(...)
+      end
+
+      local ok, err = pcall(DeletedPreview.prepare, bufnr)
+      HunkPreview.prepare_removed_source = orig
+
+      assert(ok, err)
+      return count
+    end)
+
+    eq(0, calls)
+  end)
+
+  it('keeps existing deleted lines visible while lazy capture is pending', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    expectf(function()
+      local clears, scheduled, rendered = exec_lua(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        local winid = vim.api.nvim_get_current_win()
+        local DeletedPreview = require('gitsigns.deleted_preview')
+        local orig_clear = vim.api.nvim_buf_clear_namespace
+        local orig_schedule = vim.schedule
+        local clear_calls = 0
+        local did_schedule = false
+
+        vim.schedule = function(_)
+          did_schedule = true
+        end
+
+        vim.api.nvim_buf_clear_namespace = function(...)
+          clear_calls = clear_calls + 1
+          return orig_clear(...)
+        end
+
+        local ok, result = pcall(function()
+          DeletedPreview.prepare(bufnr)
+          return DeletedPreview.on_win(winid, bufnr, 1, vim.api.nvim_buf_line_count(bufnr))
+        end)
+
+        vim.api.nvim_buf_clear_namespace = orig_clear
+        vim.schedule = orig_schedule
+
+        assert(ok, result)
+        return clear_calls, did_schedule, result
+      end)
+
+      eq(0, clears)
+      eq(true, scheduled)
+      eq(false, rendered)
+    end)
+  end)
+
+  it('renders deleted lines via the decoration provider', function()
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    expectf(function()
+      local rows = exec_lua(function()
+        vim.cmd('redraw!')
+
+        local function screenline(row, width)
+          local chars = {} --- @type string[]
+          for col = 1, width do
+            chars[#chars + 1] = vim.fn.screenstring(row, col)
+          end
+          return table.concat(chars)
+        end
+
+        local rows0 = {} --- @type string[]
+        for row = 1, 4 do
+          rows0[row] = screenline(row, 24)
+        end
+
+        return rows0
+      end)
+
+      local deleted_row, changed_row
+      for _, row in ipairs(rows) do
+        if row:find('local foo = 1', 1, true) then
+          deleted_row = row
+        elseif row:find('local bar = 1', 1, true) then
+          changed_row = row
+        end
+      end
+
+      local deleted_col = assert(deleted_row, ('rows=%s'):format(vim.inspect(rows)))
+        and assert(deleted_row:find('local', 1, true), ('rows=%s'):format(vim.inspect(rows)))
+      local changed_col = assert(changed_row, ('rows=%s'):format(vim.inspect(rows)))
+        and assert(changed_row:find('local', 1, true), ('rows=%s'):format(vim.inspect(rows)))
+      eq(deleted_col, changed_col)
+      assert(deleted_row:find('local foo = 1', 1, true))
+      assert(changed_row:find('local bar = 1', 1, true))
+    end)
+  end)
+
+  it('refreshes deleted preview captures when word_diff changes', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    expectf(function()
+      exec_lua(function()
+        vim.cmd('redraw!')
+      end)
+      eq(true, deleted_preview_has_hl('GitSignsDeleteVirtLnInLine'))
+    end)
+
+    exec_lua(function()
+      require('gitsigns').toggle_word_diff(false)
+    end)
+
+    expectf(function()
+      exec_lua(function()
+        vim.cmd('redraw!')
+      end)
+      eq(true, deleted_preview_has_hl('GitSignsDeleteVirtLn'))
+      eq(false, deleted_preview_has_hl('GitSignsDeleteVirtLnInLine'))
+    end)
+  end)
+
+  it('aligns deleted text with signcolumn and relative numbers', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'local foo = 1',
+        'omega',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.cmd('set number relativenumber signcolumn=auto:3 nowrap')
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.cmd('normal! 3G')
+    end)
+
+    expectf(function()
+      local deleted_row, changed_row = exec_lua(function()
+        vim.cmd('redraw!')
+
+        local function screenline(row, width)
+          local chars = {} --- @type string[]
+          for col = 1, width do
+            chars[#chars + 1] = vim.fn.screenstring(row, col)
+          end
+          return table.concat(chars)
+        end
+
+        return screenline(2, 24), screenline(3, 24)
+      end)
+
+      local deleted_col = assert(deleted_row:find('local', 1, true))
+      local changed_col = assert(changed_row:find('local', 1, true))
+      eq(deleted_col, changed_col)
+      eq('  ', deleted_row:sub(1, 2))
+      assert(not deleted_row:find('_', 1, true))
+      eq(changed_row:sub(3, changed_col - 1), deleted_row:sub(3, deleted_col - 1))
+      assert(deleted_row:find('1 local foo = 1', 1, true))
+    end)
+  end)
+
+  it('uses window-local prefixes for each window showing the buffer', function()
+    setup_test_repo({
+      test_file_text = {
+        'alpha',
+        'local foo = 1',
+        'omega',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.cmd('vsplit')
+
+      local wins = vim.api.nvim_tabpage_list_wins(0)
+      local left_win, right_win = wins[1], wins[2]
+      assert(left_win and right_win)
+
+      vim.api.nvim_set_current_win(left_win)
+      vim.cmd('setlocal number relativenumber signcolumn=auto:3 nowrap')
+
+      vim.api.nvim_set_current_win(right_win)
+      vim.cmd('setlocal nonumber norelativenumber signcolumn=no nowrap')
+    end)
+
+    expectf(function()
+      local left_deleted, left_changed, right_deleted, right_changed = exec_lua(function()
+        vim.cmd('redraw!')
+
+        local wins = vim.api.nvim_tabpage_list_wins(0)
+        local left_win, right_win = wins[1], wins[2]
+
+        local function screenline(winid, row, width)
+          local pos = vim.fn.win_screenpos(winid)
+          local screen_row = pos[1] + row - 1
+          local screen_col = pos[2]
+          local chars = {} --- @type string[]
+          for col = screen_col, screen_col + width - 1 do
+            chars[#chars + 1] = vim.fn.screenstring(screen_row, col)
+          end
+          return table.concat(chars)
+        end
+
+        return screenline(left_win, 2, 28),
+          screenline(left_win, 3, 28),
+          screenline(right_win, 2, 28),
+          screenline(right_win, 3, 28)
+      end)
+
+      local left_deleted_col = assert(left_deleted:find('local', 1, true))
+      local left_changed_col = assert(left_changed:find('local', 1, true))
+      local right_deleted_col = assert(right_deleted:find('local', 1, true))
+      local right_changed_col = assert(right_changed:find('local', 1, true))
+
+      eq(left_deleted_col, left_changed_col)
+      eq(right_deleted_col, right_changed_col)
+      assert(left_deleted_col > right_deleted_col)
+    end)
+  end)
+
+  it('clears deleted preview extmarks when a window switches buffers', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    local old_bufnr = exec_lua(function()
+      return vim.api.nvim_get_current_buf()
+    end)
+
+    expectf(function()
+      exec_lua(function()
+        vim.cmd('redraw!')
+      end)
+      assert(count_deleted_preview_marks(old_bufnr) > 0)
+    end)
+
+    exec_lua(function()
+      vim.cmd('enew')
+      vim.cmd('redraw!')
+    end)
+
+    expectf(function()
+      eq(0, count_deleted_preview_marks(old_bufnr))
+    end)
+  end)
+
+  it('clears deleted preview extmarks when the buffer becomes clean', function()
+    require_window_scoped_deleted_preview()
+
+    setup_test_repo({
+      test_file_text = {
+        'unchanged',
+        'local foo = 1',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+    end)
+
+    local bufnr = exec_lua(function()
+      return vim.api.nvim_get_current_buf()
+    end)
+
+    expectf(function()
+      exec_lua(function()
+        vim.cmd('redraw!')
+      end)
+      assert(count_deleted_preview_marks(bufnr) > 0)
+    end)
+
+    exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local foo = 1' })
+    end)
+
+    expectf(function()
+      local hunks = exec_lua(function()
+        vim.cmd('redraw!')
+        return require('gitsigns').get_hunks()
+      end)
+
+      eq(0, #hunks)
+      eq(0, count_deleted_preview_marks(bufnr))
+    end)
+  end)
+
+  it('keeps delayed source highlights across multiple removed hunks', function()
+    require_source_hls()
+
+    setup_test_repo({
+      test_file_text = {
+        'header',
+        'local foo = 1',
+        'middle',
+        'local baz = 2',
+      },
+    })
+    local config = vim.deepcopy(test_config)
+    config.show_deleted = true
+    config.word_diff = true
+    setup_gitsigns(config)
+    edit(test_file)
+
+    exec_lua(function()
+      local ns = vim.api.nvim_create_namespace('gitsigns_test_show_deleted_multi')
+      vim.api.nvim_create_autocmd('FileType', {
+        group = vim.api.nvim_create_augroup('gitsigns_test_show_deleted_multi', { clear = true }),
+        pattern = 'lua',
+        callback = function(args)
+          vim.api.nvim_buf_set_extmark(args.buf, ns, 1, 0, {
+            end_col = 5,
+            end_row = 1,
+            hl_group = 'ErrorMsg',
+            priority = 150,
+          })
+          vim.schedule(function()
+            if vim.api.nvim_buf_is_valid(args.buf) then
+              vim.api.nvim_buf_set_extmark(args.buf, ns, 3, 0, {
+                end_col = 5,
+                end_row = 3,
+                hl_group = 'ErrorMsg',
+                priority = 150,
+              })
+            end
+          end)
+        end,
+      })
+
+      vim.cmd('syntax on')
+      vim.bo.filetype = 'lua'
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, { 'local bar = 1' })
+      vim.api.nvim_buf_set_lines(0, 3, 4, false, { 'local qux = 2' })
+    end)
+
+    expectf(function()
+      local hunks = exec_lua(function()
+        return require('gitsigns').get_hunks()
+      end)
+      eq(2, #hunks)
+    end)
+
+    local first_stack, second_stack = exec_lua(function()
+      local function contains_hl0(hl, group)
+        if type(hl) == 'table' then
+          return vim.tbl_contains(hl, group)
+        end
+        return hl == group
+      end
+
+      local function collect_marks()
+        local marks = {} --- @type vim.api.keyset.get_extmark_item[]
+        for _, ns in pairs(vim.api.nvim_get_namespaces()) do
+          for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })) do
+            local details = mark[4]
+            if details and details.virt_lines and details.virt_lines_leftcol then
+              local chunks = details.virt_lines[1]
+              if chunks then
+                for _, chunk in ipairs(chunks) do
+                  if contains_hl0(chunk[2], 'GitSignsDeleteVirtLn') then
+                    marks[#marks + 1] = mark
+                    break
+                  end
+                end
+              end
+            end
+          end
+        end
+        table.sort(marks, function(a, b)
+          return a[2] < b[2]
+        end)
+        return marks
+      end
+
+      local marks --- @type vim.api.keyset.get_extmark_item[]?
+      vim.wait(1000, function()
+        vim.cmd('redraw!')
+        marks = collect_marks()
+        return #marks >= 2
+      end)
+      assert(marks and #marks >= 2, vim.inspect(marks))
+
+      local function collect_hls(mark)
+        local seen = {} --- @type table<string, true>
+        for _, chunk in ipairs(assert(assert(mark[4]).virt_lines)[1]) do
+          local hl = chunk[2]
+          if type(hl) == 'table' then
+            for _, name in ipairs(hl) do
+              seen[name] = true
+            end
+          elseif hl and hl ~= '' then
+            seen[hl] = true
+          end
+        end
+
+        local ret = {} --- @type string[]
+        for hl in pairs(seen) do
+          ret[#ret + 1] = hl
+        end
+        table.sort(ret)
+        return ret
+      end
+
+      return collect_hls(assert(marks[1])), collect_hls(assert(marks[2]))
+    end)
+
+    assert(contains_hl(first_stack, 'ErrorMsg'))
+    assert(contains_hl(second_stack, 'ErrorMsg'))
+  end)
+end)
+
+describe('hunk preview source buffers', function()
+  before_each(function()
+    clear()
+    refresh_paths()
+  end)
+
+  after_each(function()
+    cleanup()
+  end)
+
+  it('clears cached syntax when the source syntax is cleared', function()
+    setup_test_repo()
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    expectf(function()
+      local before_syntax, after_syntax = exec_lua(function()
+        local HunkPreview = require('gitsigns.hunk_preview')
+        local source_cache = {} --- @type table<string, Gitsigns.HunkPreview.SourceBuf>
+        local bufnr = vim.api.nvim_get_current_buf()
+
+        vim.bo[0].syntax = 'lua'
+        local _, cleanup = HunkPreview.prepare_removed_source(bufnr, false, source_cache)
+        cleanup()
+
+        local cached_bufnr = assert(source_cache['removed:unstaged']).bufnr
+        local before = vim.bo[cached_bufnr].syntax
+
+        vim.bo[0].syntax = ''
+        local _, cleanup2 = HunkPreview.prepare_removed_source(bufnr, false, source_cache)
+        cleanup2()
+
+        local after = vim.bo[cached_bufnr].syntax
+        pcall(vim.api.nvim_buf_delete, cached_bufnr, { force = true })
+        return before, after
+      end)
+
+      eq('lua', before_syntax)
+      eq('', after_syntax)
+    end)
+  end)
+
+  it('recreates cached source buffers when the source text changes', function()
+    setup_test_repo()
+    setup_gitsigns(test_config)
+    edit(test_file)
+
+    expectf(function()
+      local first_valid, second_valid, same_buf, stale_marks = exec_lua(function()
+        local HunkPreview = require('gitsigns.hunk_preview')
+        local bcache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+        assert(bcache and bcache.compare_text)
+
+        local source_cache = {} --- @type table<string, Gitsigns.HunkPreview.SourceBuf>
+        local bufnr = vim.api.nvim_get_current_buf()
+        local ns = vim.api.nvim_create_namespace('gitsigns_test_source_cache')
+
+        local _, cleanup = HunkPreview.prepare_removed_source(bufnr, false, source_cache)
+        cleanup()
+
+        local first = assert(source_cache['removed:unstaged']).bufnr
+        vim.api.nvim_buf_set_extmark(first, ns, 0, 0, {
+          end_col = 1,
+          hl_group = 'ErrorMsg',
+        })
+
+        bcache.compare_text = { 'replacement line' }
+
+        local _, cleanup2 = HunkPreview.prepare_removed_source(bufnr, false, source_cache)
+        cleanup2()
+
+        local second = assert(source_cache['removed:unstaged']).bufnr
+        local marks = vim.api.nvim_buf_get_extmarks(second, ns, 0, -1, {})
+
+        local first_valid0 = vim.api.nvim_buf_is_valid(first)
+        local second_valid0 = vim.api.nvim_buf_is_valid(second)
+        pcall(vim.api.nvim_buf_delete, second, { force = true })
+
+        return first_valid0, second_valid0, first == second, #marks
+      end)
+
+      eq(false, first_valid)
+      eq(true, second_valid)
+      eq(false, same_buf)
+      eq(0, stale_marks)
+    end)
   end)
 end)


### PR DESCRIPTION
Hunk previews were assembled through separate popup, inline,
show_deleted, and blame paths. preview_hunk_inline() still depended on a
floating window view into a rendered buffer, while the other preview
modes rebuilt the same highlight and word-diff logic.

Introduce a render pipeline that inspects a rendered buffer and derives
popup lines, virtual text, and virtual lines from that output. Switch
preview_hunk_inline() to virtual lines, reuse the same path for
show_deleted() and full blame previews, add render/word-diff/blame
coverage.
