### PR TITLE
feat(history): add file history browser panel

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -295,6 +295,30 @@ change_base({base}, {global}, {callback})              *gitsigns.change_base()*
         {global}   (`boolean?`): Change the base of all buffers.
         {callback} (`(fun(err: string?))?`)
 
+history({callback})                                       *gitsigns.history()*
+    Show the git history for the current file in a panel below the source
+    window.
+
+    Opening a revision from a normal source buffer moves the panels to a new
+    tab for that revision and closes the original panels.
+    When invoked from the command line, `:vert Gitsigns history` opens the
+    history panel on the left instead.
+
+    Mappings:
+      <CR> opens [Open buffer].
+      v    [Open buffer] in a vertical split.
+      t    [Open buffer] in a new tab.
+      gv   [Show commit] in a vertical split.
+      gt   [Show commit] in a new tab.
+      i    toggles expanded inline info for the selected entry.
+      ?    opens an action picker for the selected entry.
+
+    Attributes: ~
+        {async}
+
+    Parameters: ~
+        {callback} (`(fun(err: string?))?`)
+
 blame({opts}, {callback})                                   *gitsigns.blame()*
     Run git-blame on the current file and open the results
     in a scroll-bound vertical split.
@@ -306,6 +330,11 @@ blame({opts}, {callback})                                   *gitsigns.blame()*
       s   [Show commit] in a vertical split.
       S   [Show commit] in a new tab.
       r   [Reblame at commit]
+      R   [Reblame at commit parent]
+
+    Reblaming from a normal source buffer opens the selected revision in a new
+    tab and moves attached panels there. Reblaming from a revision buffer stays
+    in the same tab.
 
     Attributes: ~
         {async}
@@ -1111,6 +1140,7 @@ gh                                                        *gitsigns-config-gh*
 
     Enable GitHub integration. This allows the following features:
     • `:Gitsigns blame_line` will show PR numbers (with a hyperlink)
+    • `:Gitsigns history` will show associated PR numbers in expanded info
 
 word_diff                                          *gitsigns-config-word_diff*
     Type: `boolean`, Default: `false`

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -716,6 +716,11 @@ end
 ---   s   [Show commit] in a vertical split.
 ---   S   [Show commit] in a new tab.
 ---   r   [Reblame at commit]
+---   R   [Reblame at commit parent]
+---
+--- Reblaming from a normal source buffer opens the selected revision in a new
+--- tab and moves attached panels there. Reblaming from a revision buffer stays
+--- in the same tab.
 ---
 --- Attributes:
 --- - {async}
@@ -729,6 +734,35 @@ end
 C.blame = function(args, _)
   --- @diagnostic disable-next-line: param-type-mismatch
   M.blame(args)
+end
+
+--- Show the git history for the current file in a panel below the source
+--- window.
+---
+--- Opening a revision from a normal source buffer moves the panels to a new
+--- tab for that revision and closes the original panels.
+--- When invoked from the command line, `:vert Gitsigns history` opens the
+--- history panel on the left instead.
+---
+--- Mappings:
+---   <CR> opens [Open buffer].
+---   v    [Open buffer] in a vertical split.
+---   t    [Open buffer] in a new tab.
+---   gv   [Show commit] in a vertical split.
+---   gt   [Show commit] in a new tab.
+---   i    toggles expanded inline info for the selected entry.
+---   ?    opens an action picker for the selected entry.
+---
+--- Attributes:
+--- - {async}
+---
+--- @param callback? fun(err?: string)
+function M.history(callback)
+  async_run(callback, require('gitsigns.actions.history').history)
+end
+
+function C.history(_, params)
+  async_run(nil, require('gitsigns.actions.history').history, params.smods)
 end
 
 --- @async

--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -4,6 +4,7 @@ local cache = require('gitsigns.cache').cache
 local config = require('gitsigns.config').config
 local log = require('gitsigns.debug.log')
 local error_once = require('gitsigns.message').error_once
+local inspection = require('gitsigns.actions.inspection')
 local util = require('gitsigns.util')
 
 local get_temp_hl = require('gitsigns.highlight').get_temp_hl
@@ -33,6 +34,15 @@ end
 --- @param lnum integer
 --- @param hl_group string
 local function hl_line(bufnr, nsl, lnum, hl_group)
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local line_count = api.nvim_buf_line_count(bufnr)
+  if lnum < 1 or lnum > line_count then
+    return
+  end
+
   api.nvim_buf_set_extmark(bufnr, nsl, lnum - 1, 0, {
     end_row = lnum,
     hl_eol = true,
@@ -172,11 +182,11 @@ end
 
 --- @param blame Gitsigns.CacheEntry.Blame
 --- @param win integer
---- @param main_win integer
+--- @param main_cache Gitsigns.CacheEntry
 --- @param buf_sha? string
 --- @return table<integer,true> commit_lines
 --- @return table<integer,boolean> commit_summaries
-local function render(blame, win, main_win, buf_sha)
+local function render(blame, win, main_cache, buf_sha)
   local max_author_len = 0
   local entries = blame.entries
 
@@ -184,8 +194,6 @@ local function render(blame, win, main_win, buf_sha)
     max_author_len = math.max(max_author_len, vim.fn.strdisplaywidth(b.commit.author))
   end
 
-  local main_buf = api.nvim_win_get_buf(main_win)
-  local main_cache = assert(cache[main_buf])
   local username = main_cache.git_obj.repo.username or ''
 
   local lines = {} --- @type string[]
@@ -200,7 +208,7 @@ local function render(blame, win, main_win, buf_sha)
   for i, b in ipairs(entries) do
     local commit = b.commit
     local sha = commit.abbrev_sha
-    local next_sha = entries[i + 1] and entries[i + 1].commit.abbrev_sha or nil
+    local next_sha = entries[i + 1] and entries[i + 1].commit.abbrev_sha
     local hash_hl = get_hash_color(sha)
     local line_chunks --- @type Gitsigns.BlameFmtChunk[]
     local summary_line = false
@@ -246,7 +254,11 @@ local function render(blame, win, main_win, buf_sha)
 
   local bufnr = api.nvim_win_get_buf(win)
 
+  local modifiable = vim.bo[bufnr].modifiable
+  vim.bo[bufnr].modifiable = true
   api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = modifiable
+  api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
   local min_time, max_time = main_cache:get_blame_times()
 
   -- Apply highlights
@@ -277,6 +289,10 @@ end
 --- @param revision? string
 --- @param parent? boolean
 local function reblame(opts, blame, win, revision, parent)
+  if not api.nvim_win_is_valid(win) then
+    return
+  end
+
   local blm_win = api.nvim_get_current_win()
   local lnum = api.nvim_win_get_cursor(blm_win)[1]
   local sha = assert(blame[lnum]).commit.sha
@@ -287,21 +303,46 @@ local function reblame(opts, blame, win, revision, parent)
     return
   end
 
-  vim.cmd.quit()
-  api.nvim_set_current_win(win)
+  local source_buf = api.nvim_win_get_buf(win)
+  local old_tabpage = api.nvim_win_get_tabpage(win)
+  local move_panels = not inspection.is_revision_buf(source_buf)
+  local history_win = move_panels and inspection.find_panel_win(old_tabpage, 'gitsigns-history')
 
-  local did_attach = require('gitsigns.actions.diffthis').show(nil, sha)
-  if not did_attach then
-    return
+  api.nvim_set_current_win(win)
+  if move_panels then
+    if not inspection.show_revision_in_new_tab(source_buf, sha) then
+      return
+    end
+  else
+    if not require('gitsigns.actions.diffthis').show(source_buf, sha) then
+      if api.nvim_win_is_valid(blm_win) then
+        api.nvim_set_current_win(blm_win)
+      end
+      return
+    end
   end
 
-  local src_buf = api.nvim_win_get_buf(win)
-  local line_count = api.nvim_buf_line_count(src_buf)
+  win = api.nvim_get_current_win()
+  local line_count = api.nvim_buf_line_count(api.nvim_win_get_buf(win))
   local new_lnum = math.min(lnum, line_count)
   api.nvim_win_set_cursor(win, { new_lnum, 0 })
 
   async.schedule()
-  M.blame(opts)
+  if move_panels then
+    if history_win then
+      local history_vertical = vim.wo[history_win][0].winfixwidth
+      require('gitsigns.actions.history').history({
+        vertical = history_vertical,
+        split = history_vertical and 'aboveleft' or 'belowright',
+      })
+    end
+    M.blame(opts)
+    inspection.close_panels(old_tabpage)
+  elseif api.nvim_win_is_valid(blm_win) then
+    -- Keep the layout stable for revision-to-revision reblame: the existing
+    -- panel refreshes itself when focus returns instead of being closed/reopened.
+    api.nvim_set_current_win(blm_win)
+  end
 end
 
 --- @async
@@ -322,37 +363,45 @@ end
 local function sync_cursors(augroup, wins)
   local cursor_save --- @type integer?
 
-  ---@param w integer
-  local function sync_cursor(w)
-    local b = api.nvim_win_get_buf(w)
-    api.nvim_create_autocmd('BufLeave', {
-      buffer = b,
-      group = augroup,
-      callback = function()
-        if api.nvim_win_is_valid(w) then
-          cursor_save = api.nvim_win_get_cursor(w)[1]
-        end
-      end,
-    })
-
-    api.nvim_create_autocmd('BufEnter', {
-      group = augroup,
-      buffer = b,
-      callback = function()
-        if not api.nvim_win_is_valid(w) then
-          return
-        end
-        local cur_cursor, cur_cursor_col = unpack(api.nvim_win_get_cursor(w))
-        if cursor_save and cursor_save ~= cur_cursor then
-          api.nvim_win_set_cursor(w, { cursor_save, vim.o.startofline and 0 or cur_cursor_col })
-        end
-      end,
-    })
-  end
-
+  local tracked_wins = {} --- @type table<integer, true>
   for _, w in ipairs(wins) do
-    sync_cursor(w)
+    tracked_wins[w] = true
   end
+
+  local function get_tracked_win()
+    local w = api.nvim_get_current_win()
+    if tracked_wins[w] and api.nvim_win_is_valid(w) then
+      return w
+    end
+  end
+
+  api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
+    group = augroup,
+    callback = function()
+      local w = get_tracked_win()
+      if not w then
+        return
+      end
+      cursor_save = api.nvim_win_get_cursor(w)[1]
+    end,
+  })
+
+  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+    group = augroup,
+    callback = function()
+      local w = get_tracked_win()
+      if not w then
+        return
+      end
+
+      local cur_cursor, cur_cursor_col = unpack(api.nvim_win_get_cursor(w))
+      local line_count = api.nvim_buf_line_count(api.nvim_win_get_buf(w))
+      local target = cursor_save and math.min(cursor_save, line_count) or cur_cursor
+      if target ~= cur_cursor then
+        api.nvim_win_set_cursor(w, { target, vim.o.startofline and 0 or cur_cursor_col })
+      end
+    end,
+  })
 end
 
 --- @param name string
@@ -379,18 +428,30 @@ end
 --- @param commit_lines table<integer,true>
 --- @param commit_summaries table<integer,boolean>
 local function on_cursor_moved(bufnr, blm_win, blame, commit_lines, commit_summaries)
-  local blm_bufnr = api.nvim_get_current_buf()
+  if not api.nvim_win_is_valid(blm_win) then
+    return
+  end
+
+  local blm_bufnr = api.nvim_win_get_buf(blm_win)
   local lnum = api.nvim_win_get_cursor(blm_win)[1]
   local cur_sha = assert(blame[lnum]).commit.abbrev_sha
+  local highlight_source = cache[bufnr] ~= nil and vim.bo[bufnr].filetype ~= 'gitsigns-history'
   for i, info in pairs(blame) do
     if info.commit.abbrev_sha == cur_sha then
       hl_line(blm_bufnr, ns_hl, i, 'CursorLine')
       hl_line(blm_bufnr, ns_hl, i, '@markup.strong')
-      hl_line(bufnr, ns_hl, i, 'CursorLine')
+      if highlight_source then
+        hl_line(bufnr, ns_hl, i, 'CursorLine')
+      end
     end
   end
 
