### PR TITLE
fix(word-diff): anchor EOF edits

### DIFF
--- a/lua/gitsigns/diff_int.lua
+++ b/lua/gitsigns/diff_int.lua
@@ -123,6 +123,18 @@ end
 
 local gaps_between_regions = 5
 
+--- @param line string
+--- @return string
+local function split_word_diff_line(line)
+  if line == '' then
+    return ''
+  end
+
+  -- Keep a trailing separator so vim.diff can anchor edits after the final
+  -- character instead of widening them into a change at EOF.
+  return table.concat(vim.split(line, ''), '\n') .. '\n'
+end
+
 --- @param hunks Gitsigns.Hunk.Hunk[]
 --- @return Gitsigns.Hunk.Hunk[]
 local function denoise_hunks(hunks)
@@ -165,8 +177,8 @@ function M.run_word_diff(removed, added)
     local add = added[i] --- @cast add -?
 
     -- pair lines by position
-    local a = table.concat(vim.split(rmd, ''), '\n')
-    local b = table.concat(vim.split(add, ''), '\n')
+    local a = split_word_diff_line(rmd)
+    local b = split_word_diff_line(add)
 
     local hunks = {} --- @type Gitsigns.Hunk.Hunk[]
     for _, r in ipairs(run_diff(a, b, config.diff_opts)) do

--- a/test/word_diff_spec.lua
+++ b/test/word_diff_spec.lua
@@ -136,6 +136,28 @@ describe('word diff', function()
     eq({ { 1, 'change', 9, 10 } }, rems)
     eq({ { 1, 'change', 9, 10 } }, adds)
   end)
+
+  it('anchors additions after the last character', function()
+    local rems, adds = exec_lua(function()
+      local diff = require('gitsigns.diff_int')
+      local removed = { 'foo)' }
+      local added = { 'foo)+' }
+      return diff.run_word_diff(removed, added)
+    end)
+    eq({ { 1, 'add', 5, 5 } }, rems)
+    eq({ { 1, 'add', 5, 6 } }, adds)
+  end)
+
+  it('anchors deletions at the last character', function()
+    local rems, adds = exec_lua(function()
+      local diff = require('gitsigns.diff_int')
+      local removed = { 'foo)' }
+      local added = { 'foo' }
+      return diff.run_word_diff(removed, added)
+    end)
+    eq({ { 1, 'delete', 4, 5 } }, rems)
+    eq({ { 1, 'delete', 4, 4 } }, adds)
+  end)
 end)
 
 describe('inline preview', function()


### PR DESCRIPTION
Word diff split each line into newline-separated characters before
calling vim.diff. That left EOF insertions and deletions without a
stable anchor, so appending or removing a trailing character could
expand into a change region that included the previous character.

Keep a trailing separator for non-empty lines before diffing so vim.diff
can anchor edits after the final character, and cover the boundary cases
with focused word diff regressions.

Resolves #1508
