### PR TITLE
feat(heatmap): create configurable highlight group for temperature colors

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -1354,6 +1354,11 @@ GitSignsVirtLnum
     Used for line numbers in inline hunks previews.
 
     Fallbacks: `GitSignsDeleteVirtLn`
+                                                        *hl-GitSignsColorTemp*
+GitSignsColorTemp
+    Heatmap color: fg = hot (newer changes), bg = cold (older changes)
+
+    Fallbacks: `Normal`
 
 ==============================================================================
 COMMAND                                                      *gitsigns-command*

--- a/lua/gitsigns/color.lua
+++ b/lua/gitsigns/color.lua
@@ -62,16 +62,4 @@ function M.blend(color1, color2, alpha)
   }
 end
 
-local temp_color_stops = {
-  { 0, 0, 255 }, -- Blue
-  { 255, 0, 0 }, -- Red
-  { 255, 255, 0 }, -- Yellow
-}
-
---- @param value number 0-1
---- @return [integer, integer, integer]
-function M.temp(value)
-  return M.gradient(temp_color_stops, value)
-end
-
 return M

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -208,6 +208,13 @@ vim.list_extend(M.hls, {
       desc = 'Used for line numbers in inline hunks previews.',
     },
   },
+
+  {
+    GitSignsColorTemp = {
+      'Normal',
+      desc = 'Heatmap color: fg = hot (newer changes), bg = cold (older changes)',
+    },
+  },
 })
 
 ---@param name string
@@ -319,7 +326,6 @@ end
 
 do --- temperature highlight
   local temp_colors = {} --- @type table<integer,string>
-  local normal_bg --- @type [integer,integer,integer]?
 
   --- @param min integer
   --- @param max integer
@@ -332,20 +338,14 @@ do --- temperature highlight
 
     local denom = math.max(max, t) - min
     local normalized_t = denom ~= 0 and (t - min) / denom or 0
-    local raw_temp_color = Color.temp(normalized_t)
 
-    if normal_bg == nil then
-      local normal_hl = api.nvim_get_hl(0, { name = 'Normal' })
-      if normal_hl.bg then
-        normal_bg = Color.int_to_rgb(normal_hl.bg)
-      elseif vim.o.background == 'light' then
-        normal_bg = { 255, 255, 255 } -- white
-      else
-        normal_bg = { 0, 0, 0 } -- black
-      end
-    end
+    -- Smoothstep easing for a more natural distribution across the temp range
+    local t_eased = normalized_t * normalized_t * (3 - 2 * normalized_t)
 
-    local color = Color.rgb_to_int(Color.blend(raw_temp_color, normal_bg, alpha))
+    local temp_hl = api.nvim_get_hl(0, { name = 'GitSignsColorTemp', link = false })
+    local hot_color = Color.int_to_rgb(temp_hl.fg)
+    local cold_color = Color.int_to_rgb(temp_hl.bg)
+    local color = Color.rgb_to_int(Color.gradient({ cold_color, hot_color }, t_eased))
 
     if temp_colors[color] then
       return temp_colors[color]

--- a/test/highlights_spec.lua
+++ b/test/highlights_spec.lua
@@ -88,6 +88,7 @@ describe('highlights', function()
     helpers.setup_path()
     local res = helpers.exec_lua(function()
       vim.api.nvim_set_hl(0, 'Normal', { bg = 0x000000 })
+      vim.api.nvim_set_hl(0, 'GitSignsColorTemp', { fg = 0x0080ff, bg = 0x000000 })
 
       package.loaded['gitsigns.highlight'] = nil
       local hl = require('gitsigns.highlight')
@@ -98,6 +99,6 @@ describe('highlights', function()
     end)
 
     assert(res.name:match('^GitSignsColorTemp%.fg%.%d+$') ~= nil)
-    eq(0x00007F, res.fg)
+    eq(0x000000, res.fg)
   end)
 end)


### PR DESCRIPTION
So I was seeing that the current commit heatmap colors doesn't allow much configuration.

The current implementation (inspired by fugitive I see?)  is using  tri-color pattern Blue / Red / Yellow for indicating the age of the commit. On some color schemes, this makes the red pop more than the yellow: giving the impression that red commits are newer than yellow ones.

I'm proposing here a couple of improvement:
1. Using a single bi-color scheme (cold-hot) and do a smoothstep interpolation between then two. Which is generally considered a better practice to show a scale for a variable.
2. Let the user or theme define  and override the `GitSignsColorTemp` highlights
3. Fallback to `Normal` (bg = cold, fg = hot), which in my opinion is more subtle for an age indicator.


I'm happy to discuss the color/theme decisions since those can be subjective. Let me know what you think!

<details>
<summary>See screenshots</summary>
<img width="1422" height="1085" alt="Screenshot 2026-03-29 at 16 24 53" src="https://github.com/user-attachments/assets/17b565b1-33ba-4890-bae2-dd4960f9969b" />
<img width="1422" height="1085" alt="Screenshot 2026-03-29 at 16 25 22" src="https://github.com/user-attachments/assets/4abbea58-f3c0-4b5d-b377-e40f84467fbd" />
<img width="1422" height="1085" alt="Screenshot 2026-03-29 at 16 27 24" src="https://github.com/user-attachments/assets/82823dcd-b6f7-45da-a3e9-4dc82eec70e6" />
<img width="1422" height="1085" alt="Screenshot 2026-03-29 at 16 26 05" src="https://github.com/user-attachments/assets/b06ef9ac-a1e0-4884-9f32-c450e3e72c5d" />
<img width="1422" height="1085" alt="Screenshot 2026-03-29 at 16 26 32" src="https://github.com/user-attachments/assets/ceca4282-c252-4699-9f96-3bd65c90a240" />
</details>