### PR TITLE
ci(test): add a native Windows test lane

### DIFF
--- a/.github/scripts/configure-msys2-luarocks.sh
+++ b/.github/scripts/configure-msys2-luarocks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+luarocks --lua-version=5.1 config variables.LUA /ucrt64/bin/luajit.exe
+luarocks --lua-version=5.1 config variables.LUA_BINDIR /ucrt64/bin
+luarocks --lua-version=5.1 config variables.LUA_INCDIR /ucrt64/include/luajit-2.1
+luarocks --lua-version=5.1 config variables.LUA_LIBDIR /ucrt64/lib
+luarocks --lua-version=5.1 config variables.LUALIB libluajit-5.1.dll.a

--- a/.github/scripts/install-native-luarocks.ps1
+++ b/.github/scripts/install-native-luarocks.ps1
@@ -1,0 +1,34 @@
+$version = '3.8.0'
+$archive = Join-Path $env:RUNNER_TEMP "luarocks-$version.zip"
+$source = Join-Path $env:RUNNER_TEMP "luarocks-$version"
+$install = Join-Path $source 'install.bat'
+$prefix = Join-Path $env:GITHUB_WORKSPACE '.luarocks'
+$shimDir = Join-Path $prefix 'bin'
+$lua = Join-Path $env:GITHUB_WORKSPACE '.lua'
+
+Invoke-WebRequest `
+  -Uri "https://github.com/luarocks/luarocks/archive/refs/tags/v$version.zip" `
+  -OutFile $archive
+
+Expand-Archive -Path $archive -DestinationPath $env:RUNNER_TEMP
+
+Push-Location $source
+& .\install.bat /NOADMIN /SELFCONTAINED /F /Q /P $prefix /LUA $lua /LV 5.1
+$status = $LASTEXITCODE
+Pop-Location
+
+if ($status -ne 0) {
+  exit $status
+}
+
+New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
+
+Set-Content -Path (Join-Path $shimDir 'luarocks') -Encoding utf8 -Value @'
+#!/usr/bin/env bash
+exec "$(dirname "$0")/../luarocks.bat" "$@"
+'@
+
+Set-Content -Path (Join-Path $shimDir 'luarocks-admin') -Encoding utf8 -Value @'
+#!/usr/bin/env bash
+exec "$(dirname "$0")/../luarocks-admin.bat" "$@"
+'@

--- a/.github/scripts/prepare-native-luarocks.sh
+++ b/.github/scripts/prepare-native-luarocks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chmod +x "$GITHUB_WORKSPACE/.luarocks/bin/luarocks" \
+  "$GITHUB_WORKSPACE/.luarocks/bin/luarocks-admin"
+
+github_output=$(cygpath --unix "$GITHUB_OUTPUT")
+printf 'bin=%s\n' "$(cygpath --unix "$GITHUB_WORKSPACE/.luarocks/bin")" >> "$github_output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,18 @@ jobs:
             os: ubuntu-latest
             neovim_branch: 'nightly'
             setup: linux
-          - name: test windows (v0.12.0)
+          - name: test windows-native (v0.12.0)
             os: windows-latest
             neovim_branch: 'v0.12.0'
-            setup: windows
-          - name: test windows (nightly)
+            setup: windows-native
+          - name: test windows-msys2 (v0.12.0)
+            os: windows-latest
+            neovim_branch: 'v0.12.0'
+            setup: windows-msys2
+          - name: test windows-msys2 (nightly)
             os: windows-latest
             neovim_branch: 'nightly'
-            setup: windows
+            setup: windows-msys2
 
     env:
       NVIM_TEST_VERSION: ${{ matrix.neovim_branch }}
@@ -75,7 +79,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - if: matrix.setup == 'linux'
+      - name: Install native Windows test tools
+        if: matrix.setup == 'windows-native'
+        shell: pwsh
+        run: choco install make wget unzip --no-progress -y
+
+      - name: Setup MSVC
+        if: matrix.setup == 'windows-native'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - if: matrix.setup != 'windows-msys2'
         uses: lewis6991/gh-actions-lua@master
         with:
           luaVersion: "5.1.5"
@@ -83,8 +96,13 @@ jobs:
       - if: matrix.setup == 'linux'
         uses: leafo/gh-actions-luarocks@v4
 
