### PR TITLE
fix(detach): don't pass tuple of nil

### DIFF
--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -31,7 +31,7 @@ local function redraw_statuscol(bufnr, top, bot)
   if statuscolumn_active then
     api.nvim__redraw({
       buf = bufnr,
-      range = { top, bot },
+      range = (top and bot) and { top, bot } or nil,
       statuscolumn = true,
     })
   end


### PR DESCRIPTION
I kept getting brief error popups when closing neovim. When using `nvim -V9nvim.log gitfile.test`, I figured out it was this:

```
Error in VimLeavePre Autocommands for "*":
Lua callback: ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:32: Invalid 'range': Expected 2-tuple of Integers
stack traceback:
	[C]: in function 'nvim__redraw'
	...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:32: in function 'redraw_statuscol'
	...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:421: in function 'detach'
	...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:481: in function 'detach'
	...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:457: in function <...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:455>
```

Additionally it can be recreated using `:lua require 'gitsigns'.detach_all()`:

```
E5108: Lua: ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:32: Invalid 'range': Expected 2-tuple of Integers
stack traceback:                                                                                                                                                                                                                               
        [C]: in function 'nvim__redraw'                                                                                                                                                                                                        
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:32: in function 'redraw_statuscol'                                                                                                                                         
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/manager.lua:421: in function 'detach'                                                                                                                                                  
        ...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:481: in function 'detach'                                                                                                                                                  
        ...al/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/attach.lua:457: in function 'detach_all'                                                                                                                                              
        ...l/share/nvim/lazy/gitsigns.nvim/lua/gitsigns/actions.lua:87: in function 'detach_all'                                                                                                                                               
        [string ":lua"]:1: in main chunk
```

This change fixes the issues for me locally on neovim 0.12.0-dev. Though I am not sure if this may cause unforeseen side effects should `top` or `bot` ever be `0`.