-  if commit_lines[lnum] and commit_lines[lnum + 1] and commit_summaries[lnum] ~= false then
+  if
+    highlight_source
+    and commit_lines[lnum]
+    and commit_lines[lnum + 1]
+    and commit_summaries[lnum] ~= false
+  then
     local blame_info = assert(blame[lnum])
     local hash_hl = get_hash_color(blame_info.commit.abbrev_sha)
     api.nvim_buf_set_extmark(blm_bufnr, ns_hl, lnum - 1, 0, {
@@ -427,38 +488,6 @@ local function diff(bufnr, blm_win, blame)
   end
 end
 
---- Update the right-side extmarks when the window is resized
---- @param blm_bufnr integer
---- @param blm_win integer
---- @param entries table<integer,Gitsigns.BlameInfo?>
---- @param min_time integer
---- @param max_time integer
-local function update_right_extmarks(blm_bufnr, blm_win, entries, min_time, max_time)
-  if not api.nvim_win_is_valid(blm_win) or not api.nvim_buf_is_valid(blm_bufnr) then
-    return
-  end
-
-  -- Get the actual window width (not the content width)
-  -- Subtract 1 because virt_text_win_col is 0-indexed
-  local win_width = api.nvim_win_get_width(blm_win) - 1
-
-  -- Get all extmarks and delete only those with virt_text_win_col
-  -- These are the right-side heatmap indicators that need repositioning
-  local extmarks = api.nvim_buf_get_extmarks(blm_bufnr, ns, 0, -1, { details = true })
-
-  for _, ext in ipairs(extmarks) do
-    local id, _row, _col, details = ext[1], ext[2], ext[3], assert(ext[4])
-    if details.virt_text_win_col then
-      api.nvim_buf_del_extmark(blm_bufnr, ns, id)
-    end
-  end
-
-  -- Recreate the right-side extmarks with updated position
-  for i, blame_info in ipairs(entries) do
-    set_right_extmark(blm_bufnr, i, win_width, min_time, max_time, blame_info.commit.author_time)
-  end
-end
-
 --- @param mode string
 --- @param lhs string
 --- @param cb fun()
@@ -475,19 +504,41 @@ local function pmap(mode, lhs, cb, opts)
 end
 
 --- @async
+--- @param bcache Gitsigns.CacheEntry
 --- @param opts Gitsigns.BlameOpts?
-function M.blame(opts)
-  local bufnr = api.nvim_get_current_buf()
-  local win = api.nvim_get_current_win()
-  local bcache = cache[bufnr]
-  if not bcache then
-    log.dprint('Not attached')
+--- @return Gitsigns.CacheEntry.Blame
+local function load_blame(bcache, opts)
+  bcache:get_blame(nil, opts)
+  return assert(bcache.blame)
+end
+
+--- @param win integer
+local function set_blame_statusline(win)
+  if not api.nvim_win_is_valid(win) then
     return
   end
 
-  local lnum = nil
-  bcache:get_blame(lnum, opts)
-  local blame = assert(bcache.blame)
+  if vim.o.laststatus == 3 then
+    vim.wo[win][0].statusline = ''
+    return
+  end
+
+  -- Statusline plugins commonly rewrite this on WinEnter/WinLeave. Keep the
+  -- narrow blame column blank whenever the blame window is touched.
+  vim.wo[win][0].statusline = ' '
+end
+
+--- @param source_win integer
+--- @param bcache Gitsigns.CacheEntry
+--- @param blame Gitsigns.CacheEntry.Blame
+--- @return integer blm_win
+--- @return integer blm_bufnr
+--- @return table<integer,true> commit_lines
+--- @return table<integer,boolean> commit_summaries
+local function create_blame_window(source_win, bcache, blame)
+  api.nvim_set_current_win(source_win)
+
+  local bufnr = api.nvim_win_get_buf(source_win)
 
   -- Save position to align 'scrollbind'
   local top = vim.fn.line('w0') + vim.wo.scrolloff
@@ -497,10 +548,12 @@ function M.blame(opts)
   local blm_win = api.nvim_get_current_win()
 
   local blm_bufnr = api.nvim_create_buf(false, true)
+  if vim.fn.exists('&winfixbuf') == 1 then
+    vim.wo[blm_win][0].winfixbuf = false
+  end
   api.nvim_win_set_buf(blm_win, blm_bufnr)
   api.nvim_buf_set_name(blm_bufnr, (bcache:get_rev_bufname():gsub('^gitsigns:', 'gitsigns-blame:')))
-
-  local commit_lines, commit_summaries = render(blame, blm_win, win, bcache.git_obj.revision)
+  local commit_lines, commit_summaries = render(blame, blm_win, bcache, bcache.git_obj.revision)
 
   local blm_bo = vim.bo[blm_bufnr]
   blm_bo.buftype = 'nofile'
@@ -519,8 +572,9 @@ function M.blame(opts)
   blm_wlo.winfixwidth = true
   blm_wlo.wrap = false
   blm_wlo.list = false
+  set_blame_statusline(blm_win)
 
-  if vim.wo[win].winbar ~= '' and blm_wlo.winbar == '' then
+  if vim.wo[source_win].winbar ~= '' and blm_wlo.winbar == '' then
     local name = api.nvim_buf_get_name(bufnr)
     blm_wlo.winbar = vim.fn.fnamemodify(name, ':.')
   end
@@ -534,55 +588,235 @@ function M.blame(opts)
   vim.cmd(tostring(current))
   vim.cmd('normal! 0')
 
-  local cur_wlo = vim.wo[win][0]
-  local cur_orig_wlo = { cur_wlo.foldenable, cur_wlo.scrollbind, cur_wlo.wrap }
-  cur_wlo.foldenable = false
-  cur_wlo.scrollbind = true
-  cur_wlo.wrap = false
+  return blm_win, blm_bufnr, commit_lines, commit_summaries
+end
+
+--- @class (exact) Gitsigns.BlameSession.Opts
+--- @field opts Gitsigns.BlameOpts?
+--- @field source_win integer
+--- @field bufnr integer
+--- @field bcache Gitsigns.CacheEntry
+--- @field blame Gitsigns.CacheEntry.Blame
+--- @field blm_win integer
+--- @field blm_bufnr integer
+--- @field commit_lines table<integer,true>
+--- @field commit_summaries table<integer,boolean>
+
+--- @class (exact) Gitsigns.BlameSession
+--- @field private _opts Gitsigns.BlameOpts?
+--- @field private _source_win integer
+--- @field private _bufnr integer
+--- @field private _bcache Gitsigns.CacheEntry
+--- @field private _blame Gitsigns.CacheEntry.Blame
+--- @field private _blm_win integer
+--- @field private _blm_bufnr integer
+--- @field private _commit_lines table<integer,true>
+--- @field private _commit_summaries table<integer,boolean>
+--- @field private _source_win_opts table<integer,{boolean,boolean,boolean}>
+--- @field private _rerendering boolean
+local BlameSession = {}
+BlameSession.__index = BlameSession
+
+--- @param opts Gitsigns.BlameSession.Opts
+function BlameSession.start(opts)
+  local self = setmetatable({
+    _opts = opts.opts,
+    _source_win = opts.source_win,
+    _bufnr = opts.bufnr,
+    _bcache = opts.bcache,
+    _blame = opts.blame,
+    _blm_win = opts.blm_win,
+    _blm_bufnr = opts.blm_bufnr,
+    _commit_lines = opts.commit_lines,
+    _commit_summaries = opts.commit_summaries,
+    _source_win_opts = {},
+    _rerendering = false,
+  }, BlameSession)
+
+  self:_prepare_source_win(self._source_win)
 
   vim.cmd.redraw()
   vim.cmd.syncbind()
 
+  self:_setup_keymaps()
+  self:_setup_autocmds()
+end
+
+--- @private
+--- @param source_win integer
+function BlameSession:_prepare_source_win(source_win)
+  local cur_wlo = vim.wo[source_win][0]
+  self._source_win_opts[source_win] = self._source_win_opts[source_win]
+    or { cur_wlo.foldenable, cur_wlo.scrollbind, cur_wlo.wrap }
+  cur_wlo.foldenable = false
+  cur_wlo.scrollbind = true
+  cur_wlo.wrap = false
+end
+
+--- @private
+function BlameSession:_clear_highlights()
+  api.nvim_buf_clear_namespace(self._blm_bufnr, ns_hl, 0, -1)
+  if api.nvim_buf_is_valid(self._bufnr) then
+    api.nvim_buf_clear_namespace(self._bufnr, ns_hl, 0, -1)
+  end
+end
+
+--- @private
+function BlameSession:_rerender_panel()
+  if
+    self._rerendering
+    or not api.nvim_win_is_valid(self._blm_win)
+    or not api.nvim_buf_is_valid(self._blm_bufnr)
+  then
+    return
+  end
+
+  self._rerendering = true
+  self:_clear_highlights()
+
+  self._commit_lines, self._commit_summaries =
+    render(self._blame, self._blm_win, self._bcache, self._bcache.git_obj.revision)
+
+  local target_lnum = api.nvim_win_get_cursor(self._blm_win)[1]
+  if api.nvim_win_is_valid(self._source_win) then
+    pcall(api.nvim_win_call, self._source_win, function()
+      vim.cmd.syncbind()
+    end)
+    target_lnum = api.nvim_win_get_cursor(self._source_win)[1]
+  end
+  target_lnum = math.min(target_lnum, math.max(#self._blame.entries, 1))
+  api.nvim_win_set_cursor(self._blm_win, { target_lnum, 0 })
+
+  on_cursor_moved(
+    self._bufnr,
+    self._blm_win,
+    self._blame.entries,
+    self._commit_lines,
+    self._commit_summaries
+  )
+  self._rerendering = false
+end
+
+--- @async
+--- @private
+function BlameSession:_refresh()
+  if not api.nvim_win_is_valid(self._blm_win) then
+    return
+  end
+  set_blame_statusline(self._blm_win)
+
+  local tabpage = api.nvim_win_get_tabpage(self._blm_win)
+  local new_win = inspection.find_target_win(tabpage, self._source_win)
+  if not new_win then
+    if inspection.has_target_candidate_win(tabpage, self._source_win) then
+      return
+    end
+    pcall(api.nvim_win_close, self._blm_win, true)
+    return
+  end
+  self._source_win = new_win
+  self:_prepare_source_win(self._source_win)
+
+  if not api.nvim_win_is_valid(self._source_win) or not api.nvim_win_is_valid(self._blm_win) then
+    return
+  end
+
+  local new_bufnr = api.nvim_win_get_buf(self._source_win)
+  local new_bcache = cache[new_bufnr]
+  if not new_bcache then
+    async.schedule()
+    if
+      not api.nvim_win_is_valid(self._source_win)
+      or api.nvim_win_get_buf(self._source_win) ~= new_bufnr
+    then
+      return
+    end
+    new_bcache = cache[new_bufnr]
+    if not new_bcache then
+      return
+    end
+  end
+
+  if new_bufnr == self._bufnr then
+    return
+  end
+
+  local prev_bufnr = self._bufnr
+  if api.nvim_buf_is_valid(prev_bufnr) then
+    api.nvim_buf_clear_namespace(prev_bufnr, ns_hl, 0, -1)
+  end
+  api.nvim_buf_clear_namespace(self._blm_bufnr, ns_hl, 0, -1)
+
+  self._bufnr = new_bufnr
+  self._bcache = new_bcache
+  self._blame = load_blame(self._bcache, self._opts)
+
+  api.nvim_buf_set_name(
+    self._blm_bufnr,
+    (self._bcache:get_rev_bufname():gsub('^gitsigns:', 'gitsigns-blame:'))
+  )
+  if vim.wo[self._source_win].winbar ~= '' then
+    local name = api.nvim_buf_get_name(self._bufnr)
+    vim.wo[self._blm_win][0].winbar = vim.fn.fnamemodify(name, ':.')
+  end
+
+  vim.cmd.syncbind()
+  self:_rerender_panel()
+end
+
+--- @private
+function BlameSession:_setup_keymaps()
   vim.keymap.set('n', '<CR>', function()
     vim.cmd.popup(']GitsignsBlame')
   end, {
     desc = 'Open blame context menu',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   pmap('n', 'r', function()
-    async.run(reblame, opts, blame.entries, win, bcache.git_obj.revision):raise_on_error()
+    async
+      .run(reblame, self._opts, self._blame.entries, self._source_win, self._bcache.git_obj.revision)
+      :raise_on_error()
   end, {
     desc = 'Reblame at commit',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   pmap('n', 'd', function()
-    async.run(diff, bufnr, blm_win, blame.entries):raise_on_error()
+    async.run(diff, self._bufnr, self._blm_win, self._blame.entries):raise_on_error()
   end, {
     desc = 'Diff (tab)',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   pmap('n', 'R', function()
-    async.run(reblame, opts, blame.entries, win, bcache.git_obj.revision, true):raise_on_error()
+    async
+      .run(
+        reblame,
+        self._opts,
+        self._blame.entries,
+        self._source_win,
+        self._bcache.git_obj.revision,
+        true
+      )
+      :raise_on_error()
   end, {
     desc = 'Reblame at commit parent',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   pmap('n', 's', function()
-    async.run(show_commit, win, blm_win, 'vsplit', bcache):raise_on_error()
+    async.run(show_commit, self._source_win, self._blm_win, 'vsplit', self._bcache):raise_on_error()
   end, {
     desc = 'Show commit in a vertical split',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   pmap('n', 'S', function()
-    async.run(show_commit, win, blm_win, 'tabnew', bcache):raise_on_error()
+    async.run(show_commit, self._source_win, self._blm_win, 'tabnew', self._bcache):raise_on_error()
   end, {
     desc = 'Show commit in a new tab',
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
   })
 
   menu('GitsignsBlame', {
@@ -592,64 +826,135 @@ function M.blame(opts)
     { 'Show commit (vsplit)', 's' },
     { '            (tab)', 'S' },
   })
+end
 
+--- @private
+function BlameSession:_setup_autocmds()
   local group = api.nvim_create_augroup('GitsignsBlame', {})
 
-  api.nvim_create_autocmd({ 'BufHidden', 'QuitPre' }, {
-    buffer = bufnr,
+  api.nvim_create_autocmd({ 'CursorMoved', 'BufLeave' }, {
+    buffer = self._blm_bufnr,
     group = group,
-    once = true,
     callback = function()
-      if api.nvim_win_is_valid(blm_win) then
-        api.nvim_win_close(blm_win, true)
-      end
+      self:_clear_highlights()
     end,
   })
 
-  api.nvim_create_autocmd({ 'CursorMoved', 'BufLeave' }, {
-    buffer = blm_bufnr,
+  api.nvim_create_autocmd({ 'BufWinEnter', 'WinEnter', 'WinLeave' }, {
+    buffer = self._blm_bufnr,
     group = group,
     callback = function()
-      api.nvim_buf_clear_namespace(blm_bufnr, ns_hl, 0, -1)
-      if api.nvim_buf_is_valid(bufnr) then
-        api.nvim_buf_clear_namespace(bufnr, ns_hl, 0, -1)
+      local win = api.nvim_get_current_win()
+      if api.nvim_win_get_buf(win) == self._blm_bufnr then
+        if
+          win ~= self._blm_win
+          and api.nvim_win_is_valid(self._blm_win)
+          and api.nvim_win_get_buf(self._blm_win) == self._blm_bufnr
+        then
+          -- Splits can briefly show the blame buffer in the destination window.
+          -- Keep ownership on the real panel so resize refreshes do not render
+          -- blame into the buffer that replaces that transient clone.
+          set_blame_statusline(win)
+          return
+        end
+        self._blm_win = win
+        set_blame_statusline(win)
+        vim.schedule(function()
+          if api.nvim_win_is_valid(win) and api.nvim_win_get_buf(win) == self._blm_bufnr then
+            set_blame_statusline(win)
+          end
+        end)
       end
     end,
   })
 
   -- Highlight the same commit under the cursor
   api.nvim_create_autocmd('CursorMoved', {
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
     group = group,
     callback = function()
-      on_cursor_moved(bufnr, blm_win, blame.entries, commit_lines, commit_summaries)
+      on_cursor_moved(
+        self._bufnr,
+        self._blm_win,
+        self._blame.entries,
+        self._commit_lines,
+        self._commit_summaries
+      )
     end,
   })
 
-  -- Update right-side extmarks on window resize
+  -- Re-apply virtual text after layout changes. Bottom history splits can make
+  -- the scroll-bound blame/source pair settle before virtual lines catch up.
   api.nvim_create_autocmd('WinResized', {
-    buffer = blm_bufnr,
+    buffer = self._blm_bufnr,
     group = group,
     callback = function()
-      local min_time, max_time = assert(cache[bufnr]):get_blame_times()
-      update_right_extmarks(blm_bufnr, blm_win, blame.entries, min_time, max_time)
+      self:_rerender_panel()
+    end,
+  })
+
+  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+    group = group,
+    callback = function()
+      if
+        api.nvim_win_is_valid(self._source_win)
+        and api.nvim_win_get_buf(self._source_win) == self._bufnr
+      then
+        return
+      end
+      async
+        .run(function()
+          self:_refresh()
+        end)
+        :raise_on_error()
     end,
   })
 
   api.nvim_create_autocmd('WinClosed', {
-    pattern = tostring(blm_win),
+    pattern = tostring(self._blm_win),
     group = group,
     callback = function()
-      if api.nvim_buf_is_valid(bufnr) then
-        api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+      pcall(api.nvim_del_augroup_by_id, group)
+      if api.nvim_buf_is_valid(self._bufnr) then
+        api.nvim_buf_clear_namespace(self._bufnr, ns_hl, 0, -1)
       end
-      if api.nvim_win_is_valid(win) then
-        cur_wlo.foldenable, cur_wlo.scrollbind, cur_wlo.wrap = unpack(cur_orig_wlo)
+      for source_win, opts0 in pairs(self._source_win_opts) do
+        if api.nvim_win_is_valid(source_win) then
+          local wlo = vim.wo[source_win][0]
+          wlo.foldenable, wlo.scrollbind, wlo.wrap = unpack(opts0)
+        end
       end
     end,
   })
 
-  sync_cursors(group, { win, blm_win })
+  sync_cursors(group, { self._source_win, self._blm_win })
+end
+
+--- @async
+--- @param opts Gitsigns.BlameOpts?
+function M.blame(opts)
+  local source_win, bufnr, bcache = inspection.get_source_context(api.nvim_get_current_win())
+
+  if not bcache then
+    log.dprint('Not attached')
+    return
+  end
+
+  local blame = load_blame(bcache, opts)
+  local blm_win, blm_bufnr, commit_lines, commit_summaries =
+    create_blame_window(source_win, bcache, blame)
+
+  BlameSession.start({
+    opts = opts,
+    source_win = source_win,
+    bufnr = bufnr,
+    bcache = bcache,
+    blame = blame,
+    blm_win = blm_win,
+    blm_bufnr = blm_bufnr,
+    commit_lines = commit_lines,
+    commit_summaries = commit_summaries,
+  })
 end
 
 return M

--- a/lua/gitsigns/actions/diffthis.lua
+++ b/lua/gitsigns/actions/diffthis.lua
@@ -89,15 +89,28 @@ end
 local function create_revision_buf(bufnr, base, relpath)
   local bcache = assert(cache[bufnr])
   base = util.norm_base(base)
-
-  local bufname = bcache:get_rev_bufname(base, relpath)
-
-  if util.bufexists(bufname) then
-    return bufname, vim.fn.bufnr(bufname)
+  local history_relpath = vim.b[bufnr].gitsigns_history_relpath
+  if type(history_relpath) ~= 'string' then
+    history_relpath = bcache.git_obj.relpath
   end
 
-  local dbuf = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_name(dbuf, bufname)
+  local bufname = bcache:get_rev_bufname(base, relpath)
+  local exists = util.bufexists(bufname)
+  local dbuf = exists and vim.fn.bufnr(bufname) or api.nvim_create_buf(false, true)
+
+  if not exists then
+    api.nvim_buf_set_name(dbuf, bufname)
+  end
+
+  if history_relpath then
+    -- Keep history anchored to the current file path even when this buffer is
+    -- showing an older filename after a rename.
+    vim.b[dbuf].gitsigns_history_relpath = history_relpath
+  end
+
+  if exists then
+    return bufname, dbuf
+  end
 
   local ok, err = pcall(bufread, bufnr, dbuf, base, relpath)
   if not ok then
@@ -220,14 +233,21 @@ function M.show(bufnr, base, relpath)
     return false
   end
 
-  local bufname = create_revision_buf(bufnr, base, relpath)
-  if not bufname then
+  local bufname, dbuf = create_revision_buf(bufnr, base, relpath)
+  if not bufname or not dbuf then
     log.dprint('No bufname for revision ' .. base)
     return false
   end
 
   log.dprint('bufname ' .. bufname)
-  vim.cmd.edit(bufname)
+
+  if api.nvim_get_current_buf() ~= dbuf then
+    vim.cmd.edit(bufname)
+  else
+    -- Re-editing the same revision scratch buffer can clear its contents.
+    -- Treat this as a no-op when the target window already shows it.
+    return cache[dbuf] ~= nil
+  end
 
   -- Wait for the buffer to attach in case the user passes a callback that
   -- requires the buffer to be attached.

--- a/lua/gitsigns/actions/history.lua
+++ b/lua/gitsigns/actions/history.lua
@@ -1,0 +1,1087 @@
+--- File history browser.
+---
+--- The history command renders a commit list for one tracked path, opens
+--- revisions or commits from that list, and keeps the history panel attached to
+--- the active revision/source buffer without stealing ownership from it.
+local async = require('gitsigns.async')
+local cache = require('gitsigns.cache').cache
+local config = require('gitsigns.config').config
+local log = require('gitsigns.debug.log')
+local message = require('gitsigns.message')
+local inspection = require('gitsigns.actions.inspection')
+
+local api = vim.api
+
+local ns = api.nvim_create_namespace('gitsigns_history_win')
+local ns_state = api.nvim_create_namespace('gitsigns_history_state')
+
+local M = {}
+
+--- @class (exact) Gitsigns.HistoryEntry
+--- @field sha string
+--- @field abbrev_sha string
+--- @field author_date string
+--- @field author string
+--- @field refs string
+--- @field added? string
+--- @field removed? string
+--- @field rename_from? string
+--- @field summary string
+--- @field filename string
+--- @field synthetic? true
+--- @field last_changed_abbrev_sha? string
+--- @field last_changed_summary? string
+
+--- Highlight a line in the history window.
+--- @param bufnr integer
+--- @param lnum integer
+--- @param hl_group string
+local function hl_line(bufnr, lnum, hl_group)
+  api.nvim_buf_set_extmark(bufnr, ns_state, lnum - 1, 0, {
+    end_row = lnum,
+    hl_eol = true,
+    end_col = 0,
+    hl_group = hl_group,
+  })
+end
+
+--- @param path string
+--- @return string? old_path
+--- @return string? new_path
+local function parse_rename_path(path)
+  local prefix, old_path, new_path, suffix = path:match('^(.-){(.*) => (.*)}(.*)$')
+  if old_path then
+    return prefix .. old_path .. suffix, prefix .. new_path .. suffix
+  end
+
+  return path:match('^(.*) => (.*)$')
+end
+
+--- @param lines string[] `git log --format=... --numstat` output, with blank separators.
+--- @param fallback_relpath string Path used when a commit has no numstat path line.
+--- @return Gitsigns.HistoryEntry[]
+local function parse_git_log_entries(lines, fallback_relpath)
+  local entries = {} --- @type Gitsigns.HistoryEntry[]
+  local pending --- @type Gitsigns.HistoryEntry?
+
+  for _, line in ipairs(lines) do
+    local sha, abbrev_sha, author_date, author, refs, summary =
+      line:match('^([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t(.*)$')
+
+    if sha and abbrev_sha and author_date and author and refs and summary then
+      if pending then
+        entries[#entries + 1] = pending
+      end
+
+      pending = {
+        sha = sha,
+        abbrev_sha = abbrev_sha,
+        author_date = author_date,
+        author = author,
+        refs = refs,
+        summary = summary,
+        filename = fallback_relpath,
+      }
+    elseif pending then
+      local added, removed, path = line:match('^([%d-]+)\t([%d-]+)\t(.+)$')
+      if added and removed and path then
+        pending.added = added
+        pending.removed = removed
+
+        local rename_from, filename = parse_rename_path(path)
+        if rename_from and filename then
+          pending.rename_from = rename_from
+          pending.filename = filename
+        else
+          -- Keep the per-entry path so opening older revisions still works across renames.
+          pending.filename = path
+        end
+      end
+    end
+  end
+
+  if pending then
+    entries[#entries + 1] = pending
+  end
+
+  return entries
+end
+
+--- @param ...string
+local function git_log_args(...)
+  return vim.list_extend({
+    'log',
+    '--abbrev=8',
+    '--date=short',
+    '--format=format:%H\t%h\t%ad\t%an\t%D\t%s',
+  }, { ... })
+end
+
+--- @param hist_relpath string
+--- @param source_sha? string
+local function file_history_log_args(hist_relpath, source_sha)
+  local args = git_log_args('--follow', '--numstat')
+  if source_sha then
+    vim.list_extend(args, { '-1', source_sha })
+  end
+  vim.list_extend(args, { '--', hist_relpath })
+  return args
+end
+
+--- Insert a source row when the shown revision did not touch the file.
+--- This keeps the source marker on the actual buffer revision instead of
+--- snapping it to the nearest real file-change commit.
+--- @async
+--- @param repo Gitsigns.Repo
+--- @param entries Gitsigns.HistoryEntry[]
+--- @param source_sha string
+--- @param source_relpath string
+--- @param hist_relpath string
+local function maybe_insert_source_entry(repo, entries, source_sha, source_relpath, hist_relpath)
+  for _, entry in ipairs(entries) do
+    if entry.sha == source_sha then
+      return
+    end
+  end
+
+  -- The source commit may not touch this path, so fetch its row metadata
+  -- separately from the path-limited log used to position it in file history.
+  local source_log = repo:command(git_log_args('-1', source_sha), { ignore_error = true })
+  local source_entry = parse_git_log_entries(source_log, source_relpath)[1]
+  if not source_entry then
+    return
+  end
+
+  local last_changed_log =
+    repo:command(file_history_log_args(hist_relpath, source_sha), { ignore_error = true })
+  local last_changed = parse_git_log_entries(last_changed_log, hist_relpath)[1]
+
+  local insert_at = #entries + 1
+  if last_changed then
+    for i, entry in ipairs(entries) do
+      if entry.sha == last_changed.sha then
+        insert_at = i
+        break
+      end
+    end
+  end
+
+  source_entry.synthetic = true
+  source_entry.last_changed_abbrev_sha = last_changed and last_changed.abbrev_sha
+  source_entry.last_changed_summary = last_changed and last_changed.summary
+  table.insert(entries, insert_at, source_entry)
+end
+
+--- @param bufnr integer
+--- @param entries Gitsigns.HistoryEntry[]
+--- @return integer
+local function render(bufnr, entries)
+  local lines = {} --- @type string[]
+  local width = 0
+
+  for i, entry in ipairs(entries) do
+    local line = entry.abbrev_sha .. '  ' .. (entry.synthetic and '* ' or '') .. entry.summary
+
+    lines[i] = line
+    width = math.max(width, vim.fn.strdisplaywidth(line))
+  end
+
+  local modifiable = vim.bo[bufnr].modifiable
+  vim.bo[bufnr].modifiable = true
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = modifiable
+  api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+
+  for i, entry in ipairs(entries) do
+    local row = i - 1
+    local sha_end = #entry.abbrev_sha
+
+    api.nvim_buf_set_extmark(bufnr, ns, row, 0, {
+      end_col = sha_end,
+      hl_group = 'Directory',
+    })
+
+    if entry.synthetic then
+      api.nvim_buf_set_extmark(bufnr, ns, row, sha_end + 2, {
+        end_col = sha_end + 3,
+        hl_group = 'Special',
+      })
+    end
+  end
+
+  return width
+end
+
+--- @alias Gitsigns.HistoryOpen 'edit'|'vsplit'|'tabnew'
+
+--- @param source_win integer
+--- @param hist_win integer
+--- @return integer?
+local function get_target_win(source_win, hist_win)
+  local tabpage = api.nvim_win_is_valid(hist_win) and api.nvim_win_get_tabpage(hist_win) or 0
+  local target_win = inspection.find_target_win(tabpage, source_win)
+  if target_win then
+    return target_win
+  end
+
+  if api.nvim_win_is_valid(hist_win) then
+    return hist_win
+  end
+end
+
+--- @param source_win integer
+--- @param fallback_bufnr integer
+--- @return integer
+local function get_action_bufnr(source_win, fallback_bufnr)
+  if api.nvim_win_is_valid(source_win) then
+    local source_bufnr = api.nvim_win_get_buf(source_win)
+    if cache[source_bufnr] then
+      return source_bufnr
+    end
+  end
+
+  -- Revision buffers opened from history are wiped when replaced, so follow
+  -- the live source window when possible instead of pinning the original bufnr.
+  return fallback_bufnr
+end
+
+--- @async
+--- @param source_win integer
+--- @param hist_win integer
+--- @param open Gitsigns.HistoryOpen
+--- @param bufnr integer
+--- @param entry Gitsigns.HistoryEntry
+local function show_commit(source_win, hist_win, open, bufnr, entry)
+  local target_win = get_target_win(source_win, hist_win)
+  if not target_win then
+    return
+  end
+
+  local action_bufnr = get_action_bufnr(target_win, bufnr)
+  api.nvim_set_current_win(target_win)
+  require('gitsigns.actions.show_commit')(entry.sha, open, action_bufnr)
+end
+
+--- @async
+--- @param source_win integer
+--- @param hist_win integer
+--- @param open Gitsigns.HistoryOpen
+--- @param bufnr integer
+--- @param entry Gitsigns.HistoryEntry
+local function show_buffer(source_win, hist_win, open, bufnr, entry)
+  local target_win = get_target_win(source_win, hist_win)
+  if not target_win then
+    return
+  end
+
+  local target_is_hist = target_win == hist_win
+  local action_bufnr = get_action_bufnr(target_win, bufnr)
+  local old_tabpage = api.nvim_win_get_tabpage(target_win)
+  local move_panels = open == 'tabnew'
+    or (
+      open == 'edit'
+      and not target_is_hist
+      and not inspection.is_revision_buf(api.nvim_win_get_buf(target_win))
+    )
+
+  api.nvim_set_current_win(target_win)
+  if move_panels then
+    if not inspection.show_revision_in_new_tab(action_bufnr, entry.sha, entry.filename) then
+      return
+    end
+
+    local hist_vert = api.nvim_win_is_valid(hist_win) and vim.wo[hist_win][0].winfixwidth or false
+    M.history({
+      vertical = hist_vert,
+      split = hist_vert and 'aboveleft' or 'belowright',
+    })
+    inspection.close_panels(old_tabpage)
+    return
+  elseif open == 'edit' and target_is_hist then
+    -- Keep the history browser usable even if the right-hand buffer was closed.
+    vim.cmd.vsplit({ mods = { keepalt = true, split = 'botright' } })
+  elseif open ~= 'edit' then
+    vim.cmd[open]({ mods = { keepalt = true } })
+  end
+
+  local did_attach =
+    require('gitsigns.actions.diffthis').show(action_bufnr, entry.sha, entry.filename)
+  if not did_attach then
+    return
+  end
+
+  if open == 'edit' and api.nvim_win_is_valid(hist_win) then
+    api.nvim_set_current_win(hist_win)
+  end
+end
+
+--- @param hist_win integer
+--- @param entries Gitsigns.HistoryEntry[]
+--- @return Gitsigns.HistoryEntry?
+local function get_entry(hist_win, entries)
+  if api.nvim_win_is_valid(hist_win) then
+    local lnum = api.nvim_win_get_cursor(hist_win)[1]
+    return entries[lnum]
+  end
+end
+
+--- @class (exact) Gitsigns.HistoryPickerAction
+--- @field desc string
+--- @field run fun()
+
+--- @class (exact) Gitsigns.HistoryStatusAction
+--- @field key string
+--- @field status string
+
+--- @class (exact) Gitsigns.HistoryAction : Gitsigns.HistoryPickerAction, Gitsigns.HistoryStatusAction
+
+--- @class (exact) Gitsigns.HistoryKeymappedActionsOpts
+--- @field bufnr integer
+--- @field actions Gitsigns.HistoryAction[]
+--- @field prompt fun(): string
+--- @field format_item fun(action: Gitsigns.HistoryPickerAction): string
+--- @field run_action fun(action: Gitsigns.HistoryPickerAction)
+--- @param opts Gitsigns.HistoryKeymappedActionsOpts
+local function set_keymapped_actions(opts)
+  local picker_actions = {} --- @type Gitsigns.HistoryPickerAction[]
+
+  for i, action in ipairs(opts.actions) do
+    local picker_action = {
+      desc = action.desc,
+      run = action.run,
+    }
+    picker_actions[i] = picker_action
+
+    vim.keymap.set('n', action.key, function()
+      opts.run_action(picker_action)
+    end, {
+      buffer = opts.bufnr,
+      desc = action.desc,
+    })
+  end
+
+  vim.keymap.set('n', '?', function()
+    vim.ui.select(picker_actions, {
+      prompt = opts.prompt(),
+      format_item = opts.format_item,
+    }, function(action)
+      if action then
+        opts.run_action(action)
+      end
+    end)
+  end, {
+    buffer = opts.bufnr,
+    desc = 'Open action picker',
+  })
+end
+
+--- @param actions Gitsigns.HistoryStatusAction[]
+--- @return string
+local function format_statusline(actions)
+  local items = {} --- @type { keys: string[], status: string }[]
+  local by_status = {} --- @type table<string,{ keys: string[], status: string }>
+
+  for _, action in ipairs(actions) do
+    local item = by_status[action.status]
+    if item then
+      item.keys[#item.keys + 1] = action.key
+    else
+      item = { keys = { action.key }, status = action.status }
+      by_status[action.status] = item
+      items[#items + 1] = item
+    end
+  end
+
+  local chunks = {} --- @type string[]
+  for i, item in ipairs(items) do
+    chunks[i] = table.concat(item.keys, '/') .. ' ' .. item.status
+  end
+
+  return ' ' .. table.concat(chunks, '  ') .. ' '
+end
+
+--- @param hist_win integer
+--- @param entry Gitsigns.HistoryEntry
+local function set_winbar(hist_win, entry)
+  if not api.nvim_win_is_valid(hist_win) then
+    return
+  end
+
+  local wlo = vim.wo[hist_win][0]
+  -- Winbars use statusline syntax, so '%' needs escaping.
+  local file_label = vim.fn.pathshorten(entry.filename):gsub('%%', '%%%%')
+  wlo.winbar = ' History %<' .. file_label .. ' '
+end
+
+--- @param detail_lines Gitsigns.VirtTextChunk[][]
+--- @param label string
+--- @param value string
+--- @param value_hl string
+local function add_detail_line(detail_lines, label, value, value_hl)
+  detail_lines[#detail_lines + 1] = {
+    { '  ' .. label .. ' ', 'Comment' },
+    { value, value_hl },
+  }
+end
+
+--- @param detail_lines Gitsigns.VirtTextChunk[][]
+--- @param added? string
+--- @param removed? string
+local function add_stats_line(detail_lines, added, removed)
+  if not added or not removed then
+    return
+  end
+
+  if added == '-' or removed == '-' then
+    add_detail_line(detail_lines, 'changes', 'binary', 'Comment')
+    return
+  end
+
+  detail_lines[#detail_lines + 1] = {
+    { '  changes ', 'Comment' },
+    { '+' .. added, 'DiffAdd' },
+    { ' ', 'Comment' },
+    { '-' .. removed, 'DiffDelete' },
+  }
+end
+
+--- @param hist_bufnr integer
+--- @param lnum integer
+--- @param entry Gitsigns.HistoryEntry
+--- @param relpath string
+--- @param show_info boolean
+--- @param prs_loading boolean
+--- @param prs gitsigns.gh.PrInfo[]|false|nil
+local function set_detail(hist_bufnr, lnum, entry, relpath, show_info, prs_loading, prs)
+  if not api.nvim_buf_is_valid(hist_bufnr) then
+    return
+  end
+
+  if not show_info then
+    return
+  end
+
+  local detail_lines = {
+    {
+      { '  ' .. entry.author_date, 'Label' },
+      { '  ' .. entry.author, 'MoreMsg' },
+    },
+  } --- @type Gitsigns.VirtTextChunk[][]
+
+  if entry.refs ~= '' then
+    add_detail_line(detail_lines, 'refs', entry.refs, 'Title')
+  end
+
+  if entry.synthetic then
+    add_detail_line(detail_lines, 'status', 'unchanged in this commit', 'Comment')
+    if entry.last_changed_abbrev_sha and entry.last_changed_summary then
+      add_detail_line(
+        detail_lines,
+        'last changed',
+        entry.last_changed_abbrev_sha .. '  ' .. entry.last_changed_summary,
+        'Directory'
+      )
+    end
+  else
+    add_stats_line(detail_lines, entry.added, entry.removed)
+
+    if entry.rename_from then
+      add_detail_line(detail_lines, 'renamed from', entry.rename_from, 'Directory')
+    elseif entry.filename ~= relpath then
+      add_detail_line(detail_lines, 'old path', entry.filename, 'Directory')
+    end
+  end
+
+  if prs and next(prs) then
+    local labels = {} --- @type string[]
+    for i, pr in ipairs(prs) do
+      labels[i] = ('#%s'):format(pr.number)
+    end
+    add_detail_line(detail_lines, 'prs', table.concat(labels, ' '), 'Title')
+  end
+  if prs_loading then
+    add_detail_line(detail_lines, 'prs', 'loading...', 'Comment')
+  end
+  api.nvim_buf_set_extmark(hist_bufnr, ns_state, lnum - 1, 0, {
+    virt_lines = detail_lines,
+  })
+end
+
+--- @param source_bufnr integer
+--- @param bcache Gitsigns.CacheEntry
+--- @return string?
+local function get_source_sha(source_bufnr, bcache)
+  local source_sha = vim.b[source_bufnr].gitsigns_history_source_sha
+  if type(source_sha) == 'string' and source_sha ~= '' then
+    return source_sha
+  end
+
+  source_sha = bcache.git_obj.revision
+  if not source_sha or vim.startswith(source_sha, ':') or source_sha == 'FILE' then
+    return
+  end
+
+  return source_sha
+end
+
+--- @async
+--- @param bufnr integer
+--- @param bcache Gitsigns.CacheEntry
+--- @param relpath string
+--- @return Gitsigns.HistoryEntry[]?
+--- @return string? hist_relpath
+local function load_history_entries(bufnr, bcache, relpath)
+  local source_sha = bcache.git_obj.revision
+  if source_sha and source_sha ~= 'FILE' and not vim.startswith(source_sha, ':') then
+    if not source_sha:match('^%x+$') or #source_sha < 40 then
+      local resolved = bcache.git_obj.repo:command(
+        { 'rev-parse', '--verify', source_sha .. '^{commit}' },
+        { ignore_error = true }
+      )[1]
+      if type(resolved) == 'string' and resolved:match('^%x+$') and #resolved == 40 then
+        vim.b[bufnr].gitsigns_history_source_sha = resolved
+      end
+    end
+  end
+
+  local hist_relpath = vim.b[bufnr].gitsigns_history_relpath
+  if type(hist_relpath) ~= 'string' then
+    hist_relpath = relpath
+  end
+
+  local history, stderr = bcache.git_obj.repo:command(file_history_log_args(hist_relpath), {
+    ignore_error = true,
+  })
+
+  if stderr then
+    local msg = 'Error running git-log: ' .. stderr
+    message.error('%s', msg)
+    log.eprint(msg)
+    return
+  end
+
+  local entries = parse_git_log_entries(history, hist_relpath)
+  if #entries == 0 then
+    message.warn('No history for current buffer')
+    return
+  end
+
+  source_sha = get_source_sha(bufnr, bcache)
+  if source_sha then
+    maybe_insert_source_entry(bcache.git_obj.repo, entries, source_sha, relpath, hist_relpath)
+  end
+
+  return entries, hist_relpath
+end
+
+--- @param source_win integer
+--- @param bufnr integer
+--- @param entries Gitsigns.HistoryEntry[]
+--- @return integer?
+local function get_source_lnum(source_win, bufnr, entries)
+  if not api.nvim_win_is_valid(source_win) then
+    return
+  end
+
+  local source_bufnr = api.nvim_win_get_buf(source_win)
+  local bcache = cache[source_bufnr]
+  if not bcache then
+    return
+  end
+
+  local source_relpath = bcache.git_obj.relpath
+  if not source_relpath then
+    return
+  end
+
+  if source_bufnr == bufnr and not bcache.git_obj.revision then
+    -- The live buffer does not map to a single commit entry, so keep the
+    -- source marker on the newest history item for the current path.
+    for i, entry in ipairs(entries) do
+      if entry.filename == source_relpath then
+        return i
+      end
+    end
+    return
+  end
+
+  local source_sha = get_source_sha(source_bufnr, bcache)
+  if not source_sha then
+    return
+  end
+
+  for i, entry in ipairs(entries) do
+    -- File history has at most one row per commit, so matching by SHA keeps
+    -- revision buffers anchored even when the file had a different name then.
+    if entry.sha == source_sha then
+      return i
+    end
+  end
+end
+
+--- @param hist_bufnr integer
+--- @param hist_win integer
+--- @param source_win integer
+--- @param bufnr integer
+--- @param entries Gitsigns.HistoryEntry[]
+local function update_highlights(hist_bufnr, hist_win, source_win, bufnr, entries)
+  if not api.nvim_buf_is_valid(hist_bufnr) then
+    return
+  end
+
+  local cursor_lnum = api.nvim_win_is_valid(hist_win) and api.nvim_win_get_cursor(hist_win)[1]
+  if cursor_lnum and entries[cursor_lnum] then
+    hl_line(hist_bufnr, cursor_lnum, 'CursorLine')
+  end
+
+  local source_lnum = get_source_lnum(source_win, bufnr, entries)
+  if source_lnum then
+    hl_line(hist_bufnr, source_lnum, 'Visual')
+  end
+end
+
+--- @param hist_win integer
+local function scroll_cursor_into_view(hist_win)
+  if not api.nvim_win_is_valid(hist_win) then
+    return
+  end
+
+  pcall(api.nvim_win_call, hist_win, function()
+    local lnum = vim.fn.line('.')
+    local height = vim.fn.winheight(0)
+    if height < 1 then
+      return
+    end
+
+    local line_count = vim.fn.line('$')
+    local scrolloff = math.min(math.max(vim.wo.scrolloff, 0), math.floor((height - 1) / 2))
+    local topline = vim.fn.line('w0')
+    local botline = vim.fn.line('w$')
+
+    -- Avoid cursor jumps here: refresh may run from CursorMoved, and moving the
+    -- cursor while repairing the viewport can schedule another refresh.
+    if lnum < topline + scrolloff then
+      vim.fn.winrestview({ topline = math.max(1, lnum - scrolloff) })
+    elseif lnum > botline - scrolloff then
+      local max_topline = math.max(1, line_count - height + 1)
+      vim.fn.winrestview({
+        topline = math.min(max_topline, math.max(1, lnum + scrolloff - height + 1)),
+      })
+    end
+  end)
+end
+
+--- @class (exact) Gitsigns.HistoryPrLoader
+--- @field private _toplevel string
+--- @field private _refresh fun()
+--- @field private _cache table<string, gitsigns.gh.PrInfo[]|false>
+--- @field private _failed table<string, boolean?>
+--- @field private _loading table<string, boolean?>
+--- @field private _last_detail_sha? string
+--- @field private _last_show_info boolean
+local PrLoader = {}
+PrLoader.__index = PrLoader
+
+--- @param toplevel string
+--- @param refresh fun()
+--- @return Gitsigns.HistoryPrLoader
+function PrLoader.new(toplevel, refresh)
+  return setmetatable({
+    _toplevel = toplevel,
+    _refresh = refresh,
+    _cache = {},
+    _failed = {},
+    _loading = {},
+    _last_show_info = false,
+  }, PrLoader)
+end
+
+--- @param sha string
+function PrLoader:load(sha)
+  if self._cache[sha] ~= nil or self._failed[sha] or self._loading[sha] then
+    return
+  end
+
+  self._loading[sha] = true
+  async
+    .run(function()
+      local prs_by_sha = require('gitsigns.gh').associated_prs_many({ sha }, self._toplevel)
+      async.schedule()
+
+      self._loading[sha] = nil
+      local prs = prs_by_sha and prs_by_sha[sha]
+      if prs ~= nil then
+        self._cache[sha] = prs
+        self._failed[sha] = nil
+      else
+        self._failed[sha] = true
+      end
+
+      self._refresh()
+    end)
+    :raise_on_error()
+end
+
+--- @param sha string?
+--- @param show_info boolean
+--- @return gitsigns.gh.PrInfo[]|false|nil prs
+--- @return boolean prs_loading
+function PrLoader:get(sha, show_info)
+  if not sha then
+    self._last_detail_sha = nil
+    self._last_show_info = show_info
+    return nil, false
+  end
+
+  if show_info and (sha ~= self._last_detail_sha or not self._last_show_info) then
+    -- Retry inconclusive lookups when the user re-enters a row or re-enables
+    -- expanded info, but avoid hammering `gh` on every refresh while the same
+    -- failed row stays selected.
+    self._failed[sha] = nil
+  end
+
+  if config.gh and show_info then
+    self:load(sha)
+  end
+
+  self._last_detail_sha = sha
+  self._last_show_info = show_info
+  return self._cache[sha], self._loading[sha] == true
+end
+
+--- @class (exact) Gitsigns.HistorySession.Opts
+--- @field source_win integer
+--- @field bufnr integer
+--- @field hist_win integer
+--- @field hist_relpath string
+--- @field entries Gitsigns.HistoryEntry[]
+--- @field toplevel string
+
+--- @class (exact) Gitsigns.HistorySession
+--- @field private _source_win integer
+--- @field private _source_bufnr integer
+--- @field private _bufnr integer
+--- @field private _hist_win integer
+--- @field private _hist_relpath string
+--- @field private _entries Gitsigns.HistoryEntry[]
+--- @field private _pr_loader Gitsigns.HistoryPrLoader
+local HistorySession = {}
+HistorySession.__index = HistorySession
+
+--- @param opts Gitsigns.HistorySession.Opts
+function HistorySession.start(opts)
+  local self = setmetatable({
+    _source_win = opts.source_win,
+    _source_bufnr = api.nvim_win_get_buf(opts.source_win),
+    _bufnr = opts.bufnr,
+    _hist_win = opts.hist_win,
+    _hist_relpath = opts.hist_relpath,
+    _entries = opts.entries,
+  }, HistorySession)
+
+  self._pr_loader = PrLoader.new(opts.toplevel, function()
+    if api.nvim_win_is_valid(self._hist_win) then
+      self:_refresh()
+    end
+  end)
+
+  api.nvim_win_set_cursor(
+    self._hist_win,
+    { get_source_lnum(self._source_win, self._bufnr, self._entries) or 1, 0 }
+  )
+  scroll_cursor_into_view(self._hist_win)
+
+  self:_refresh()
+  self:_setup_autocmds()
+  self:_setup_keymaps()
+end
+
+--- @private
+function HistorySession:_setup_autocmds()
+  local hist_bufnr = api.nvim_win_get_buf(self._hist_win)
+  local group = api.nvim_create_augroup('GitsignsHistory' .. hist_bufnr, { clear = true })
+
+  api.nvim_create_autocmd('CursorMoved', {
+    buffer = hist_bufnr,
+    group = group,
+    callback = function()
+      self:_refresh()
+    end,
+  })
+
+  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+    group = group,
+    callback = function()
+      self:_refresh()
+    end,
+  })
+
+  api.nvim_create_autocmd('BufWipeout', {
+    buffer = hist_bufnr,
+    group = group,
+    once = true,
+    callback = function()
+      pcall(api.nvim_del_augroup_by_id, group)
+    end,
+  })
+end
+
+--- @private
+function HistorySession:_setup_keymaps()
+  local hist_bufnr = api.nvim_win_get_buf(self._hist_win)
+
+  --- @param fn async fun(source_win: integer, history_win: integer, open: Gitsigns.HistoryOpen, bufnr: integer, entry: Gitsigns.HistoryEntry)
+  --- @param open Gitsigns.HistoryOpen
+  --- @return fun()
+  local function entry_action(fn, open)
+    return function()
+      local entry = assert(get_entry(self._hist_win, self._entries))
+      async.run(fn, self._source_win, self._hist_win, open, self._bufnr, entry):raise_on_error()
+    end
+  end
+
+  local actions = {
+    {
+      key = '<CR>',
+      status = 'open',
+      desc = 'Open buffer revision',
+      run = entry_action(show_buffer, 'edit'),
+    },
+    {
+      key = 'v',
+      status = 'split',
+      desc = 'Open buffer revision in a vertical split',
+      run = entry_action(show_buffer, 'vsplit'),
+    },
+    {
+      key = 't',
+      status = 'tab',
+      desc = 'Open buffer revision in a new tab',
+      run = entry_action(show_buffer, 'tabnew'),
+    },
+    {
+      key = 'gv',
+      status = 'commit',
+      desc = 'Show commit in a vertical split',
+      run = entry_action(show_commit, 'vsplit'),
+    },
+    {
+      key = 'gt',
+      status = 'commit',
+      desc = 'Show commit in a new tab',
+      run = entry_action(show_commit, 'tabnew'),
+    },
+    {
+      key = 'i',
+      status = 'info',
+      desc = 'Toggle expanded inline info',
+      run = function()
+        vim.b[hist_bufnr].gitsigns_history_show_info =
+          not vim.b[hist_bufnr].gitsigns_history_show_info
+        self:_refresh()
+      end,
+    },
+    {
+      key = 'q',
+      status = 'quit',
+      desc = 'Close history',
+      run = function()
+        self:_close()
+      end,
+    },
+  } --- @type Gitsigns.HistoryAction[]
+
+  local status_actions = {} --- @type Gitsigns.HistoryStatusAction[]
+  vim.list_extend(status_actions, actions)
+  status_actions[#status_actions + 1] = { key = '?', status = 'menu' }
+  vim.wo[self._hist_win][0].statusline = format_statusline(status_actions)
+
+  set_keymapped_actions({
+    bufnr = hist_bufnr,
+    actions = actions,
+    prompt = function()
+      local entry = assert(get_entry(self._hist_win, self._entries))
+      return ('Gitsigns history: %s'):format(entry.abbrev_sha)
+    end,
+    format_item = function(action)
+      return action.desc
+    end,
+    run_action = function(action)
+      action.run()
+    end,
+  })
+end
+
+--- @private
+function HistorySession:_close()
+  if not api.nvim_win_is_valid(self._hist_win) then
+    return
+  end
+
+  local win = api.nvim_get_current_win()
+  if api.nvim_win_get_buf(win) == api.nvim_win_get_buf(self._hist_win) then
+    vim.cmd.quit()
+  else
+    pcall(api.nvim_win_close, self._hist_win, false)
+  end
+end
+
+--- @private
+function HistorySession:_refresh()
+  if not api.nvim_win_is_valid(self._hist_win) then
+    return
+  end
+
+  local tabpage = api.nvim_win_get_tabpage(self._hist_win)
+  local new_source_win = inspection.find_target_win(tabpage, self._source_win)
+  if not new_source_win then
+    if inspection.has_target_candidate_win(tabpage, self._source_win) then
+      return
+    end
+    pcall(api.nvim_win_close, self._hist_win, true)
+    return
+  end
+  self._source_win = new_source_win
+
+  local hist_bufnr = api.nvim_win_get_buf(self._hist_win)
+
+  local new_source_bufnr = api.nvim_win_get_buf(self._source_win)
+  if new_source_bufnr ~= self._source_bufnr then
+    self._source_bufnr = new_source_bufnr
+    local source_lnum = get_source_lnum(self._source_win, self._bufnr, self._entries)
+    if source_lnum then
+      api.nvim_win_set_cursor(self._hist_win, { source_lnum, 0 })
+    end
+  end
+
+  local show_info = vim.b[hist_bufnr].gitsigns_history_show_info == true --[[@as boolean]]
+  local lnum = api.nvim_win_get_cursor(self._hist_win)[1]
+  local entry = self._entries[lnum]
+  local prs, prs_loading = self._pr_loader:get(entry and entry.sha, show_info)
+
+  api.nvim_buf_clear_namespace(hist_bufnr, ns_state, 0, -1)
+  if entry then
+    set_winbar(self._hist_win, entry)
+    set_detail(hist_bufnr, lnum, entry, self._hist_relpath, show_info, prs_loading, prs)
+    update_highlights(hist_bufnr, self._hist_win, self._source_win, self._bufnr, self._entries)
+    scroll_cursor_into_view(self._hist_win)
+  end
+end
+
+--- @param opts? Gitsigns.CmdParams.Smods
+--- @param bcache Gitsigns.CacheEntry
+--- @param hist_relpath string
+--- @param entries Gitsigns.HistoryEntry[]
+--- @return integer history_win
+local function create_history_window(opts, bcache, hist_relpath, entries)
+  local vertical = opts and opts.vertical or false
+  local split = opts and opts.split
+  if not split or split == '' then
+    split = vertical and 'aboveleft' or 'belowright'
+  end
+
+  local hist_win = inspection.find_panel_win(0, 'gitsigns-history')
+  local blame_win = inspection.find_panel_win(0, 'gitsigns-blame')
+
+  local hist_bufnr = api.nvim_create_buf(false, true)
+
+  --- Create the history window
+  if not hist_win then
+    if blame_win then
+      api.nvim_set_current_win(blame_win)
+      vertical = false
+      -- Blame lines track the source buffer, so history belongs under the
+      -- source+blame row rather than under only the source window.
+      split = 'botright'
+    end
+    vim.cmd[vertical and 'vsplit' or 'split']({ mods = { keepalt = true, split = split } })
+    hist_win = api.nvim_get_current_win()
+    vim.wo[hist_win][0].scrollbind = false
+  end
+
+  if vim.fn.exists('&winfixbuf') == 1 then
+    vim.wo[hist_win][0].winfixbuf = false
+  end
+  api.nvim_win_set_buf(hist_win, hist_bufnr)
+
+  api.nvim_buf_set_name(
+    hist_bufnr,
+    (bcache:get_rev_bufname(nil, hist_relpath):gsub('^gitsigns:', 'gitsigns-history:'))
+  )
+  api.nvim_set_current_win(hist_win)
+
+  local content_width = render(hist_bufnr, entries)
+
+  if vertical then
+    local max_width = math.max(32, math.floor(vim.o.columns * 0.4))
+    local width = math.max(math.min(content_width + 1, max_width), math.min(24, max_width))
+    -- Keep the browser narrow enough that the file view remains the primary pane.
+    api.nvim_win_set_width(hist_win, width)
+  else
+    local max_height = math.max(4, math.floor(math.max(vim.o.lines - 2, 1) * 0.35))
+    local height = math.max(math.min(#entries, max_height), math.min(4, max_height))
+    -- Keep the browser short enough that the file view remains the primary pane.
+    api.nvim_win_set_height(hist_win, height)
+  end
+
+  local bo = vim.bo[hist_bufnr]
+  bo.buftype = 'nofile'
+  bo.bufhidden = 'wipe'
+  bo.modifiable = false
+  bo.filetype = 'gitsigns-history'
+  vim.b[hist_bufnr].gitsigns_history_show_info = false
+
+  local wlo = vim.wo[hist_win][0]
+  wlo.foldcolumn = '0'
+  wlo.foldenable = false
+  wlo.number = false
+  wlo.relativenumber = false
+  wlo.signcolumn = 'no'
+  wlo.spell = false
+  wlo.scrollbind = false
+  wlo.winfixwidth = vertical
+  wlo.winfixheight = not vertical
+  wlo.wrap = false
+  wlo.list = false
+
+  if vim.fn.exists('&winfixbuf') == 1 then
+    wlo.winfixbuf = true
+  end
+
+  return hist_win
+end
+
+--- @async
+--- @param opts? Gitsigns.CmdParams.Smods
+function M.history(opts)
+  local source_win, bufnr, bcache = inspection.get_source_context(api.nvim_get_current_win())
+
+  if not bcache then
+    log.dprint('Not attached')
+    return
+  end
+
+  local relpath = bcache.git_obj.relpath
+  if not relpath then
+    message.warn('No tracked path for current buffer')
+    return
+  end
+
+  local entries, hist_relpath = load_history_entries(bufnr, bcache, relpath)
+  if not entries or not hist_relpath then
+    return
+  end
+
+  local hist_win = create_history_window(opts, bcache, hist_relpath, entries)
+
+  HistorySession.start({
+    source_win = source_win,
+    bufnr = bufnr,
+    hist_win = hist_win,
+    hist_relpath = hist_relpath,
+    entries = entries,
+    toplevel = bcache.git_obj.repo.toplevel,
+  })
+end
+
+return M

--- a/lua/gitsigns/actions/inspection.lua
+++ b/lua/gitsigns/actions/inspection.lua
@@ -1,0 +1,159 @@
+--- Helpers for inspection-style tabs and panels.
+---
+--- Blame and history can temporarily move the user into revision buffers with
+--- attached panels. This module keeps the shared window selection rules in one
+--- place: which windows count as panels, which buffers can act as targets, and
+--- how panel state moves when a revision is opened in a new tab.
+local cache = require('gitsigns.cache').cache
+
+local api = vim.api
+
+local M = {}
+
+local panel_filetypes = {
+  ['gitsigns-blame'] = true,
+  ['gitsigns-history'] = true,
+}
+
+--- @param tabpage integer?
+--- @return integer[]
+local function list_wins(tabpage)
+  if tabpage and tabpage ~= 0 and not api.nvim_tabpage_is_valid(tabpage) then
+    return {}
+  end
+  return api.nvim_tabpage_list_wins(tabpage or 0)
+end
+
+--- @param win integer
+--- @return boolean
+function M.is_panel_win(win)
+  if not api.nvim_win_is_valid(win) then
+    return false
+  end
+
+  local bufnr = api.nvim_win_get_buf(win)
+  return panel_filetypes[vim.bo[bufnr].filetype] == true
+end
+
+--- @param bufnr integer
+--- @return boolean
+function M.is_revision_buf(bufnr)
+  return vim.startswith(api.nvim_buf_get_name(bufnr), 'gitsigns://')
+end
+
+--- @param tabpage integer?
+--- @param win integer
+--- @return boolean
+local function win_is_in_tab(tabpage, win)
+  for _, tab_win in ipairs(list_wins(tabpage)) do
+    if tab_win == win then
+      return true
+    end
+  end
+  return false
+end
+
+--- @param win integer
+--- @return boolean
+local function is_target_candidate_win(win)
+  return api.nvim_win_is_valid(win) and not M.is_panel_win(win)
+end
+
+--- @param win integer
+--- @return boolean
+local function is_target_win(win)
+  return is_target_candidate_win(win) and cache[api.nvim_win_get_buf(win)] ~= nil
+end
+
+--- @param tabpage? integer
+--- @param preferred? integer
+--- @return integer?
+function M.find_target_win(tabpage, preferred)
+  if preferred and win_is_in_tab(tabpage, preferred) and is_target_win(preferred) then
+    return preferred
+  end
+
+  local current = api.nvim_get_current_win()
+  if win_is_in_tab(tabpage, current) and is_target_win(current) then
+    return current
+  end
+
+  for _, win in ipairs(list_wins(tabpage)) do
+    if is_target_win(win) then
+      return win
+    end
+  end
+end
+
+--- @param tabpage? integer
+--- @param win integer?
+--- @return boolean
+function M.has_target_candidate_win(tabpage, win)
+  return win ~= nil and win_is_in_tab(tabpage, win) and is_target_candidate_win(win)
+end
+
+--- @param tabpage? integer
+--- @param filetype string
+--- @return integer?
+function M.find_panel_win(tabpage, filetype)
+  for _, win in ipairs(list_wins(tabpage)) do
+    local bufnr = api.nvim_win_get_buf(win)
+    if vim.bo[bufnr].filetype == filetype then
+      return win
+    end
+  end
+end
+
+--- @param win integer
+--- @return integer source_win
+--- @return integer bufnr
+--- @return Gitsigns.CacheEntry? bcache
+function M.get_source_context(win)
+  local bufnr = api.nvim_win_get_buf(win)
+  local bcache = cache[bufnr]
+  if not bcache and M.is_panel_win(win) then
+    local target_win = M.find_target_win(0, win)
+    if target_win then
+      win = target_win
+      api.nvim_set_current_win(win)
+      bufnr = api.nvim_win_get_buf(win)
+      bcache = cache[bufnr]
+    end
+  end
+
+  return win, bufnr, bcache
+end
+
+--- @async
+--- @param bufnr integer
+--- @param revision string?
+--- @param relpath string?
+--- @return boolean did_attach
+function M.show_revision_in_new_tab(bufnr, revision, relpath)
+  local old_tabpage = api.nvim_get_current_tabpage()
+  vim.cmd.tabnew({ mods = { keepalt = true } })
+
+  local did_attach = require('gitsigns.actions.diffthis').show(bufnr, revision, relpath)
+  if not did_attach then
+    pcall(vim.cmd.tabclose)
+    if api.nvim_tabpage_is_valid(old_tabpage) then
+      pcall(api.nvim_set_current_tabpage, old_tabpage)
+    end
+    return false
+  end
+
+  return true
+end
+
+--- @param tabpage? integer
+function M.close_panels(tabpage)
+  tabpage = tabpage or api.nvim_get_current_tabpage()
+
+  for _, win in ipairs(list_wins(tabpage)) do
+    if M.is_panel_win(win) then
+      pcall(api.nvim_win_close, win, true)
+    end
+  end
+end
+
+return M

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -820,6 +820,7 @@ M.schema = {
     description = [[
       Enable GitHub integration. This allows the following features:
       • `:Gitsigns blame_line` will show PR numbers (with a hyperlink)
+      • `:Gitsigns history` will show associated PR numbers in expanded info
     ]],
   },
 

--- a/lua/gitsigns/gh.lua
+++ b/lua/gitsigns/gh.lua
@@ -2,6 +2,8 @@ local async = require('gitsigns.async')
 local log = require('gitsigns.debug.log')
 local system = require('gitsigns.system').system
 
+local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
+
 --- @type async fun(cmd: string[], opts?: vim.SystemOpts): vim.SystemCompleted
 local asystem = async.wrap(3, system)
 
@@ -9,7 +11,24 @@ local asystem = async.wrap(3, system)
 --- @field url string
 --- @field number string
 
+--- @class (exact) Gitsigns.Gh.RepoMeta
+--- @field nameWithOwner string
+--- @field url string?
+
 local M = {}
+
+local session_pr_cache = {} --- @type table<string, table<string, gitsigns.gh.PrInfo[]|false>>
+local repo_meta_cache = {} --- @type table<string, Gitsigns.Gh.RepoMeta|false>
+
+--- @param cwd string
+--- @return string
+local function repo_key(cwd)
+  return uv.fs_realpath(cwd) or cwd
+end
+
+local function log_gh_error(fmt, ...)
+  pcall(log.eprintf, fmt, ...)
+end
 
 --- @async
 --- @param args string[]
@@ -17,7 +36,7 @@ local M = {}
 --- @return table? json
 local function gh_cmd(args, cwd)
   if vim.fn.executable('gh') == 0 then
-    log.eprintf('Could not find gh command')
+    log_gh_error('Could not find gh command')
     return
   end
   --- @diagnostic disable-next-line: param-type-not-match EmmyLuaLs/emmylua-analyzer-rust#594
@@ -32,7 +51,7 @@ local function gh_cmd(args, cwd)
     then
       return
     end
-    log.eprintf(
+    log_gh_error(
       "Error running 'gh %s', code=%d: %s",
       table.concat(args, ' '),
       obj.code,
@@ -45,39 +64,255 @@ local function gh_cmd(args, cwd)
 end
 
 --- @async
---- @param cwd? string
---- @return string? : The URL of the current repository
-local function repo_url(cwd)
-  local res = gh_cmd({ 'repo', 'view', '--json', 'url' }, cwd)
-  if res then
-    return res.url
+--- @param cwd string
+--- @return Gitsigns.Gh.RepoMeta?
+local function repo_meta(cwd)
+  local key = repo_key(cwd)
+  local cached = repo_meta_cache[key]
+  if cached ~= nil then
+    return cached or nil
   end
+
+  local res = gh_cmd({ 'repo', 'view', '--json', 'nameWithOwner,url' }, cwd)
+  if type(res) ~= 'table' or type(res.nameWithOwner) ~= 'string' then
+    repo_meta_cache[key] = false
+    return
+  end
+
+  --- @type Gitsigns.Gh.RepoMeta
+  local meta = {
+    nameWithOwner = res.nameWithOwner,
+    url = type(res.url) == 'string' and res.url or nil,
+  }
+  repo_meta_cache[key] = meta
+  return meta
+end
+
+--- @async
+--- @param query string
+--- @param fields table<string, string>
+--- @param cwd string
+--- @return table? data
+local function gh_graphql(query, fields, cwd)
+  local args = { 'api', 'graphql', '-f', 'query=' .. query }
+  for name, value in pairs(fields) do
+    args[#args + 1] = '-F'
+    args[#args + 1] = ('%s=%s'):format(name, value)
+  end
+
+  local res = gh_cmd(args, cwd)
+  if type(res) == 'table' then
+    return res.data
+  end
+end
+
+--- @param nodes any
+--- @return gitsigns.gh.PrInfo[]|false
+local function normalize_graphql_prs(nodes)
+  local prs = {} --- @type gitsigns.gh.PrInfo[]
+  if type(nodes) == 'table' then
+    for _, pr in ipairs(nodes) do
+      if pr.mergedAt ~= vim.NIL and pr.mergedAt ~= nil then
+        prs[#prs + 1] = {
+          number = tostring(pr.number),
+          url = pr.url,
+        }
+      end
+    end
+  end
+
+  return next(prs) and prs or false
+end
+
+--- @param pulls any
+--- @return gitsigns.gh.PrInfo[]|false|nil
+local function normalize_rest_prs(pulls)
+  if type(pulls) ~= 'table' then
+    return
+  end
+
+  local prs = {} --- @type gitsigns.gh.PrInfo[]
+  for _, pr in ipairs(pulls) do
+    if pr.merged_at ~= vim.NIL and pr.merged_at ~= nil then
+      prs[#prs + 1] = {
+        number = tostring(pr.number),
+        url = pr.html_url or pr.url,
+      }
+    end
+  end
+
+  return next(prs) and prs or false
+end
+
+--- @async
+--- @param shas string[]
+--- @param owner string
+--- @param name string
+--- @param cwd string
+--- @return table<string, gitsigns.gh.PrInfo[]|false>
+local function lookup_associated_prs_rest_many(shas, owner, name, cwd)
+  local ret = {} --- @type table<string, gitsigns.gh.PrInfo[]|false>
+  for _, sha in ipairs(shas) do
+    local pulls = gh_cmd({ 'api', ('repos/%s/%s/commits/%s/pulls'):format(owner, name, sha) }, cwd)
+    local prs = normalize_rest_prs(pulls)
+    if prs ~= nil then
+      -- A failed REST request is inconclusive; don't turn it into a stable
+      -- "no PRs" result.
+      ret[sha] = prs
+    end
+  end
+  return ret
+end
+
+--- @param shas string[]
+--- @return string
+local function build_associated_prs_query(shas)
+  -- Build one aliased commit lookup per SHA so visible history rows can share
+  -- a single GraphQL round-trip instead of spawning a `gh` search per commit.
+  local vars = {
+    '$owner:String!',
+    '$name:String!',
+  }
+  local fields = {} --- @type string[]
+
+  for i = 1, #shas do
+    vars[#vars + 1] = ('$sha%d:GitObjectID!'):format(i)
+    fields[#fields + 1] = ([[
+      c%d: object(oid:$sha%d) {
+        ... on Commit {
+          associatedPullRequests(first:10) {
+            nodes {
+              number
+              url
+              mergedAt
+            }
+          }
+        }
+      }
+    ]]):format(i, i)
+  end
+
+  return ('query(%s) { repository(owner:$owner, name:$name) { %s } }'):format(
+    table.concat(vars, ', '),
+    table.concat(fields, ' ')
+  )
+end
+
+--- Requests GitHub PRs associated with multiple commit SHAs.
+--- @async
+--- @param shas string[]
+--- @param cwd string
+--- @return table<string, gitsigns.gh.PrInfo[]|false>?
+local function lookup_associated_prs_many(shas, cwd)
+  if #shas == 0 then
+    return {}
+  end
+
+  local meta = repo_meta(cwd)
+  if not meta then
+    return
+  end
+
+  local owner, name = meta.nameWithOwner:match('^([^/]+)/(.+)$')
+  if not owner or not name then
+    return
+  end
+
+  local fields = {
+    owner = owner,
+    name = name,
+  }
+
+  for i, sha in ipairs(shas) do
+    fields[('sha%d'):format(i)] = sha
+  end
+
+  local data = gh_graphql(build_associated_prs_query(shas), fields, cwd)
+  local repo = type(data) == 'table' and data.repository or nil
+  if type(repo) ~= 'table' then
+    return lookup_associated_prs_rest_many(shas, owner, name, cwd)
+  end
+
+  local ret = {} --- @type table<string, gitsigns.gh.PrInfo[]|false>
+  for i, sha in ipairs(shas) do
+    local obj = repo[('c%d'):format(i)]
+    local nodes = type(obj) == 'table'
+        and type(obj.associatedPullRequests) == 'table'
+        and obj.associatedPullRequests.nodes
+      or nil
+
+    ret[sha] = normalize_graphql_prs(nodes)
+  end
+
+  return ret
 end
 
 --- @async
 function M.commit_url(sha, cwd)
-  local url = repo_url(cwd)
-  if url then
-    return ('%s/commit/%s'):format(url, sha)
+  if not cwd then
+    return
+  end
+
+  local meta = repo_meta(cwd)
+  if meta and meta.url then
+    return ('%s/commit/%s'):format(meta.url, sha)
   end
 end
 
 --- Requests a list of GitHub PRs associated with the given commit SHA
 --- @async
+--- @param shas string[]
+--- @param cwd string
+--- @return table<string, gitsigns.gh.PrInfo[]|false>?
+function M.associated_prs_many(shas, cwd)
+  local ret = {} --- @type table<string, gitsigns.gh.PrInfo[]|false>
+  local missing = {} --- @type string[]
+  local cache_key = repo_key(cwd)
+  local repo_cache = session_pr_cache[cache_key]
+
+  for _, sha in ipairs(shas) do
+    local prs = repo_cache and repo_cache[sha]
+    if prs ~= nil then
+      ret[sha] = prs
+    else
+      missing[#missing + 1] = sha
+    end
+  end
+
+  if #missing == 0 then
+    return ret
+  end
+
+  local fetched = lookup_associated_prs_many(missing, cwd)
+  if not fetched then
+    return next(ret) and ret or nil
+  end
+
+  for _, sha in ipairs(missing) do
+    local prs = fetched[sha]
+    if prs ~= nil then
+      if not repo_cache then
+        repo_cache = {}
+        session_pr_cache[cache_key] = repo_cache
+      end
+      repo_cache[sha] = prs
+      ret[sha] = prs
+    end
+  end
+
+  return ret
+end
+
+--- @async
 --- @param sha string
 --- @param cwd string
---- @return gitsigns.gh.PrInfo[]? : Array of PR object
-local function associated_prs(sha, cwd)
-  return gh_cmd({
-    'pr',
-    'list',
-    '--search',
-    sha,
-    '--state',
-    'merged',
-    '--json',
-    'url,number',
-  }, cwd)
+--- @return gitsigns.gh.PrInfo[]?
+function M.associated_prs(sha, cwd)
+  local prs = M.associated_prs_many({ sha }, cwd)
+  if prs then
+    local pr = prs[sha]
+    return pr ~= false and pr or nil
+  end
 end
 
 --- @async
@@ -86,7 +321,7 @@ end
 --- @return Gitsigns.LineSpec
 function M.create_pr_linespec(sha, toplevel)
   local ret = {} --- @type Gitsigns.LineSpec
-  local prs = associated_prs(sha, toplevel)
+  local prs = M.associated_prs(sha, toplevel)
   if prs and next(prs) then
     ret[#ret + 1] = { '(', 'Title' }
     for i, pr in ipairs(prs) do

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -165,6 +165,7 @@ describe('actions', function()
 
   it('completes action command arguments', function()
     eq(true, vim.tbl_contains(complete('', 'vertical Gits '), 'attach'))
+    eq(true, vim.tbl_contains(complete('', 'vertical Gits '), 'history'))
     eq({ '--bufnr=', '--force', '--trigger=' }, complete('', 'Gitsigns attach '))
     eq({ '--ignore_whitespace' }, complete('', 'Gitsigns blame '))
     eq({ '--full', '--ignore_whitespace' }, complete('', 'Gitsigns blame_line '))

--- a/test/blame_spec.lua
+++ b/test/blame_spec.lua
@@ -31,6 +31,54 @@ local function open_blame_panel()
   )
 end
 
+local function open_blame_panel_from_source()
+  eq(
+    'gitsigns-blame',
+    exec_lua(function()
+      local source_win --- @type integer?
+
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        local filetype = vim.bo[bufnr].filetype
+        if filetype ~= 'gitsigns-history' and filetype ~= 'gitsigns-blame' then
+          source_win = win
+          break
+        end
+      end
+
+      assert(source_win)
+      vim.api.nvim_set_current_win(source_win)
+      vim.wait(5000, function()
+        return require('gitsigns.cache').cache[vim.api.nvim_win_get_buf(source_win)] ~= nil
+      end)
+
+      local async = require('gitsigns.async')
+      async.run(require('gitsigns.actions.blame').blame):wait(5000)
+
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        if vim.bo[bufnr].filetype == 'gitsigns-blame' then
+          vim.api.nvim_set_current_win(win)
+          return vim.bo.filetype
+        end
+      end
+
+      return vim.bo.filetype
+    end)
+  )
+end
+
+local function open_history_panel()
+  eq(
+    'gitsigns-history',
+    exec_lua(function()
+      local async = require('gitsigns.async')
+      async.run(require('gitsigns.actions.history').history):wait(5000)
+      return vim.bo.filetype
+    end)
+  )
+end
+
 local function get_blame_panel_state()
   return exec_lua(function()
     local bufnr = vim.api.nvim_get_current_buf()
@@ -58,10 +106,126 @@ local function get_blame_panel_state()
       line_widths = line_widths,
       lines = lines,
       row_hls = row_hls,
+      statusline = vim.wo.statusline,
       win_width = vim.api.nvim_win_get_width(0),
       year = os.date('%Y'),
     }
   end)
+end
+
+local function get_history_blame_state()
+  return exec_lua(function()
+    local history_win --- @type integer?
+    local blame_win --- @type integer?
+    local source_win --- @type integer?
+
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      local bufnr = vim.api.nvim_win_get_buf(win)
+      local filetype = vim.bo[bufnr].filetype
+      if filetype == 'gitsigns-history' then
+        history_win = win
+      elseif filetype == 'gitsigns-blame' then
+        blame_win = win
+      else
+        source_win = win
+      end
+    end
+
+    if not history_win or not source_win then
+      return
+    end
+
+    local namespaces = vim.api.nvim_get_namespaces()
+    local history_bufnr = vim.api.nvim_win_get_buf(history_win)
+    local source_bufnr = vim.api.nvim_win_get_buf(source_win)
+    local history_pos = vim.fn.win_screenpos(history_win)
+    local source_pos = vim.fn.win_screenpos(source_win)
+    local result = {
+      history_has_blame_hls = namespaces.gitsigns_blame_win_hl and #vim.api.nvim_buf_get_extmarks(
+        history_bufnr,
+        namespaces.gitsigns_blame_win_hl,
+        0,
+        -1,
+        {}
+      ) > 0 or false,
+      history_col = history_pos[2],
+      history_height = vim.api.nvim_win_get_height(history_win),
+      history_top = history_pos[1],
+      history_width = vim.api.nvim_win_get_width(history_win),
+      source_col = source_pos[2],
+      source_height = vim.api.nvim_win_get_height(source_win),
+      source_lines = vim.api.nvim_buf_get_lines(source_bufnr, 0, -1, false),
+      source_name = vim.api.nvim_buf_get_name(source_bufnr),
+      source_top = source_pos[1],
+      source_width = vim.api.nvim_win_get_width(source_win),
+    }
+
+    if blame_win then
+      local blame_bufnr = vim.api.nvim_win_get_buf(blame_win)
+      local blame_pos = vim.fn.win_screenpos(blame_win)
+      result.blame_col = blame_pos[2]
+      result.blame_height = vim.api.nvim_win_get_height(blame_win)
+      result.blame_lines = vim.api.nvim_buf_get_lines(blame_bufnr, 0, -1, false)
+      result.blame_name = vim.api.nvim_buf_get_name(blame_bufnr)
+      result.blame_top = blame_pos[1]
+      result.blame_width = vim.api.nvim_win_get_width(blame_win)
+    end
+
+    return result
+  end)
+end
+
+local function focus_window(filetype)
+  return exec_lua(function(target)
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      local bufnr = vim.api.nvim_win_get_buf(win)
+      if vim.bo[bufnr].filetype == target then
+        vim.api.nvim_set_current_win(win)
+        return true
+      end
+    end
+
+    return false
+  end, filetype)
+end
+
+local function panels_moved_to_revision_tab(source_name, expect_blame)
+  return exec_lua(function(source_name0, expect_blame0)
+    expect_blame0 = expect_blame0 ~= false
+    local tabs = vim.api.nvim_list_tabpages()
+    if #tabs ~= 2 then
+      return false
+    end
+
+    local old_panel_count = 0
+    local old_source_name --- @type string?
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabs[1])) do
+      local bufnr = vim.api.nvim_win_get_buf(win)
+      local filetype = vim.bo[bufnr].filetype
+      if filetype == 'gitsigns-blame' or filetype == 'gitsigns-history' then
+        old_panel_count = old_panel_count + 1
+      else
+        old_source_name = vim.api.nvim_buf_get_name(bufnr)
+      end
+    end
+
+    local new_filetypes = {} --- @type table<string,true>
+    local new_revision = false
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      local bufnr = vim.api.nvim_win_get_buf(win)
+      new_filetypes[vim.bo[bufnr].filetype] = true
+      if vim.api.nvim_buf_get_name(bufnr):match('^gitsigns://') then
+        new_revision = true
+      end
+    end
+
+    return old_panel_count == 0
+      and old_source_name == source_name0
+      and #vim.api.nvim_tabpage_list_wins(0) == (expect_blame0 and 3 or 2)
+      and (new_filetypes['gitsigns-blame'] == true) == expect_blame0
+      and new_filetypes['gitsigns-history']
+      and new_revision
+  end, source_name, expect_blame)
 end
 
 local function has_hl(row_hls, row, name)
@@ -122,6 +286,410 @@ describe('blame', function()
     eq('gitsigns-blame', exec_lua('return vim.bo.filetype'))
   end)
 
+  it('moves history and blame panels to a revision tab on reblame', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    helpers.write_to_file(test_file, { 'ONE', 'TWO' })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'second commit')
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_blame_panel()
+    open_history_panel()
+    eq(true, focus_window('gitsigns-blame'))
+
+    feed('r')
+
+    expectf(function()
+      return panels_moved_to_revision_tab(test_file)
+    end)
+
+    local revision_tab = exec_lua(function()
+      local state = {
+        tab_count = #vim.api.nvim_list_tabpages(),
+        win_count = #vim.api.nvim_tabpage_list_wins(0),
+      }
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        local filetype = vim.bo[bufnr].filetype
+        if filetype == 'gitsigns-blame' then
+          state.blame_win = win
+        elseif filetype == 'gitsigns-history' then
+          state.history_win = win
+        elseif vim.api.nvim_buf_get_name(bufnr):match('^gitsigns://') then
+          state.source_win = win
+          state.source_name = vim.api.nvim_buf_get_name(bufnr)
+        end
+      end
+      return state
+    end)
+
+    feed('R')
+
+    expectf(function()
+      return exec_lua(function(before)
+        if #vim.api.nvim_list_tabpages() ~= before.tab_count then
+          return false
+        end
+        if #vim.api.nvim_tabpage_list_wins(0) ~= before.win_count then
+          return false
+        end
+        for _, key in ipairs({ 'blame_win', 'history_win', 'source_win' }) do
+          local win = before[key]
+          if type(win) ~= 'number' or not vim.api.nvim_win_is_valid(win) then
+            return false
+          end
+        end
+        local blame_lines =
+          vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(before.blame_win), 0, -1, false)
+        local source_name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(before.source_win))
+        return vim.bo[vim.api.nvim_win_get_buf(before.blame_win)].filetype == 'gitsigns-blame'
+          and vim.bo[vim.api.nvim_win_get_buf(before.history_win)].filetype == 'gitsigns-history'
+          and source_name:match('^gitsigns://') ~= nil
+          and source_name ~= before.source_name
+          and blame_lines[2] == '┕ init commit'
+      end, revision_tab)
+    end)
+  end)
+
+  it('scrolls the history selection as repeated reblame updates it', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'line 01' },
+    })
+
+    for i = 2, 12 do
+      local lines = {} --- @type string[]
+      for j = 1, i do
+        lines[j] = ('line %02d'):format(j)
+      end
+      helpers.write_to_file(test_file, lines)
+      helpers.git('add', test_file)
+      helpers.git('commit', '-m', ('commit %02d'):format(i))
+    end
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+    exec_lua(function()
+      vim.o.scrolloff = 3
+    end)
+
+    open_blame_panel()
+    open_history_panel()
+    eq(true, focus_window('gitsigns-blame'))
+
+    feed('7G')
+    feed('r')
+
+    local function get_history_cursor()
+      return exec_lua(function()
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+          for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
+            local bufnr = vim.api.nvim_win_get_buf(win)
+            if vim.bo[bufnr].filetype == 'gitsigns-history' then
+              return vim.api.nvim_win_call(win, function()
+                return {
+                  cursor = vim.api.nvim_win_get_cursor(win)[1],
+                  scrolloff = vim.wo.scrolloff,
+                  visible_bot = vim.fn.line('w$'),
+                  visible_top = vim.fn.line('w0'),
+                }
+              end)
+            end
+          end
+        end
+      end)
+    end
+
+    local function focus_blame_panel()
+      return exec_lua(function()
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+          for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
+            local bufnr = vim.api.nvim_win_get_buf(win)
+            if vim.bo[bufnr].filetype == 'gitsigns-blame' then
+              vim.api.nvim_set_current_win(win)
+              return true
+            end
+          end
+        end
+        return false
+      end)
+    end
+
+    expectf(function()
+      local state = get_history_cursor()
+      return exec_lua('return #vim.api.nvim_list_tabpages()') == 2 and state and state.cursor > 1
+    end)
+
+    local previous = assert(get_history_cursor()).cursor
+    for _ = 1, 3 do
+      eq(true, focus_blame_panel())
+      feed('R')
+      expectf(function()
+        local state = get_history_cursor()
+        return state
+          and state.cursor > previous
+          and state.visible_top <= state.cursor - state.scrolloff
+          and state.visible_bot >= state.cursor + state.scrolloff
+      end)
+      previous = assert(get_history_cursor()).cursor
+    end
+  end)
+
+  it('keeps the blame panel in sync with history buffer switches', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    helpers.write_to_file(test_file, { 'ONE', 'TWO' })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'second commit')
+
+    helpers.write_to_file(test_file, { 'uno', 'dos' })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'third commit')
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_history_panel()
+
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_blame_state()
+      return state and state.source_lines[1] == 'ONE' and state.source_lines[2] == 'TWO'
+    end)
+
+    open_blame_panel_from_source()
+
+    expectf(function()
+      local state = get_history_blame_state()
+      return state
+        and state.blame_lines[2] == '┕ second commit'
+        and state.blame_height == state.source_height
+        and not state.history_has_blame_hls
+        and state.blame_name == state.source_name:gsub('^gitsigns:', 'gitsigns-blame:')
+    end)
+
+    eq(true, focus_window('gitsigns-history'))
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_blame_state()
+      return state
+        and state.source_lines[1] == 'one'
+        and state.source_lines[2] == 'two'
+        and state.blame_lines[2] == '┕ init commit'
+        and state.blame_height == state.source_height
+        and not state.history_has_blame_hls
+        and state.blame_name == state.source_name:gsub('^gitsigns:', 'gitsigns-blame:')
+    end)
+  end)
+
+  it('keeps the blame panel aligned with the source when opening history', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_blame_panel()
+
+    eq(
+      'gitsigns-history',
+      exec_lua(function()
+        vim.cmd('Gitsigns history')
+        vim.wait(5000, function()
+          return vim.bo.filetype == 'gitsigns-history'
+        end)
+        return vim.bo.filetype
+      end)
+    )
+
+    expectf(function()
+      local state = get_history_blame_state()
+      return state
+        and state.blame_height ~= nil
+        and not state.history_has_blame_hls
+        and state.blame_height == state.source_height
+        and state.blame_top == state.source_top
+        and state.history_top > state.blame_top
+        and state.history_col <= state.blame_col
+        and state.history_col + state.history_width >= state.source_col + state.source_width
+        and state.history_height < state.source_height
+    end)
+  end)
+
+  it('does not let transient blame clones steal panel ownership', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_blame_panel()
+
+    eq(
+      { 'scratch' },
+      exec_lua(function()
+        local blame_bufnr = vim.api.nvim_get_current_buf()
+
+        vim.cmd('botright split')
+        local win = vim.api.nvim_get_current_win()
+        local scratch_bufnr = vim.api.nvim_create_buf(false, true)
+        if vim.fn.exists('&winfixbuf') == 1 then
+          vim.wo[win][0].winfixbuf = false
+        end
+        vim.api.nvim_win_set_buf(win, scratch_bufnr)
+        vim.api.nvim_buf_set_lines(scratch_bufnr, 0, -1, false, { 'scratch' })
+
+        vim.api.nvim_exec_autocmds('WinResized', { buffer = blame_bufnr })
+        return vim.api.nvim_buf_get_lines(scratch_bufnr, 0, -1, false)
+      end)
+    )
+  end)
+
+  it('opens blame from the history panel', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_history_panel()
+    open_blame_panel()
+
+    eq(
+      true,
+      exec_lua(function()
+        local filetypes = {} --- @type table<string,true>
+        for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+          local bufnr = vim.api.nvim_win_get_buf(win)
+          filetypes[vim.bo[bufnr].filetype] = true
+        end
+        return filetypes['gitsigns-history'] and filetypes['gitsigns-blame']
+      end)
+    )
+  end)
+
+  it('does not retarget blame from an unrelated unattached window', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    eq(
+      false,
+      exec_lua(function()
+        vim.cmd.new()
+        local async = require('gitsigns.async')
+        async.run(require('gitsigns.actions.blame').blame):wait(5000)
+
+        for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+          local bufnr = vim.api.nvim_win_get_buf(win)
+          if vim.bo[bufnr].filetype == 'gitsigns-blame' then
+            return true
+          end
+        end
+
+        return false
+      end)
+    )
+  end)
+
+  it('does not reopen blame when history opens a revision', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    helpers.write_to_file(test_file, { 'ONE', 'TWO' })
+    helpers.git('add', test_file)
+    helpers.git('commit', '-m', 'second commit')
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_blame_panel()
+    exec_lua(function()
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        if vim.bo[bufnr].filetype ~= 'gitsigns-blame' then
+          vim.api.nvim_set_current_win(win)
+          return
+        end
+      end
+    end)
+    open_history_panel()
+
+    local before = exec_lua(function()
+      local filetypes = {} --- @type table<string,true>
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        filetypes[vim.bo[bufnr].filetype] = true
+      end
+      return {
+        filetypes = filetypes,
+        tab_count = #vim.api.nvim_list_tabpages(),
+        win_count = #vim.api.nvim_tabpage_list_wins(0),
+      }
+    end)
+
+    eq(1, before.tab_count)
+    eq(3, before.win_count)
+    eq(true, before.filetypes['gitsigns-blame'])
+    eq(true, before.filetypes['gitsigns-history'])
+
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      return panels_moved_to_revision_tab(test_file, false)
+    end)
+  end)
+
   it('renders the default side-panel layout', function()
     setup_gitsigns(test_config)
     setup_test_repo({
@@ -141,8 +709,113 @@ describe('blame', function()
 
     assert(result.lines[1]:match('^┍ %x%x%x%x%x%x%x%x tester ' .. date_pat .. '$'))
     eq('┕ init commit', result.lines[2])
+    eq(' ', result.statusline)
     eq(true, has_hl_match(result.row_hls, 1, '^GitSignsBlameColor%.'))
     eq(true, has_hl(result.row_hls, 2, 'Comment'))
+  end)
+
+  it('keeps the side-panel statusline blank across window changes', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function()
+      local group = vim.api.nvim_create_augroup('GitsignsTestStatuslineReset', {})
+      vim.api.nvim_create_autocmd({ 'BufWinEnter', 'WinEnter', 'WinLeave' }, {
+        group = group,
+        callback = function()
+          vim.wo.statusline = ' reset '
+        end,
+      })
+    end)
+
+    open_blame_panel()
+
+    local result = exec_lua(function()
+      local blame_win = vim.api.nvim_get_current_win()
+      vim.cmd.wincmd('p')
+      local after_leave = vim.wo[blame_win][0].statusline
+      vim.cmd.wincmd('p')
+      local after_enter = vim.wo[blame_win][0].statusline
+      pcall(vim.api.nvim_del_augroup_by_name, 'GitsignsTestStatuslineReset')
+      return { after_enter = after_enter, after_leave = after_leave }
+    end)
+
+    eq(' ', result.after_leave)
+    eq(' ', result.after_enter)
+  end)
+
+  it('does not blank the global statusline', function()
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function()
+      vim.o.laststatus = 3
+      vim.o.statusline = ' global '
+    end)
+
+    open_blame_panel()
+
+    local result = exec_lua(function()
+      local win = vim.api.nvim_get_current_win()
+      return {
+        effective_statusline = vim.wo[win].statusline,
+        local_statusline = vim.wo[win][0].statusline,
+      }
+    end)
+
+    eq(' global ', result.effective_statusline)
+    eq('', result.local_statusline)
+  end)
+
+  it('opens when the new panel split starts with winfixbuf', function()
+    if exec_lua(function()
+      return vim.fn.exists('&winfixbuf') == 0
+    end) then
+      return
+    end
+
+    setup_gitsigns(test_config)
+    setup_test_repo({
+      test_file_text = { 'one', 'two' },
+    })
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function()
+      local group = vim.api.nvim_create_augroup('GitsignsTestWinfixbuf', {})
+      vim.api.nvim_create_autocmd('WinNew', {
+        group = group,
+        callback = function()
+          vim.wo[0][0].winfixbuf = true
+        end,
+      })
+    end)
+
+    open_blame_panel()
+
+    exec_lua(function()
+      pcall(vim.api.nvim_del_augroup_by_name, 'GitsignsTestWinfixbuf')
+    end)
   end)
 
   it('supports string side-panel formatters', function()

--- a/test/gh_spec.lua
+++ b/test/gh_spec.lua
@@ -1,0 +1,229 @@
+local helpers = require('test.gs_helpers')
+
+local clear = helpers.clear
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+
+helpers.env()
+
+local function run_gh_case(case)
+  return exec_lua(function(case0)
+    local async = require('gitsigns.async')
+    local cwd = vim.fn.getcwd()
+    local calls = {} --- @type string[]
+    local repo_view_calls = 0
+    local graphql_calls = 0
+    local rest_failures = 1
+    local original_executable = vim.fn.executable
+    local original_system = package.loaded['gitsigns.system']
+
+    local function complete(on_exit, code, stdout, stderr)
+      local timer = assert((vim.uv or vim.loop).new_timer())
+      timer:start(0, 0, function()
+        on_exit({
+          code = code,
+          stdout = stdout,
+          stderr = stderr,
+        })
+      end)
+      return timer
+    end
+
+    local function repo_meta()
+      return '{"nameWithOwner":"example/test","url":"https://example.test/example/test"}'
+    end
+
+    local function graphql_response(sha)
+      local nodes = sha == 'hitsha'
+          and '[{"url":"https://example.test/pr/42","number":42,"mergedAt":"2026-01-01T00:00:00Z"}]'
+        or '[]'
+      return ('{"data":{"repository":{"c1":{"associatedPullRequests":{"nodes":%s}}}}}'):format(
+        nodes
+      )
+    end
+
+    local function rest_response(sha)
+      if sha == 'hitsha' then
+        return '[{"number":42,"url":"https://api.example.test/pulls/42","html_url":"https://example.test/pr/42","merged_at":"2026-01-01T00:00:00Z"}]'
+      end
+      return '[]'
+    end
+
+    local function lookup(gh, sha)
+      return async
+        .run(function()
+          return gh.associated_prs(sha, cwd)
+        end)
+        :wait(1000)
+    end
+
+    local function reload_gh()
+      package.loaded['gitsigns.gh'] = nil
+      return require('gitsigns.gh')
+    end
+
+    local ok, ret = xpcall(function()
+      vim.fn.executable = function(cmd)
+        if cmd == 'gh' then
+          return 1
+        end
+        return original_executable(cmd)
+      end
+
+      package.loaded['gitsigns.system'] = {
+        system = function(cmd, _, on_exit)
+          if cmd[2] == 'repo' and cmd[3] == 'view' then
+            repo_view_calls = repo_view_calls + 1
+
+            if case0 == 'repo-metadata-failure' and repo_view_calls == 1 then
+              return complete(on_exit, 1, '', 'gh: HTTP 502')
+            end
+
+            return complete(on_exit, 0, repo_meta(), '')
+          end
+
+          if cmd[2] == 'api' and cmd[3] == 'graphql' then
+            graphql_calls = graphql_calls + 1
+
+            if case0 == 'cache' then
+              local sha --- @type string?
+              for _, arg in ipairs(cmd) do
+                if type(arg) == 'string' and vim.startswith(arg, 'sha1=') then
+                  sha = arg:sub(6)
+                  break
+                end
+              end
+              calls[#calls + 1] = assert(sha)
+              return complete(on_exit, 0, graphql_response(sha), '')
+            end
+
+            if case0 == 'rest-fallback' or case0 == 'rest-failure-retry' then
+              return complete(on_exit, 1, '', 'gh: HTTP 504')
+            end
+          end
+
+          local sha = assert(cmd[3]:match('/commits/(.+)/pulls$'))
+          calls[#calls + 1] = sha
+
+          if case0 == 'rest-failure-retry' and rest_failures > 0 then
+            rest_failures = rest_failures - 1
+            return complete(on_exit, 1, '', 'gh: HTTP 502')
+          end
+
+          return complete(on_exit, 0, rest_response(sha), '')
+        end,
+      }
+
+      if case0 == 'cache' then
+        local gh = reload_gh()
+        local hit1 = lookup(gh, 'hitsha')
+        local miss1 = lookup(gh, 'misssha')
+        local hit1_cached = lookup(gh, 'hitsha')
+        local miss1_cached = lookup(gh, 'misssha')
+
+        gh = reload_gh()
+
+        return {
+          calls = calls,
+          hit1 = hit1,
+          hit1_cached = hit1_cached,
+          hit2 = lookup(gh, 'hitsha'),
+          miss1 = miss1,
+          miss1_cached = miss1_cached,
+          miss2 = lookup(gh, 'misssha'),
+        }
+      end
+
+      local gh = reload_gh()
+
+      if case0 == 'rest-fallback' then
+        return {
+          calls = calls,
+          prs = async
+            .run(function()
+              return gh.associated_prs_many({ 'hitsha', 'misssha' }, cwd)
+            end)
+            :wait(1000),
+        }
+      end
+
+      if case0 == 'rest-failure-retry' then
+        return {
+          calls = calls,
+          first = lookup(gh, 'hitsha'),
+          second = lookup(gh, 'hitsha'),
+          third = lookup(gh, 'hitsha'),
+        }
+      end
+
+      if case0 == 'repo-metadata-failure' then
+        return {
+          first = lookup(gh, 'hitsha'),
+          second = lookup(gh, 'hitsha'),
+          repo_view_calls = repo_view_calls,
+          graphql_calls = graphql_calls,
+        }
+      end
+
+      error('unknown gh test case: ' .. tostring(case0))
+    end, debug.traceback)
+
+    vim.fn.executable = original_executable
+    package.loaded['gitsigns.system'] = original_system
+    package.loaded['gitsigns.gh'] = nil
+
+    if not ok then
+      error(ret)
+    end
+
+    return ret
+  end, case)
+end
+
+describe('gh', function()
+  before_each(function()
+    clear()
+    helpers.chdir_tmp()
+    helpers.setup_path()
+  end)
+
+  it('caches associated PRs in-session but not across reloads', function()
+    local result = run_gh_case('cache')
+
+    eq({ 'hitsha', 'misssha', 'hitsha', 'misssha' }, result.calls)
+    eq('42', result.hit1[1].number)
+    eq('https://example.test/pr/42', result.hit1[1].url)
+    eq('42', result.hit1_cached[1].number)
+    eq('42', result.hit2[1].number)
+    eq(nil, result.miss1)
+    eq(nil, result.miss1_cached)
+    eq(nil, result.miss2)
+  end)
+
+  it('falls back to REST PR lookup when GraphQL batching fails', function()
+    local result = run_gh_case('rest-fallback')
+
+    eq({ 'hitsha', 'misssha' }, result.calls)
+    eq('42', result.prs.hitsha[1].number)
+    eq('https://example.test/pr/42', result.prs.hitsha[1].url)
+    eq(false, result.prs.misssha)
+  end)
+
+  it('does not cache failed REST PR lookups as misses', function()
+    local result = run_gh_case('rest-failure-retry')
+
+    eq({ 'hitsha', 'hitsha' }, result.calls)
+    eq(nil, result.first)
+    eq('42', result.second[1].number)
+    eq('42', result.third[1].number)
+  end)
+
+  it('caches failed repo metadata lookups for the session', function()
+    local result = run_gh_case('repo-metadata-failure')
+
+    eq(nil, result.first)
+    eq(nil, result.second)
+    eq(1, result.repo_view_calls)
+    eq(0, result.graphql_calls)
+  end)
+end)

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -14,6 +14,9 @@ local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 
 --- @return boolean
 local function is_win()
+  if not M.get_session() then
+    return package.config:sub(1, 1) == '\\'
+  end
   return M.fn.has('win32') == 1
 end
 
@@ -329,8 +332,8 @@ function M.cleanup()
       pcall(vim.cmd, 'silent! cd ' .. vim.fn.fnameescape(tmpdir0))
 
       for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-        local name = vim.api.nvim_buf_get_name(buf)
-        if name ~= '' and name:find(root, 1, true) then
+        local ok, name = pcall(vim.api.nvim_buf_get_name, buf)
+        if ok and name ~= '' and name:find(root, 1, true) then
           pcall(vim.api.nvim_buf_delete, buf, { force = true })
         end
       end

--- a/test/history_spec.lua
+++ b/test/history_spec.lua
@@ -1,0 +1,792 @@
+local helpers = require('test.gs_helpers')
+
+local check = helpers.check
+local clear = helpers.clear
+local command = helpers.api.nvim_command
+local edit = helpers.edit
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+local expectf = helpers.expectf
+local feed = helpers.feed
+local git = helpers.git
+local setup_gitsigns = helpers.setup_gitsigns
+local setup_test_repo = helpers.setup_test_repo
+local test_config = helpers.test_config
+local wait_for_attach = helpers.wait_for_attach
+local write_to_file = helpers.write_to_file
+local scratch --- @type string
+local test_file --- @type string
+
+helpers.env()
+
+local function open_history_panel()
+  eq(
+    'gitsigns-history',
+    exec_lua(function()
+      local async = require('gitsigns.async')
+      async.run(require('gitsigns.actions.history').history):wait(5000)
+      return vim.bo.filetype
+    end)
+  )
+end
+
+local function open_history_panel_command(cmd)
+  local filetype = exec_lua(function(cmdline)
+    vim.cmd(cmdline)
+
+    local history_win --- @type integer?
+    local ok = vim.wait(5000, function()
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        if
+          vim.bo[bufnr].filetype == 'gitsigns-history'
+          and vim.wo[win].statusline:find('<CR> open', 1, true) ~= nil
+        then
+          history_win = win
+          return true
+        end
+      end
+    end)
+
+    if not ok or not history_win then
+      return nil
+    end
+
+    vim.api.nvim_set_current_win(history_win)
+    return vim.bo.filetype
+  end, cmd)
+
+  eq('gitsigns-history', filetype)
+end
+
+local function open_history_panel_from_source()
+  eq(
+    'gitsigns-history',
+    exec_lua(function()
+      local history_win = vim.api.nvim_get_current_win()
+      local source_win --- @type integer?
+
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        if win ~= history_win then
+          source_win = win
+          break
+        end
+      end
+
+      assert(source_win)
+      vim.api.nvim_set_current_win(source_win)
+
+      local async = require('gitsigns.async')
+      async.run(require('gitsigns.actions.history').history):wait(5000)
+      return vim.bo.filetype
+    end)
+  )
+end
+
+local function get_history_browser_state()
+  return exec_lua(function()
+    local history_win = vim.api.nvim_get_current_win()
+    local history_bufnr = vim.api.nvim_get_current_buf()
+    local source_win --- @type integer?
+    local source_bufnr --- @type integer?
+
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if win ~= history_win then
+        source_win = win
+        source_bufnr = vim.api.nvim_win_get_buf(win)
+        break
+      end
+    end
+
+    local lines = vim.api.nvim_buf_get_lines(history_bufnr, 0, -1, false)
+    local namespaces = vim.api.nvim_get_namespaces()
+    local ns = assert(namespaces.gitsigns_history_win)
+    local state_ns = assert(namespaces.gitsigns_history_state)
+    local marks = vim.api.nvim_buf_get_extmarks(history_bufnr, ns, 0, -1, { details = true })
+    local state_marks =
+      vim.api.nvim_buf_get_extmarks(history_bufnr, state_ns, 0, -1, { details = true })
+    local row_hls = {} --- @type table<integer, string[]>
+    local detail_lines = {} --- @type string[]
+    local detail_row --- @type integer?
+    local cursor_row --- @type integer?
+    local cursor_hl --- @type string?
+    local source_row --- @type integer?
+    local source_hl --- @type string?
+
+    for _, mark in ipairs(marks) do
+      local row = mark[2] + 1
+      local details = assert(mark[4])
+      if type(details.hl_group) == 'string' then
+        row_hls[row] = row_hls[row] or {}
+        row_hls[row][#row_hls[row] + 1] = details.hl_group
+      end
+    end
+
+    table.sort(state_marks, function(a, b)
+      return a[1] < b[1]
+    end)
+
+    for _, mark in ipairs(state_marks) do
+      local details = assert(mark[4])
+      local row = mark[2] + 1
+      if details.virt_lines then
+        detail_row = row
+        for _, chunks in ipairs(details.virt_lines) do
+          local parts = {} --- @type string[]
+          for _, chunk in ipairs(chunks) do
+            parts[#parts + 1] = chunk[1]
+          end
+          detail_lines[#detail_lines + 1] = table.concat(parts)
+        end
+      elseif details.hl_group == 'CursorLine' then
+        cursor_row = row
+        cursor_hl = details.hl_group
+      elseif details.hl_group == 'Visual' then
+        source_row = row
+        source_hl = details.hl_group
+      end
+    end
+
+    return {
+      columns = vim.o.columns,
+      cursor_hl = cursor_hl,
+      cursor_row = cursor_row,
+      detail_lines = detail_lines,
+      detail_row = detail_row,
+      history_height = vim.api.nvim_win_get_height(history_win),
+      history_col = vim.fn.win_screenpos(history_win)[2],
+      history_name = vim.api.nvim_buf_get_name(history_bufnr),
+      history_statusline = vim.wo[history_win].statusline,
+      history_top = vim.fn.win_screenpos(history_win)[1],
+      history_width = vim.api.nvim_win_get_width(history_win),
+      history_winbar = vim.wo[history_win].winbar,
+      lines = lines,
+      row_hls = row_hls,
+      screen_lines = vim.o.lines,
+      source_col = source_win and vim.fn.win_screenpos(source_win)[2] or nil,
+      source_height = source_win and vim.api.nvim_win_get_height(source_win) or nil,
+      source_hl = source_hl,
+      source_lines = source_bufnr and vim.api.nvim_buf_get_lines(source_bufnr, 0, -1, false) or nil,
+      source_name = source_bufnr and vim.api.nvim_buf_get_name(source_bufnr) or nil,
+      source_row = source_row,
+      source_top = source_win and vim.fn.win_screenpos(source_win)[1] or nil,
+      source_width = source_win and vim.api.nvim_win_get_width(source_win) or nil,
+      tab_count = #vim.api.nvim_list_tabpages(),
+      visible_bot = vim.fn.line('w$'),
+      visible_top = vim.fn.line('w0'),
+      win_count = #vim.api.nvim_tabpage_list_wins(0),
+    }
+  end)
+end
+
+local function has_hl(row_hls, row, name)
+  for _, hl in ipairs(row_hls[row] or {}) do
+    if hl == name then
+      return true
+    end
+  end
+  return false
+end
+
+local function setup_two_commit_history()
+  setup_gitsigns(test_config)
+  setup_test_repo({
+    test_file_text = { 'one', 'two' },
+  })
+
+  write_to_file(test_file, { 'one', 'TWO' })
+  git('add', test_file)
+  git('commit', '-m', 'second commit')
+
+  edit(test_file)
+  check({
+    status = { head = 'main', added = 0, changed = 0, removed = 0 },
+    signs = {},
+  })
+end
+
+describe('history', function()
+  before_each(function()
+    clear()
+    scratch = helpers.scratch
+    test_file = helpers.test_file
+    helpers.chdir_tmp()
+    helpers.setup_path()
+  end)
+
+  it('renders the current buffer history in the current tab', function()
+    setup_two_commit_history()
+    open_history_panel()
+
+    local result = get_history_browser_state()
+
+    eq(1, result.tab_count)
+    eq(2, result.win_count)
+    assert(result.history_top > assert(result.source_top))
+    assert(result.history_height < assert(result.source_height))
+    assert(
+      result.history_height <= math.max(4, math.floor(math.max(result.screen_lines - 2, 1) * 0.35))
+    )
+    eq('CursorLine', result.cursor_hl)
+    eq(1, result.cursor_row)
+    eq(test_file, result.source_name)
+    eq(1, result.source_row)
+    eq(nil, result.detail_row)
+    assert(result.history_name:match('^gitsigns%-history://'))
+    assert(result.history_winbar:find('History', 1, true))
+    assert(result.history_winbar:find('dummy.txt', 1, true))
+    assert(not result.history_winbar:find('tester', 1, true))
+    eq(
+      ' <CR> open  v split  t tab  gv/gt commit  i info  q quit  ? menu ',
+      result.history_statusline
+    )
+    eq(nil, result.detail_lines[1])
+    eq(2, #result.lines)
+    assert(result.lines[1]:match('^%x%x%x%x%x%x%x%x  second commit$'))
+    assert(result.lines[2]:match('^%x%x%x%x%x%x%x%x  init commit$'))
+    eq(true, has_hl(result.row_hls, 1, 'Directory'))
+
+    feed('i')
+
+    local expanded = get_history_browser_state()
+    eq(1, expanded.detail_row)
+    assert(expanded.detail_lines[1]:match('^  %d%d%d%d%-%d%d%-%d%d  tester$'))
+    assert(expanded.detail_lines[2]:find('HEAD', 1, true))
+    assert(expanded.detail_lines[2]:find('main', 1, true))
+    assert(expanded.detail_lines[3]:match('^  changes %+1 %-1$'))
+    eq(nil, expanded.detail_lines[4])
+
+    feed('i')
+
+    local collapsed = get_history_browser_state()
+    eq(nil, collapsed.detail_row)
+    eq(nil, collapsed.detail_lines[1])
+
+    feed('j')
+
+    local moved = get_history_browser_state()
+    eq('CursorLine', moved.cursor_hl)
+    eq(2, moved.cursor_row)
+    eq(1, moved.source_row)
+
+    feed('<CR>')
+
+    expectf(function()
+      local opened = get_history_browser_state()
+      return opened.tab_count == 2
+        and opened.cursor_hl == 'CursorLine'
+        and opened.cursor_row == 2
+        and opened.source_row == 2
+        and opened.source_name ~= nil
+        and opened.source_name:match('^gitsigns://') ~= nil
+    end)
+
+    feed('<CR>')
+
+    expectf(function()
+      local reopened = get_history_browser_state()
+      return reopened.cursor_hl == 'CursorLine'
+        and reopened.cursor_row == 2
+        and reopened.source_row == 2
+        and reopened.source_name ~= nil
+        and reopened.source_name:match('^gitsigns://') ~= nil
+        and vim.deep_equal(reopened.source_lines, { 'one', 'two' })
+    end)
+  end)
+
+  it('does not retarget history from an unrelated unattached window', function()
+    setup_two_commit_history()
+
+    eq(
+      false,
+      exec_lua(function()
+        vim.cmd.new()
+        local async = require('gitsigns.async')
+        async.run(require('gitsigns.actions.history').history):wait(5000)
+
+        for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+          local bufnr = vim.api.nvim_win_get_buf(win)
+          if vim.bo[bufnr].filetype == 'gitsigns-history' then
+            return true
+          end
+        end
+
+        return false
+      end)
+    )
+  end)
+
+  it('follows renames', function()
+    helpers.git_init_scratch()
+    setup_gitsigns(test_config)
+
+    local old_path = scratch .. '/old.txt'
+    local new_path = scratch .. '/new.txt'
+
+    write_to_file(old_path, { 'one' })
+    git('add', old_path)
+    git('commit', '-m', 'add original file')
+
+    git('mv', old_path, new_path)
+    git('commit', '-m', 'rename file')
+
+    edit(new_path)
+    wait_for_attach()
+
+    open_history_panel()
+
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(0, 0, -1, false)')
+    eq(2, #lines)
+    assert(lines[1]:find('rename file', 1, true))
+    assert(lines[2]:find('add original file', 1, true))
+
+    feed('i')
+
+    local rename_info = get_history_browser_state()
+    eq(1, rename_info.detail_row)
+    assert(rename_info.detail_lines[1]:match('^  %d%d%d%d%-%d%d%-%d%d  tester$'))
+    assert(rename_info.detail_lines[2]:find('HEAD', 1, true))
+    assert(rename_info.detail_lines[2]:find('main', 1, true))
+    assert(rename_info.detail_lines[3]:match('^  changes %+0 %-0$'))
+    eq('  renamed from old.txt', rename_info.detail_lines[4])
+
+    feed('i')
+
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_browser_state()
+      return state.win_count == 2
+        and state.source_name ~= nil
+        and state.source_name:match('^gitsigns://') ~= nil
+        and state.source_name:find('old.txt', 1, true) ~= nil
+        and state.history_winbar:find('old.txt', 1, true) ~= nil
+        and state.detail_row == nil
+        and state.source_row == 2
+        and vim.deep_equal(state.source_lines, { 'one' })
+    end)
+
+    open_history_panel_from_source()
+
+    local reopened = get_history_browser_state()
+    eq(2, reopened.tab_count)
+    eq(2, reopened.win_count)
+    eq(2, #reopened.lines)
+    assert(reopened.lines[1]:find('rename file', 1, true))
+    assert(reopened.lines[2]:find('add original file', 1, true))
+    eq('CursorLine', reopened.cursor_hl)
+    eq(2, reopened.cursor_row)
+    eq(2, reopened.source_row)
+    eq(nil, reopened.detail_row)
+    eq(nil, reopened.detail_lines[1])
+  end)
+
+  it('keeps detail paths anchored to the history path across renames', function()
+    helpers.git_init_scratch()
+    setup_gitsigns(test_config)
+
+    local old_path = scratch .. '/old.txt'
+    local new_path = scratch .. '/new.txt'
+
+    write_to_file(old_path, { 'one' })
+    git('add', old_path)
+    git('commit', '-m', 'add original file')
+
+    git('mv', old_path, new_path)
+    git('commit', '-m', 'rename file')
+
+    write_to_file(new_path, { 'two' })
+    git('add', new_path)
+    git('commit', '-m', 'update renamed file')
+
+    edit(new_path)
+    wait_for_attach()
+
+    open_history_panel()
+    feed('j')
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_browser_state()
+      return state.source_name ~= nil
+        and state.source_name:match('^gitsigns://') ~= nil
+        and state.source_name:find('old.txt', 1, true) ~= nil
+        and state.source_row == 3
+    end)
+
+    open_history_panel_from_source()
+    feed('k')
+    feed('k')
+    feed('i')
+
+    local reopened = get_history_browser_state()
+    eq(1, reopened.cursor_row)
+    eq(1, reopened.detail_row)
+    assert(reopened.detail_lines[3]:match('^  changes %+1 %-1$'))
+    eq(false, vim.tbl_contains(reopened.detail_lines, '  old path new.txt'))
+    eq(false, vim.tbl_contains(reopened.detail_lines, '  renamed from old.txt'))
+  end)
+
+  it('opens a revision beside a lone history panel in the current tab', function()
+    setup_two_commit_history()
+    open_history_panel()
+
+    exec_lua(function()
+      local history_win = vim.api.nvim_get_current_win()
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        if win ~= history_win then
+          vim.api.nvim_win_close(win, true)
+        end
+      end
+      vim.api.nvim_set_current_win(history_win)
+    end)
+
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_browser_state()
+      return state.tab_count == 1
+        and state.win_count == 2
+        and state.cursor_row == 2
+        and state.source_row == 2
+        and state.source_name ~= nil
+        and state.source_name:match('^gitsigns://') ~= nil
+    end)
+  end)
+
+  it('reopens history for a revision buffer in the current tab', function()
+    setup_two_commit_history()
+    open_history_panel()
+
+    feed('j')
+    feed('t')
+
+    expectf(function()
+      return exec_lua(function()
+        local has_source_panel = false
+        for _, win in ipairs(vim.api.nvim_tabpage_list_wins(vim.api.nvim_list_tabpages()[1])) do
+          local bufnr = vim.api.nvim_win_get_buf(win)
+          if vim.bo[bufnr].filetype == 'gitsigns-history' then
+            has_source_panel = true
+          end
+        end
+        return #vim.api.nvim_list_tabpages() == 2
+          and not has_source_panel
+          and vim.bo.filetype == 'gitsigns-history'
+      end)
+    end)
+
+    open_history_panel_command('Gitsigns history')
+
+    local reopened = get_history_browser_state()
+    eq(2, reopened.tab_count)
+    eq(2, reopened.win_count)
+    eq('CursorLine', reopened.cursor_hl)
+    eq(2, reopened.cursor_row)
+    eq(2, reopened.source_row)
+    assert(reopened.source_name:match('^gitsigns://') ~= nil)
+
+    feed('k')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_browser_state()
+      return state.cursor_row == 1
+        and state.source_row == 1
+        and vim.deep_equal(state.source_lines, { 'one', 'TWO' })
+    end)
+
+    feed('j')
+    feed('<CR>')
+
+    expectf(function()
+      local state = get_history_browser_state()
+      return state.cursor_row == 2
+        and state.source_row == 2
+        and vim.deep_equal(state.source_lines, { 'one', 'two' })
+    end)
+  end)
+
+  it('shows a synthetic source row when the shown revision did not touch the file', function()
+    setup_two_commit_history()
+    local other_file = scratch .. '/other.txt'
+    write_to_file(other_file, { 'other' })
+    git('add', other_file)
+    git('commit', '-m', 'third commit')
+
+    command('Gitsigns show HEAD')
+    wait_for_attach()
+
+    open_history_panel_command('Gitsigns history')
+
+    local result = get_history_browser_state()
+    eq(1, result.tab_count)
+    eq(2, result.win_count)
+    eq('CursorLine', result.cursor_hl)
+    eq(1, result.cursor_row)
+    eq(1, result.source_row)
+    assert(result.source_name:match('^gitsigns://') ~= nil)
+    assert(result.lines[1]:match('^%x%x%x%x%x%x%x%x  %* third commit$'))
+    eq(true, has_hl(result.row_hls, 1, 'Special'))
+    assert(result.lines[2]:find('second commit', 1, true))
+    assert(result.lines[3]:find('init commit', 1, true))
+
+    feed('i')
+
+    local expanded = get_history_browser_state()
+    eq(1, expanded.detail_row)
+    assert(expanded.detail_lines[1]:match('^  %d%d%d%d%-%d%d%-%d%d  tester$'))
+    assert(expanded.detail_lines[2]:find('HEAD', 1, true))
+    assert(expanded.detail_lines[2]:find('main', 1, true))
+    eq('  status unchanged in this commit', expanded.detail_lines[3])
+    assert(expanded.detail_lines[4]:match('^  last changed %x%x%x%x%x%x%x%x  second commit$'))
+    eq(nil, expanded.detail_lines[5])
+  end)
+
+  it('renders associated PRs asynchronously for expanded info only', function()
+    local config = vim.deepcopy(test_config)
+    config.gh = true
+    setup_gitsigns(config)
+    setup_test_repo({
+      test_file_text = { 'line 0' },
+    })
+
+    for i = 1, 2 do
+      write_to_file(test_file, { ('line %d'):format(i) })
+      git('add', test_file)
+      git('commit', '-m', ('commit %d'):format(i))
+    end
+
+    local shas = exec_lua(function(repo, path)
+      return vim.fn.systemlist({ 'git', '-C', repo, 'log', '--format=%H', '--', path })
+    end, scratch, 'dummy.txt')
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function(sha_list)
+      local async = require('gitsigns.async')
+      local prs_by_sha = {} --- @type table<string, gitsigns.gh.PrInfo[]>
+      vim.g.gitsigns_history_pr_batches = {}
+
+      for i, sha in ipairs(sha_list) do
+        prs_by_sha[sha] = {
+          {
+            number = tostring(i),
+            url = ('https://example.test/pr/%d'):format(i),
+          },
+        }
+      end
+
+      package.loaded['gitsigns.gh'] = {
+        associated_prs_many = function(shas)
+          async.schedule()
+          vim.g.gitsigns_history_pr_batches[#vim.g.gitsigns_history_pr_batches + 1] =
+            vim.deepcopy(shas)
+
+          local ret = {} --- @type table<string, gitsigns.gh.PrInfo[]|false>
+          for _, sha in ipairs(shas) do
+            ret[sha] = prs_by_sha[sha] or false
+          end
+          return ret
+        end,
+      }
+    end, shas)
+
+    open_history_panel()
+
+    eq({}, exec_lua('return vim.g.gitsigns_history_pr_batches'))
+
+    feed('i')
+
+    expectf(function()
+      local result = get_history_browser_state()
+      return result.lines[1]:find('#1', 1, true) == nil
+        and vim.tbl_contains(result.detail_lines, '  prs #1')
+    end)
+
+    expectf(function()
+      return vim.deep_equal(exec_lua('return vim.g.gitsigns_history_pr_batches'), { { shas[1] } })
+    end)
+
+    feed('j')
+
+    expectf(function()
+      local result = get_history_browser_state()
+      return result.cursor_row == 2
+        and result.lines[1]:find('#1', 1, true) == nil
+        and result.lines[2]:find('#2', 1, true) == nil
+        and vim.tbl_contains(result.detail_lines, '  prs #2')
+    end)
+
+    expectf(function()
+      return vim.deep_equal(exec_lua('return vim.g.gitsigns_history_pr_batches'), {
+        { shas[1] },
+        { shas[2] },
+      })
+    end)
+  end)
+
+  it('retries expanded-info PR lookups after an inconclusive fetch', function()
+    local config = vim.deepcopy(test_config)
+    config.gh = true
+    setup_gitsigns(config)
+    setup_test_repo({
+      test_file_text = { 'line 0' },
+    })
+
+    write_to_file(test_file, { 'line 1' })
+    git('add', test_file)
+    git('commit', '-m', 'commit 1')
+
+    local shas = exec_lua(function(repo, path)
+      return vim.fn.systemlist({ 'git', '-C', repo, 'log', '--format=%H', '--', path })
+    end, scratch, 'dummy.txt')
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    exec_lua(function(sha)
+      local async = require('gitsigns.async')
+      local calls = 0
+      vim.g.gitsigns_history_pr_batches = {}
+
+      package.loaded['gitsigns.gh'] = {
+        associated_prs_many = function(shas)
+          async.schedule()
+          calls = calls + 1
+          vim.g.gitsigns_history_pr_batches[#vim.g.gitsigns_history_pr_batches + 1] =
+            vim.deepcopy(shas)
+
+          if calls == 1 then
+            return {}
+          end
+
+          return {
+            [sha] = {
+              {
+                number = '1',
+                url = 'https://example.test/pr/1',
+              },
+            },
+          }
+        end,
+      }
+    end, shas[1])
+
+    open_history_panel()
+    feed('i')
+
+    expectf(function()
+      local result = get_history_browser_state()
+      return not vim.tbl_contains(result.detail_lines, '  prs #1')
+        and not vim.tbl_contains(result.detail_lines, '  prs loading...')
+        and vim.deep_equal(exec_lua('return vim.g.gitsigns_history_pr_batches'), { { shas[1] } })
+    end)
+
+    feed('i')
+    feed('i')
+
+    expectf(function()
+      local result = get_history_browser_state()
+      return vim.tbl_contains(result.detail_lines, '  prs #1')
+        and vim.deep_equal(exec_lua('return vim.g.gitsigns_history_pr_batches'), {
+          { shas[1] },
+          { shas[1] },
+        })
+    end)
+  end)
+
+  it('opens vertically with the :vert modifier', function()
+    setup_two_commit_history()
+    open_history_panel_command('vert Gitsigns history')
+
+    local result = get_history_browser_state()
+
+    eq(1, result.tab_count)
+    eq(2, result.win_count)
+    eq(assert(result.history_top), assert(result.source_top))
+    assert(result.history_col < assert(result.source_col))
+    assert(result.history_width < assert(result.source_width))
+    assert(result.history_width <= math.max(32, math.floor(result.columns * 0.4)))
+    eq('CursorLine', result.cursor_hl)
+    eq(1, result.cursor_row)
+    eq(1, result.source_row)
+  end)
+
+  it('opens the history action picker on ?', function()
+    setup_gitsigns(test_config)
+    setup_test_repo()
+
+    edit(test_file)
+    check({
+      status = { head = 'main', added = 0, changed = 0, removed = 0 },
+      signs = {},
+    })
+
+    open_history_panel()
+
+    exec_lua(function()
+      _G.gitsigns_test_select_orig = vim.ui.select
+      vim.g.gitsigns_history_prompt = nil
+      vim.g.gitsigns_history_items = nil
+      vim.ui.select = function(items, opts, on_choice)
+        vim.g.gitsigns_history_prompt = opts and opts.prompt or nil
+        vim.g.gitsigns_history_items = vim.tbl_map(function(item)
+          return item.desc
+        end, items)
+        on_choice(nil)
+      end
+    end)
+
+    feed('?')
+
+    local result = exec_lua(function()
+      local prompt = vim.g.gitsigns_history_prompt
+      local items = vim.g.gitsigns_history_items
+      vim.ui.select = _G.gitsigns_test_select_orig
+      _G.gitsigns_test_select_orig = nil
+      return { prompt = prompt, items = items }
+    end)
+
+    assert(result.prompt:match('^Gitsigns history: %x%x%x%x%x%x%x%x$'))
+    eq({
+      'Open buffer revision',
+      'Open buffer revision in a vertical split',
+      'Open buffer revision in a new tab',
+      'Show commit in a vertical split',
+      'Show commit in a new tab',
+      'Toggle expanded inline info',
+      'Close history',
+    }, result.items)
+  end)
+
+  it('opens the selected commit', function()
+    setup_two_commit_history()
+    open_history_panel()
+
+    feed('j')
+    feed('s')
+
+    expectf(function()
+      return exec_lua(function()
+        if vim.bo.filetype ~= 'git' then
+          return false
+        end
+
+        local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+        return lines[1]:match('^commit %x+$') ~= nil
+          and table.concat(lines, '\n'):find('init commit', 1, true) ~= nil
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Problem

Gitsigns has blame panels for inspecting a buffer, but file history did
not have an equivalent browser. Moving between the current file, older
revisions, and blame/history panels needed a coherent model that keeps
inspection state contained without disrupting the user's working buffer.

## Solution

Add `:Gitsigns history` as a dedicated file-history panel. The panel can
open file revisions, show commits, expand entry metadata, and surface
associated GitHub PRs while keeping the browser attached to the active
source or revision buffer.

Share the inspection-panel rules between blame and history so panels move
together when a revision action creates a tab. Track the history path
separately from each entry path, preserve browser state across renames,
and insert a synthetic source row when the selected revision did not touch
the file.