+      - name: Install LuaRocks
+        if: matrix.setup == 'windows-native'
+        shell: pwsh
+        run: ./.github/scripts/install-native-luarocks.ps1
+
       - name: Setup MSYS2
-        if: matrix.setup == 'windows'
+        if: matrix.setup == 'windows-msys2'
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
@@ -98,25 +116,33 @@ jobs:
             mingw-w64-ucrt-x86_64-neovim
 
       - name: Configure LuaRocks for LuaJIT
-        if: matrix.setup == 'windows'
+        if: matrix.setup == 'windows-msys2'
         shell: msys2 {0}
-        run: |
-          luarocks --lua-version=5.1 config variables.LUA /ucrt64/bin/luajit.exe
-          luarocks --lua-version=5.1 config variables.LUA_BINDIR /ucrt64/bin
-          luarocks --lua-version=5.1 config variables.LUA_INCDIR /ucrt64/include/luajit-2.1
-          luarocks --lua-version=5.1 config variables.LUA_LIBDIR /ucrt64/lib
-          luarocks --lua-version=5.1 config variables.LUALIB libluajit-5.1.dll.a
+        run: bash .github/scripts/configure-msys2-luarocks.sh
 
       - name: Set XDG_DATA_HOME
-        if: matrix.setup == 'linux'
+        if: matrix.setup != 'windows-msys2'
         shell: bash
-        run: echo "XDG_DATA_HOME=$GITHUB_WORKSPACE/.data" >> "$GITHUB_ENV"
+        run: |
+          workspace=$GITHUB_WORKSPACE
+          github_env=$GITHUB_ENV
+          if [ "${{ runner.os }}" = 'Windows' ]; then
+            workspace=$(cygpath --unix "$workspace")
+            github_env=$(cygpath --unix "$github_env")
+          fi
+          printf 'XDG_DATA_HOME=%s/.data\n' "$workspace" >> "$github_env"
 
       - name: Set XDG_DATA_HOME
-        if: matrix.setup == 'windows'
+        if: matrix.setup == 'windows-msys2'
         shell: msys2 {0}
         run: |
           printf 'XDG_DATA_HOME=%s/.data\n' "$(cygpath --unix "$GITHUB_WORKSPACE")" >> "$(cygpath --unix "$GITHUB_ENV")"
+
+      - name: Prepare native LuaRocks shims
+        if: matrix.setup == 'windows-native'
+        id: native_luarocks
+        shell: bash
+        run: bash .github/scripts/prepare-native-luarocks.sh
 
       - name: Set nvim-test cache epoch
         id: nvim_test_cache
@@ -134,26 +160,25 @@ jobs:
           path: |
             deps/nvim-test
             .data/nvim-test
-          key: nvim-test-${{ runner.os }}-${{ matrix.neovim_branch }}-${{ steps.nvim_test_cache.outputs.epoch }}-${{ hashFiles('Makefile') }}
+          key: nvim-test-${{ runner.os }}-${{ matrix.setup }}-${{ matrix.neovim_branch }}-${{ steps.nvim_test_cache.outputs.epoch }}-${{ hashFiles('Makefile') }}
           restore-keys: |
-            nvim-test-${{ runner.os }}-${{ matrix.neovim_branch }}-
+            nvim-test-${{ runner.os }}-${{ matrix.setup }}-${{ matrix.neovim_branch }}-
+            nvim-test-${{ runner.os }}-${{ matrix.setup }}-
             nvim-test-${{ runner.os }}-
 
-      - name: Download nvim-test
-        if: matrix.setup == 'linux'
-        run: make nvim-test
-
-      - name: Download nvim-test
-        if: matrix.setup == 'windows'
-        shell: msys2 {0}
-        run: make nvim-test
+      - name: Run Test
+        if: matrix.setup != 'windows-msys2'
+        shell: bash
+        env:
+          NATIVE_LUAROCKS_BIN: ${{ steps.native_luarocks.outputs.bin }}
+        run: |
+          if [ -n "$NATIVE_LUAROCKS_BIN" ]; then
+            export PATH="$NATIVE_LUAROCKS_BIN:$PATH"
+          fi
+          make test
 
       - name: Run Test
