### PR TITLE
fix(blame): don't run 'textconv' diff filters on blamed files

### DIFF
--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -264,6 +264,7 @@ function M.run_blame(obj, contents, lnum, revision, opts)
   local _, stderr = obj.repo:command(
     util.flatten({
       'blame',
+      '--no-textconv',
       '--incremental',
       contents and { '--contents', '-' },
       opts.ignore_whitespace and '-w' or nil,


### PR DESCRIPTION
Problem: gitsigns passes UTF-8 converted buffer into git-blame stdin,
which is not what a user-defined textconv diff filter may expect.

Solution: don't let git-blame run textconv diff filters.

Reproducing:
- Set up a custom textconv driver in your gitconfig
  ```
  [diff "my-diff-cp866"]
    textconv = "iconv -f cp866"
  ```
- Prepare a test repo
  ```
  cd "$(mktemp -d)" \
    && echo "*.txt text diff=my-diff-cp866" >> .gitattributes \
    && git init \
    && echo -e "Кирилл\\nLatin" | iconv -t cp866 > cp866.txt \
    && git add .gitattributes cp866.txt \
    && git commit -m 'hi'
  ```
- With gitsigns in your Neovim config, `nvim ./cp866.txt`, `:Gitsigns
  blame_line`
- Observe error:
  > Error running git-blame: iconv: illegal input sequence at position 0

The downside of this approach is that blaming won't work on lines the
'textconv' filter would transform, such as the first line in the example
above, by saying 'Not Committed Yet'.
Ideally 'fileencoding'-encoded buffer should be passed into git-blame
stdin, but this approach plugs the hole in a simpler way.