-        if: matrix.setup == 'linux'
-        run: make test
-
-      - name: Run Test
-        if: matrix.setup == 'windows'
+        if: matrix.setup == 'windows-msys2'
         shell: msys2 {0}
         run: make test
 

--- a/lua/gitsigns/git/repo/watcher.lua
+++ b/lua/gitsigns/git/repo/watcher.lua
@@ -34,9 +34,10 @@ function Watcher.new(gitdir, commondir)
   self.notify_callbacks_debounced = debounce_trailing(200, Watcher.notify_callbacks)
 
   local weak_self = util.weak_ref(self)
+  local handles = self.handles
 
   self._gc = util.gc_proxy(function()
-    for _, handle in pairs(self.handles) do
+    for _, handle in pairs(handles) do
       handle:stop()
       handle:close()
     end

--- a/test/gitdir_watcher_spec.lua
+++ b/test/gitdir_watcher_spec.lua
@@ -213,6 +213,44 @@ describe('gitdir_watcher', function()
     helpers.check({ signs = {} }, b2)
   end)
 
+  it('gc proxy closes over handles without retaining watcher', function()
+    setup_test_repo()
+    helpers.setup_path()
+
+    local result = helpers.exec_lua(function(scratch)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+
+      local repo, err = async.run(Repo.get, scratch):wait(5000)
+      assert(repo, err)
+
+      local watcher = repo._watcher
+      local gc = assert(getmetatable(watcher._gc).__gc)
+      local captured = {
+        handles = false,
+        watcher = false,
+      }
+
+      for i = 1, 20 do
+        local name, value = debug.getupvalue(gc, i)
+        if not name then
+          break
+        end
+        if value == watcher.handles then
+          captured.handles = true
+        end
+        if value == watcher then
+          captured.watcher = true
+        end
+      end
+
+      return captured
+    end, helpers.scratch)
+
+    eq(true, result.handles)
+    eq(false, result.watcher)
+  end)
+
   it('garbage collects repo and watcher', function()
     setup_test_repo()
     helpers.setup_path()

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -838,12 +838,7 @@ describe('gitsigns (with screen)', function()
           signs = { changed = 1, added = 4 },
         })
 
-        -- Minor delay to avoid the test being flaky
-        helpers.sleep(50)
-
-        exec_lua(function()
-          require('gitsigns.actions').stage_hunk()
-        end)
+        helpers.stage_hunk()
 
         check({
           status = { head = 'HEAD(rebasing)', added = 0, changed = 0, removed = 0 },

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -291,6 +291,8 @@ function M.git_init_scratch()
   M.git('config', 'color.pager', 'true')
   M.git('config', 'color.decorate', 'always')
   M.git('config', 'color.showbranch', 'always')
+  M.git('config', 'core.autocrlf', 'false')
+  M.git('config', 'core.eol', 'lf')
 
   M.git('config', 'merge.conflictStyle', 'merge')
 
@@ -328,6 +330,26 @@ function M.expectf(cond, interval)
     interval = interval * 2
   end
   cond()
+end
+
+--- @param range [integer, integer]?
+function M.stage_hunk(range)
+  M.exec_lua(function(range0)
+    local async = require('gitsigns.async')
+
+    if range0 == vim.NIL then
+      range0 = nil
+    end
+
+    async
+      .run(function()
+        local err = async.await(1, function(cb)
+          require('gitsigns').stage_hunk(range0, nil, cb)
+        end)
+        assert(not err, err)
+      end)
+      :wait(5000)
+  end, range == nil and vim.NIL or range)
 end
 
 --- @param path string


### PR DESCRIPTION
Problem:
The current Windows CI coverage only exercises the MSYS2/UCRT64 environment. That is convenient for bootstrapping the test stack, but it does not cover the more typical Windows user setup of native Neovim with Git for Windows Bash.

Solution:
Add a separate native Windows test lane on v0.12.0 that uses Git for Windows Bash, the existing Lua/LuaRocks setup actions, and a small Chocolatey bootstrap for make, wget, and unzip. Keep the MSYS2 lanes for Unix-like Windows coverage and split the nvim-test cache key by setup so the two environments do not share incompatible LuaRocks artifacts.