### PR TITLE
refactor(manager): move rendering into subscribers

### DIFF
--- a/lua/gitsigns.lua
+++ b/lua/gitsigns.lua
@@ -91,8 +91,8 @@ local function setup_cwd_watcher(cwd, towatch)
   end)
 
   -- Watch .git/HEAD to detect branch changes
-  cwd_watcher:start(towatch, {}, function()
-    async().run(function(err)
+  cwd_watcher:start(towatch, {}, function(err)
+    async().run(function()
       local __FUNC__ = 'cwd_watcher_cb'
       if err then
         log().dprintf('Git dir update error: %s', err)
@@ -247,8 +247,9 @@ function M.setup(cfg)
   if init then
     api.nvim_create_augroup('gitsigns', {})
     setup_cli()
-    -- TODO(lewis6991): do this lazily
-    require('gitsigns.highlight').setup()
+    -- Highlights are global editor state, so define them during setup even
+    -- when attach-time rendering features stay lazy.
+    require('gitsigns.highlight')
     setup_attach()
     setup_cwd_head()
 
@@ -260,7 +261,7 @@ end
 --- @param lnum? integer Line number to return status for. Defaults to `vim.v.lnum`
 --- @return string
 function M.statuscolumn(bufnr, lnum)
-  return require('gitsigns.manager').statuscolumn(bufnr, lnum)
+  return require('gitsigns.sign_renderer').statuscolumn(bufnr, lnum)
 end
 
 M = setmetatable(M, {

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -1049,9 +1049,9 @@ end
 ---
 --- @param callback? fun(err?: string)
 function M.refresh(callback)
-  manager.reset_signs()
+  require('gitsigns.sign_renderer').reset()
   require('gitsigns.highlight').setup_highlights()
-  require('gitsigns.current_line_blame').setup()
+  require('gitsigns.current_line_blame').refresh()
   async_run(callback, function()
     for k, v in pairs(cache) do
       v:invalidate(true)

--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -20,6 +20,8 @@ local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 --- @class gitsigns.attach
 local M = {}
 
+local group = api.nvim_create_augroup('gitsigns.attach', {})
+
 --- @param name string
 --- @return string? rel_path
 --- @return string? commit
@@ -62,7 +64,7 @@ local function on_lines(_, bufnr, _, first, last_orig, last_new, byte_count)
     -- call which indicates no changes.
     return
   end
-  return manager.on_lines(bufnr, first, last_orig, last_new)
+  return manager.handle_on_lines(bufnr, first, last_orig, last_new)
 end
 
 --- @param _ 'reload'
@@ -76,7 +78,7 @@ end
 --- @param _ 'detach'
 --- @param bufnr integer
 local function on_detach(_, bufnr)
-  api.nvim_clear_autocmds({ group = 'gitsigns', buffer = bufnr })
+  api.nvim_clear_autocmds({ group = group, buffer = bufnr })
   M.detach(bufnr, true)
 end
 
@@ -102,26 +104,6 @@ local function on_attach_pre(bufnr)
   end
   return gitdir, toplevel
 end
-
-local setup = Util.once(function()
-  manager.setup()
-
-  require('gitsigns.current_line_blame').setup()
-
-  api.nvim_create_autocmd('BufFilePre', {
-    group = 'gitsigns',
-    desc = 'Gitsigns: detach when changing buffer names',
-    callback = function(args)
-      M.detach(args.buf)
-    end,
-  })
-
-  api.nvim_create_autocmd('VimLeavePre', {
-    desc = 'Gitsigns: detach from all buffers',
-    group = 'gitsigns',
-    callback = M.detach_all,
-  })
-end)
 
 --- @class (exact) Gitsigns.GitContext
 --- @field file string Path to the file represented by the buffer.
@@ -274,7 +256,7 @@ local function repo_update_handler(bufnr)
     end
   end
 
-  require('gitsigns.manager').update(bufnr)
+  manager.update(bufnr)
 end
 
 --- @param opts Gitsigns.AttachOpts?
@@ -294,8 +276,6 @@ M.attach = throttle_async({ hash = attach_hash }, function(opts)
   local ctx = attach_opts.ctx
   local passed_ctx = ctx ~= nil
   local trigger = attach_opts.trigger
-
-  setup()
 
   if cache[cbuf] then
     dprint('Already attached')
@@ -401,6 +381,10 @@ M.attach = throttle_async({ hash = attach_hash }, function(opts)
     return
   end
 
+  -- From here the buffer is accepted; activate manager infrastructure and the
+  -- modules that subscribe to it.
+  manager.setup()
+
   cache[cbuf] = Cache.new(cbuf, file, git_obj)
 
   if not api.nvim_buf_is_loaded(cbuf) then
@@ -434,7 +418,7 @@ M.attach = throttle_async({ hash = attach_hash }, function(opts)
   })
 
   api.nvim_create_autocmd('BufWrite', {
-    group = 'gitsigns',
+    group = group,
     buffer = cbuf,
     callback = function()
       manager.update_sync_debounced(cbuf)
@@ -480,10 +464,25 @@ function M.detach(bufnr, keep_signs)
 
   manager.detach(bufnr, keep_signs)
 
-  -- Clear status variables
-  Status.clear(bufnr)
-
   Cache.destroy(bufnr)
+end
+
+do -- Module-level activation
+  api.nvim_create_autocmd('BufFilePre', {
+    group = group,
+    desc = 'Gitsigns: detach when changing buffer names',
+    callback = function(args)
+      M.detach(args.buf)
+    end,
+  })
+
+  api.nvim_create_autocmd('VimLeavePre', {
+    desc = 'Gitsigns: detach from all buffers',
+    group = group,
+    callback = function()
+      M.detach_all()
+    end,
+  })
 end
 
 return M

--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -65,6 +65,27 @@ function CacheEntry:invalidate(all)
   end
 end
 
+--- Keep line-indexed cache state aligned with buffer edits.
+--- @param first integer
+--- @param last_orig integer
+--- @param last_new integer
+function CacheEntry:on_lines(first, last_orig, last_new)
+  local blame = self.blame and self.blame.entries
+  if not blame then
+    return
+  end
+
+  if last_new < last_orig then
+    util.list_remove(blame, last_new + 1, last_orig)
+  elseif last_new > last_orig then
+    util.list_insert(blame, last_orig + 1, last_new)
+  end
+
+  for i = first + 1, last_new do
+    blame[i] = nil
+  end
+end
+
 --- @param bufnr integer
 --- @param file string
 --- @param git_obj Gitsigns.GitObj

--- a/lua/gitsigns/current_line_blame.lua
+++ b/lua/gitsigns/current_line_blame.lua
@@ -233,11 +233,10 @@ M.update = debounce.debounce_trailing(
   end
 )
 
-function M.setup()
+function M.refresh()
   for k in pairs(cache) do
     reset(k)
   end
-  local group = api.nvim_create_augroup('gitsigns_blame', {})
 
   if not config.current_line_blame then
     return
@@ -245,6 +244,16 @@ function M.setup()
 
   -- show current buffer line blame immediately
   M.update(api.nvim_get_current_buf())
+end
+
+local function configure()
+  M.refresh()
+
+  local group = api.nvim_create_augroup('gitsigns.current_line_blame', {})
+
+  if not config.current_line_blame then
+    return
+  end
 
   local update_events = { 'BufEnter', 'CursorMoved', 'CursorMovedI', 'WinResized' }
   local reset_events = { 'InsertEnter', 'BufLeave' }
@@ -278,8 +287,12 @@ function M.setup()
   })
 end
 
-Config.subscribe('current_line_blame', function()
-  M.setup()
-end)
+do -- Module-level activation
+  configure()
+
+  Config.subscribe({ 'current_line_blame', 'current_line_blame_opts' }, function()
+    configure()
+  end)
+end
 
 return M

--- a/lua/gitsigns/deleted_preview.lua
+++ b/lua/gitsigns/deleted_preview.lua
@@ -3,6 +3,7 @@ local config = require('gitsigns.config').config
 local HunkPreview = require('gitsigns.hunk_preview')
 local Virt = require('gitsigns.render.virt')
 local Inspect = require('gitsigns.inspect')
+local manager = require('gitsigns.manager')
 local util = require('gitsigns.util')
 
 local api = vim.api
@@ -416,7 +417,7 @@ function M.prepare(bufnr)
 end
 
 --- @param winid integer
-function M.clear_win(winid)
+local function clear_win(winid)
   local entry = win_ns[winid]
   if not entry then
     return
@@ -497,6 +498,39 @@ function M.on_win(winid, bufnr, topline, botline)
   end
 
   return #visible > 0
+end
+
+do -- Module-level activation
+  manager.on_detach(function(bufnr)
+    M.detach(bufnr)
+  end)
+
+  manager.on_update(function(ctx)
+    if ctx.hunks_changed then
+      M.prepare(ctx.bufnr)
+    end
+  end)
+
+  manager.on_win(function(ctx)
+    if not (ctx.bcache and ctx.bcache.hunks) then
+      clear_win(ctx.winid)
+      return false
+    end
+
+    M.on_win(ctx.winid, ctx.bufnr, ctx.topline, ctx.botline)
+    return false
+  end)
+
+  api.nvim_create_autocmd('WinClosed', {
+    group = api.nvim_create_augroup('gitsigns.deleted_preview', {}),
+    callback = function(args)
+      local winid = tonumber(args.match)
+      if winid then
+        --- @cast winid integer
+        clear_win(winid)
+      end
+    end,
+  })
 end
 
 return M

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -309,14 +309,6 @@ function M.setup_highlights()
   end
 end
 
-function M.setup()
-  M.setup_highlights()
-  api.nvim_create_autocmd('ColorScheme', {
-    group = 'gitsigns',
-    callback = M.setup_highlights,
-  })
-end
-
 do --- temperature highlight
   local temp_colors = {} --- @type table<integer,string>
   local normal_bg --- @type [integer,integer,integer]?
@@ -357,6 +349,14 @@ do --- temperature highlight
     temp_colors[color] = hl_name
     return hl_name
   end
+end
+
+do -- Module-level activation
+  M.setup_highlights()
+  api.nvim_create_autocmd('ColorScheme', {
+    group = api.nvim_create_augroup('gitsigns.highlight', {}),
+    callback = M.setup_highlights,
+  })
 end
 
 return M

--- a/lua/gitsigns/manager.lua
+++ b/lua/gitsigns/manager.lua
@@ -1,11 +1,8 @@
 local async = require('gitsigns.async')
 local log = require('gitsigns.debug.log')
-local DeletedPreview = require('gitsigns.deleted_preview')
 local util = require('gitsigns.util')
 local run_diff = require('gitsigns.diff')
 local Hunks = require('gitsigns.hunks')
-local Signs = require('gitsigns.signs')
-local Status = require('gitsigns.status')
 
 local debounce_trailing = require('gitsigns.debounce').debounce_trailing
 local throttle_async = require('gitsigns.debounce').throttle_async
@@ -16,152 +13,82 @@ local config = Config.config
 
 local api = vim.api
 
-local signs_normal = Signs.new()
-local signs_staged = Signs.new(true)
-
 --- @class gitsigns.manager
 local M = {}
 
-local statuscolumn_active = false
+--- @class (exact) Gitsigns.ManagerUpdate
+--- @field bufnr                integer
+--- @field bcache               Gitsigns.CacheEntry
+--- @field hunks_changed        boolean
+--- @field hunks_staged_changed boolean
 
---- @param bufnr? integer
---- @param top? integer
---- @param bot? integer
-local function redraw_statuscol(bufnr, top, bot)
-  if statuscolumn_active then
-    api.nvim__redraw({
-      buf = bufnr,
-      range = (top and bot) and { top, bot } or nil,
-      statuscolumn = true,
-    })
-  end
+--- @class (exact) Gitsigns.ManagerLines
+--- @field bufnr     integer
+--- @field bcache    Gitsigns.CacheEntry
+--- @field first     integer
+--- @field last_orig integer
+--- @field last_new  integer
+
+--- @class (exact) Gitsigns.ManagerWin
+--- @field ns      integer
+--- @field winid   integer
+--- @field bufnr   integer
+--- @field topline integer
+--- @field botline integer
+--- @field bcache? Gitsigns.CacheEntry
+
+--- @class (exact) Gitsigns.ManagerLine
+--- @field ns      integer
+--- @field winid   integer
+--- @field bufnr   integer
+--- @field row     integer
+--- @field bcache? Gitsigns.CacheEntry
+
+--- @alias Gitsigns.ManagerUpdateCb fun(ctx: Gitsigns.ManagerUpdate)
+--- @alias Gitsigns.ManagerLinesCb fun(ctx: Gitsigns.ManagerLines)
+--- @alias Gitsigns.ManagerDetachCb fun(bufnr: integer, keep_signs?: boolean)
+--- Return true to request on_line callbacks for the window.
+--- @alias Gitsigns.ManagerWinCb fun(ctx: Gitsigns.ManagerWin): boolean?
+--- @alias Gitsigns.ManagerLineCb fun(ctx: Gitsigns.ManagerLine)
+
+--- @type Gitsigns.ManagerUpdateCb[]
+local update_callbacks = {}
+
+--- @type Gitsigns.ManagerLinesCb[]
+local lines_callbacks = {}
+
+--- @type Gitsigns.ManagerDetachCb[]
+local detach_callbacks = {}
+
+--- @type Gitsigns.ManagerWinCb[]
+local win_callbacks = {}
+
+--- @type Gitsigns.ManagerLineCb[]
+local line_callbacks = {}
+
+--- @param cb Gitsigns.ManagerUpdateCb
+function M.on_update(cb)
+  update_callbacks[#update_callbacks + 1] = cb
 end
 
---- @param bufnr? integer
---- @param lnum? integer
---- @return string
-function M.statuscolumn(bufnr, lnum)
-  if bufnr == nil or bufnr == 0 then
-    bufnr = api.nvim_get_current_buf()
-  end
-  lnum = lnum or vim.v.lnum
-  statuscolumn_active = true
-
-  if not config._statuscolumn then
-    config.signcolumn = false
-    config._statuscolumn = true
-  end
-
-  local res = {} --- @type string[]
-  local res_len = 0
-  for _, signs in ipairs({ signs_normal, signs_staged }) do
-    local buf_signs = signs.signs[bufnr]
-    if buf_signs and next(buf_signs) then
-      local marks = api.nvim_buf_get_extmarks(
-        bufnr,
-        signs.ns,
-        { lnum - 1, 0 },
-        { lnum - 1, -1 },
-        {}
-      )
-      for _, mark in ipairs(marks) do
-        local id = mark[1]
-        local s = buf_signs[id]
-        if s then
-          vim.list_extend(res, { '%#' .. s[2] .. '#', s[1], '%*' })
-          --- @diagnostic disable-next-line: missing-parameter
-          res_len = res_len + vim.str_utfindex(s[1])
-        end
-      end
-    end
-  end
-  local pad = math.max(0, 2 - res_len)
-  return table.concat(res) .. string.rep(' ', pad)
+--- @param cb Gitsigns.ManagerLinesCb
+function M.on_lines(cb)
+  lines_callbacks[#lines_callbacks + 1] = cb
 end
 
---- @param bufnr integer
---- @param signs Gitsigns.Signs
---- @param hunks? Gitsigns.Hunk.Hunk[]
---- @param top integer
---- @param bot integer
---- @param clear? boolean
---- @param untracked boolean
---- @param filter? fun(line: integer):boolean
-local function apply_win_signs0(bufnr, signs, hunks, top, bot, clear, untracked, filter)
-  if clear then
-    signs:remove(bufnr) -- Remove all signs
-  end
-
-  hunks = hunks or {}
-
-  for i, hunk in ipairs(hunks) do
-    --- @type Gitsigns.Hunk.Hunk?, Gitsigns.Hunk.Hunk?
-    local prev_hunk, next_hunk = hunks[i - 1], hunks[i + 1]
-
-    -- To stop the sign column width changing too much, if there are signs to be
-    -- added but none of them are visible in the window, then make sure to add at
-    -- least one sign. Only do this on the first call after an update when we all
-    -- the signs have been cleared.
-    if clear and i == 1 then
-      signs:add(
-        bufnr,
-        Hunks.calc_signs(prev_hunk, hunk, next_hunk, hunk.added.start, hunk.added.start, untracked),
-        filter
-      )
-    end
-
-    signs:add(bufnr, Hunks.calc_signs(prev_hunk, hunk, next_hunk, top, bot, untracked), filter)
-    if hunk.added.start > bot then
-      break
-    end
-  end
+--- @param cb Gitsigns.ManagerDetachCb
+function M.on_detach(cb)
+  detach_callbacks[#detach_callbacks + 1] = cb
 end
 
---- @param bufnr integer
---- @param top integer
---- @param bot integer
---- @param clear? boolean
-local function apply_win_signs(bufnr, top, bot, clear)
-  local bcache = assert(cache[bufnr])
-  local untracked = bcache.git_obj.object_name == nil
-  apply_win_signs0(bufnr, signs_normal, bcache.hunks, top, bot, clear, untracked)
-  if signs_staged then
-    apply_win_signs0(
-      bufnr,
-      signs_staged,
-      bcache.hunks_staged,
-      top,
-      bot,
-      clear,
-      false,
-      function(lnum)
-        return not signs_normal:contains(bufnr, lnum)
-      end
-    )
-  end
-  if clear then
-    redraw_statuscol(bufnr, top, bot)
-  end
+--- @param cb Gitsigns.ManagerWinCb
+function M.on_win(cb)
+  win_callbacks[#win_callbacks + 1] = cb
 end
 
---- @param blame table<integer,Gitsigns.BlameInfo?>?
---- @param first integer
---- @param last_orig integer
---- @param last_new integer
-local function on_lines_blame(blame, first, last_orig, last_new)
-  if not blame then
-    return
-  end
-
-  if last_new < last_orig then
-    util.list_remove(blame, last_new + 1, last_orig)
-  elseif last_new > last_orig then
-    util.list_insert(blame, last_orig + 1, last_new)
-  end
-
-  for i = first + 1, last_new do
-    blame[i] = nil
-  end
+--- @param cb Gitsigns.ManagerLineCb
+function M.on_line(cb)
+  line_callbacks[#line_callbacks + 1] = cb
 end
 
 --- @param buf integer
@@ -169,115 +96,29 @@ end
 --- @param last_orig integer
 --- @param last_new integer
 --- @return true?
-function M.on_lines(buf, first, last_orig, last_new)
+function M.handle_on_lines(buf, first, last_orig, last_new)
   local bcache = cache[buf]
   if not bcache then
     log.dprint('Cache for buffer was nil. Detaching')
     return true
   end
 
-  if bcache.blame then
-    on_lines_blame(bcache.blame.entries, first, last_orig, last_new)
-  end
+  bcache:on_lines(first, last_orig, last_new)
 
-  signs_normal:on_lines(buf, first, last_orig, last_new)
-  if signs_staged then
-    signs_staged:on_lines(buf, first, last_orig, last_new)
-  end
-
-  -- Signs in changed regions get invalidated so we need to force a redraw if
-  -- any signs get removed.
-  if bcache.hunks and signs_normal:contains(buf, first, last_new) then
-    -- Force a sign redraw on the next update (fixes #521)
-    bcache.force_next_update = true
-  end
-
-  if signs_staged then
-    if bcache.hunks_staged and signs_staged:contains(buf, first, last_new) then
-      -- Force a sign redraw on the next update (fixes #521)
-      bcache.force_next_update = true
-    end
+  for _, cb in ipairs(lines_callbacks) do
+    cb({
+      bufnr = buf,
+      bcache = bcache,
+      first = first,
+      last_orig = last_orig,
+      last_new = last_new,
+    })
   end
 
   M.update_sync_debounced(buf)
 end
 
 local ns = api.nvim_create_namespace('gitsigns')
-
---- @param bufnr integer
---- @param row integer
-local function apply_word_diff(bufnr, row)
-  -- Don't run on folded lines
-  if vim.fn.foldclosed(row + 1) ~= -1 then
-    return
-  end
-
-  local bcache = cache[bufnr]
-
-  if not bcache or not bcache.hunks then
-    return
-  end
-
-  local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
-  if not line then
-    -- Invalid line
-    return
-  end
-
-  local lnum = row + 1
-
-  local hunk = Hunks.find_hunk(lnum, bcache.hunks)
-  if not hunk then
-    -- No hunk at line
-    return
-  end
-
-  if hunk.added.count ~= hunk.removed.count then
-    -- Only word diff if added count == removed
-    return
-  end
-
-  local pos = lnum - hunk.added.start + 1
-
-  local added_line = assert(hunk.added.lines[pos])
-  local removed_line = assert(hunk.removed.lines[pos])
-
-  local _, added_regions = require('gitsigns.diff_int').run_word_diff(
-    { removed_line },
-    { added_line }
-  )
-
-  local cols = #line
-
-  for _, region in ipairs(added_regions) do
-    local rtype, scol, ecol = region[2], region[3] - 1, region[4] - 1
-    if ecol == scol then
-      -- Make sure region is at least 1 column wide so deletes can be shown
-      ecol = scol + 1
-    end
-
-    local hl_group = rtype == 'add' and 'GitSignsAddLnInline'
-      or rtype == 'change' and 'GitSignsChangeLnInline'
-      or 'GitSignsDeleteLnInline'
-
-    local opts = {
-      ephemeral = true,
-      priority = 1000,
-    }
-
-    if ecol > cols and ecol == scol + 1 then
-      -- delete on last column, use virtual text instead
-      opts.virt_text = { { ' ', hl_group } }
-      opts.virt_text_pos = 'overlay'
-    else
-      opts.end_col = ecol
-      opts.hl_group = hl_group
-    end
-
-    api.nvim_buf_set_extmark(bufnr, ns, row, scol, opts)
-    util.redraw({ buf = bufnr, range = { row, row + 1 } })
-  end
-end
 
 --- @param bufnr integer
 --- @return boolean
@@ -381,19 +222,16 @@ M.update = throttle_async({ hash = 1, schedule = true }, function(bufnr)
     local hunks_staged_changed = Hunks.compare_heads(bcache.hunks_staged, old_hunks_staged)
 
     if hunks_changed or hunks_staged_changed then
-      -- Apply signs to the window. Other signs will be added by the decoration
-      -- provider as they are drawn.
-      apply_win_signs(bufnr, vim.fn.line('w0'), vim.fn.line('w$'), true)
-
       bcache.force_next_update = false
 
-      local summary = Hunks.get_summary(bcache.hunks)
-      summary.head = git_obj.repo.abbrev_head
-      Status.update(bufnr, summary)
-    end
-
-    if hunks_changed then
-      DeletedPreview.prepare(bufnr)
+      for _, cb in ipairs(update_callbacks) do
+        cb({
+          bufnr = bufnr,
+          bcache = bcache,
+          hunks_changed = hunks_changed,
+          hunks_staged_changed = hunks_staged_changed,
+        })
+      end
     end
   end)
 end)
@@ -410,67 +248,74 @@ end)
 --- @param bufnr integer
 --- @param keep_signs? boolean
 function M.detach(bufnr, keep_signs)
-  DeletedPreview.detach(bufnr)
-
-  if not keep_signs then
-    -- Remove all signs
-    signs_normal:remove(bufnr)
-    if signs_staged then
-      signs_staged:remove(bufnr)
-    end
-    redraw_statuscol(bufnr)
+  for _, cb in ipairs(detach_callbacks) do
+    cb(bufnr, keep_signs)
   end
 end
 
-function M.reset_signs()
-  -- Remove all signs
-  signs_normal:reset()
-  signs_staged:reset()
-end
-
+--- @param _ 'win'
 --- @param winid integer
 --- @param bufnr integer
 --- @param topline integer
 --- @param botline_guess integer
 --- @return boolean
-local function on_win(winid, bufnr, topline, botline_guess)
+local function on_win(_, winid, bufnr, topline, botline_guess)
   local bcache = cache[bufnr]
-  if not bcache or not bcache.hunks then
-    DeletedPreview.clear_win(winid)
-    return false
-  end
   local botline = math.min(botline_guess, api.nvim_buf_line_count(bufnr))
 
-  apply_win_signs(bufnr, topline + 1, botline + 1)
-
   local wants_on_line = false
-  if config.word_diff and config.diff_opts.internal then
-    wants_on_line = true
+
+  local ctx = {
+    ns = ns,
+    winid = winid,
+    bufnr = bufnr,
+    topline = topline,
+    botline = botline,
+    bcache = bcache,
+  }
+  for _, cb in ipairs(win_callbacks) do
+    wants_on_line = cb(ctx) or wants_on_line
   end
 
-  DeletedPreview.on_win(winid, bufnr, topline, botline)
-
-  return wants_on_line or false
+  return wants_on_line
 end
 
-function M.setup()
+--- @param _ 'line'
+--- @param winid integer
+--- @param bufnr integer
+--- @param row integer
+local function on_line(_, winid, bufnr, row)
+  local ctx = {
+    ns = ns,
+    winid = winid,
+    bufnr = bufnr,
+    row = row,
+    bcache = cache[bufnr],
+  }
+  for _, cb in ipairs(line_callbacks) do
+    cb(ctx)
+  end
+end
+
+M.setup = util.once(function()
+  -- Load default runtime subscribers here, not at module load, so requiring
+  -- manager stays cheap.
+  require('gitsigns.sign_renderer')
+  require('gitsigns.status')
+  require('gitsigns.deleted_preview')
+  require('gitsigns.word_diff')
+
+  api.nvim_create_augroup('gitsigns', { clear = false })
+
   -- Calling this before any await calls will stop nvim's intro messages being
   -- displayed
   api.nvim_set_decoration_provider(ns, {
-    on_win = function(_, winid, bufnr, topline, botline)
-      return on_win(winid, bufnr, topline, botline)
-    end,
-    on_line = function(_, _winid, bufnr, row)
-      if config.word_diff and config.diff_opts.internal then
-        apply_word_diff(bufnr, row)
-      end
-    end,
+    on_win = on_win,
+    on_line = on_line,
   })
 
+  -- These options change render output derived from cached hunks.
   Config.subscribe({ 'signcolumn', 'numhl', 'linehl', 'show_deleted', 'word_diff' }, function()
-    -- Remove all signs
-    M.reset_signs()
-
     for k, v in pairs(cache) do
       v:invalidate(true)
       M.update_sync_debounced(k)
@@ -488,17 +333,6 @@ function M.setup()
       end
       bcache:invalidate(true)
       M.update_sync_debounced(buf)
-    end,
-  })
-
-  api.nvim_create_autocmd('WinClosed', {
-    group = 'gitsigns',
-    callback = function(args)
-      local winid = tonumber(args.match)
-      if winid then
-        --- @cast winid integer
-        DeletedPreview.clear_win(winid)
-      end
     end,
   })
 
@@ -529,6 +363,8 @@ function M.setup()
       end,
     })
   end
-end
+
+  require('gitsigns.current_line_blame')
+end)
 
 return M

--- a/lua/gitsigns/sign_renderer.lua
+++ b/lua/gitsigns/sign_renderer.lua
@@ -1,0 +1,174 @@
+local api = vim.api
+
+local Config = require('gitsigns.config')
+local config = Config.config
+local Hunks = require('gitsigns.hunks')
+local manager = require('gitsigns.manager')
+local Signs = require('gitsigns.signs')
+
+local signs_normal = Signs.new()
+local signs_staged = Signs.new(true)
+
+local M = {}
+
+local statuscolumn_active = false
+
+--- @param bufnr? integer
+--- @param top? integer
+--- @param bot? integer
+local function redraw_statuscol(bufnr, top, bot)
+  if statuscolumn_active then
+    api.nvim__redraw({
+      buf = bufnr,
+      range = (top and bot) and { top, bot } or nil,
+      statuscolumn = true,
+    })
+  end
+end
+
+--- @param bufnr? integer
+--- @param lnum? integer
+--- @return string
+function M.statuscolumn(bufnr, lnum)
+  if bufnr == nil or bufnr == 0 then
+    bufnr = api.nvim_get_current_buf()
+  end
+  lnum = lnum or vim.v.lnum
+  statuscolumn_active = true
+
+  if not config._statuscolumn then
+    config.signcolumn = false
+    config._statuscolumn = true
+  end
+
+  local res = {} --- @type string[]
+  local res_len = 0
+  for _, signs in ipairs({ signs_normal, signs_staged }) do
+    local buf_signs = signs.signs[bufnr]
+    if buf_signs and next(buf_signs) then
+      local marks = api.nvim_buf_get_extmarks(
+        bufnr,
+        signs.ns,
+        { lnum - 1, 0 },
+        { lnum - 1, -1 },
+        {}
+      )
+      for _, mark in ipairs(marks) do
+        local id = mark[1]
+        local s = buf_signs[id]
+        if s then
+          vim.list_extend(res, { '%#' .. s[2] .. '#', s[1], '%*' })
+          --- @diagnostic disable-next-line: missing-parameter
+          res_len = res_len + vim.str_utfindex(s[1])
+        end
+      end
+    end
+  end
+  local pad = math.max(0, 2 - res_len)
+  return table.concat(res) .. string.rep(' ', pad)
+end
+
+--- @param bufnr integer
+--- @param signs Gitsigns.Signs
+--- @param hunks? Gitsigns.Hunk.Hunk[]
+--- @param top integer
+--- @param bot integer
+--- @param clear? boolean
+--- @param untracked boolean
+--- @param filter? fun(line: integer):boolean
+local function apply_hunk_signs(bufnr, signs, hunks, top, bot, clear, untracked, filter)
+  if clear then
+    signs:remove(bufnr)
+  end
+
+  hunks = hunks or {}
+
+  for i, hunk in ipairs(hunks) do
+    --- @type Gitsigns.Hunk.Hunk?, Gitsigns.Hunk.Hunk?
+    local prev_hunk, next_hunk = hunks[i - 1], hunks[i + 1]
+
+    -- To stop the sign column width changing too much, if there are signs to be
+    -- added but none of them are visible in the window, then make sure to add at
+    -- least one sign. Only do this on the first call after an update, when all
+    -- signs have been cleared.
+    if clear and i == 1 then
+      signs:add(
+        bufnr,
+        Hunks.calc_signs(prev_hunk, hunk, next_hunk, hunk.added.start, hunk.added.start, untracked),
+        filter
+      )
+    end
+
+    signs:add(bufnr, Hunks.calc_signs(prev_hunk, hunk, next_hunk, top, bot, untracked), filter)
+    if hunk.added.start > bot then
+      break
+    end
+  end
+end
+
+--- @param bufnr integer
+--- @param bcache Gitsigns.CacheEntry
+--- @param top integer
+--- @param bot integer
+--- @param clear? boolean
+local function apply_win(bufnr, bcache, top, bot, clear)
+  local untracked = bcache.git_obj.object_name == nil
+  apply_hunk_signs(bufnr, signs_normal, bcache.hunks, top, bot, clear, untracked)
+  apply_hunk_signs(bufnr, signs_staged, bcache.hunks_staged, top, bot, clear, false, function(lnum)
+    return not signs_normal:contains(bufnr, lnum)
+  end)
+  if clear then
+    redraw_statuscol(bufnr, top, bot)
+  end
+end
+
+function M.reset()
+  signs_normal:reset()
+  signs_staged:reset()
+end
+
+do -- Module-level activation
+  manager.on_lines(function(ctx)
+    signs_normal:on_lines(ctx.bufnr, ctx.first, ctx.last_orig, ctx.last_new)
+    signs_staged:on_lines(ctx.bufnr, ctx.first, ctx.last_orig, ctx.last_new)
+
+    -- Signs in changed regions get invalidated so we need to force a redraw if
+    -- any signs get removed.
+    if ctx.bcache.hunks and signs_normal:contains(ctx.bufnr, ctx.first, ctx.last_new) then
+      -- Force a sign redraw on the next update (fixes #521)
+      ctx.bcache.force_next_update = true
+    end
+
+    if ctx.bcache.hunks_staged and signs_staged:contains(ctx.bufnr, ctx.first, ctx.last_new) then
+      -- Force a sign redraw on the next update (fixes #521)
+      ctx.bcache.force_next_update = true
+    end
+  end)
+
+  manager.on_update(function(ctx)
+    apply_win(ctx.bufnr, ctx.bcache, vim.fn.line('w0'), vim.fn.line('w$'), true)
+  end)
+
+  manager.on_detach(function(bufnr, keep_signs)
+    if keep_signs then
+      return
+    end
+
+    signs_normal:remove(bufnr)
+    signs_staged:remove(bufnr)
+    redraw_statuscol(bufnr)
+  end)
+
+  manager.on_win(function(ctx)
+    if ctx.bcache and ctx.bcache.hunks then
+      apply_win(ctx.bufnr, ctx.bcache, ctx.topline + 1, ctx.botline + 1)
+    end
+    return false
+  end)
+
+  Config.subscribe({ 'signcolumn', 'numhl', 'linehl', 'show_deleted', 'word_diff' }, function()
+    M.reset()
+  end)
+end
+
+return M

--- a/lua/gitsigns/status.lua
+++ b/lua/gitsigns/status.lua
@@ -44,21 +44,31 @@ function M.update(bufnr, status)
   autocmd_update(bufnr)
 end
 
-function M.clear(bufnr)
-  if not api.nvim_buf_is_loaded(bufnr) then
-    return
-  end
+do -- Module-level activation
+  local manager = require('gitsigns.manager')
 
-  local b = vim.b[bufnr]
+  manager.on_update(function(ctx)
+    local summary = require('gitsigns.hunks').get_summary(ctx.bcache.hunks or {})
+    summary.head = ctx.bcache.git_obj.repo.abbrev_head
+    M.update(ctx.bufnr, summary)
+  end)
 
-  if b.gitsigns_head == nil and b.gitsigns_status_dict == nil and b.gitsigns_status == nil then
-    return
-  end
+  manager.on_detach(function(bufnr)
+    if not api.nvim_buf_is_loaded(bufnr) then
+      return
+    end
 
-  b.gitsigns_head = nil
-  b.gitsigns_status_dict = nil
-  b.gitsigns_status = nil
-  autocmd_update(bufnr)
+    local b = vim.b[bufnr]
+
+    if b.gitsigns_head == nil and b.gitsigns_status_dict == nil and b.gitsigns_status == nil then
+      return
+    end
+
+    b.gitsigns_head = nil
+    b.gitsigns_status_dict = nil
+    b.gitsigns_status = nil
+    autocmd_update(bufnr)
+  end)
 end
 
 return M

--- a/lua/gitsigns/word_diff.lua
+++ b/lua/gitsigns/word_diff.lua
@@ -1,0 +1,101 @@
+local api = vim.api
+
+local config = require('gitsigns.config').config
+local Hunks = require('gitsigns.hunks')
+local manager = require('gitsigns.manager')
+local util = require('gitsigns.util')
+
+local M = {}
+
+--- @param ctx Gitsigns.ManagerLine
+local function apply_word_diff(ctx)
+  if not (config.word_diff and config.diff_opts.internal) then
+    return
+  end
+
+  -- Don't run on folded lines.
+  if vim.fn.foldclosed(ctx.row + 1) ~= -1 then
+    return
+  end
+
+  local bcache = ctx.bcache
+  if not bcache then
+    return
+  end
+
+  local hunks = bcache.hunks
+  if not hunks then
+    return
+  end
+
+  local line = api.nvim_buf_get_lines(ctx.bufnr, ctx.row, ctx.row + 1, false)[1]
+  if not line then
+    return
+  end
+
+  local lnum = ctx.row + 1
+
+  local hunk = Hunks.find_hunk(lnum, hunks)
+  if not hunk then
+    return
+  end
+
+  if hunk.added.count ~= hunk.removed.count then
+    return
+  end
+
+  local pos = lnum - hunk.added.start + 1
+
+  local added_line = assert(hunk.added.lines[pos])
+  local removed_line = assert(hunk.removed.lines[pos])
+
+  local _, added_regions = require('gitsigns.diff_int').run_word_diff(
+    { removed_line },
+    { added_line }
+  )
+
+  local cols = #line
+
+  for _, region in ipairs(added_regions) do
+    local rtype, scol, ecol = region[2], region[3] - 1, region[4] - 1
+    if ecol == scol then
+      -- Make sure region is at least 1 column wide so deletes can be shown.
+      ecol = scol + 1
+    end
+
+    local hl_group = rtype == 'add' and 'GitSignsAddLnInline'
+      or rtype == 'change' and 'GitSignsChangeLnInline'
+      or 'GitSignsDeleteLnInline'
+
+    local opts = {
+      ephemeral = true,
+      priority = 1000,
+    }
+
+    if ecol > cols and ecol == scol + 1 then
+      -- Delete on last column, use virtual text instead.
+      opts.virt_text = { { ' ', hl_group } }
+      opts.virt_text_pos = 'overlay'
+    else
+      opts.end_col = ecol
+      opts.hl_group = hl_group
+    end
+
+    api.nvim_buf_set_extmark(ctx.bufnr, ctx.ns, ctx.row, scol, opts)
+    util.redraw({ buf = ctx.bufnr, range = { ctx.row, ctx.row + 1 } })
+  end
+end
+
+do -- Module-level activation
+  manager.on_win(function(ctx)
+    if not (config.word_diff and config.diff_opts.internal) then
+      return false
+    end
+    local bcache = ctx.bcache
+    return bcache ~= nil and bcache.hunks ~= nil
+  end)
+
+  manager.on_line(apply_word_diff)
+end
+
+return M

--- a/luafmt.toml
+++ b/luafmt.toml
@@ -1,0 +1,2 @@
+[emmy_doc]
+space_between_tag_columns = true


### PR DESCRIPTION
Split sign and word diff rendering out of manager. Manager now owns
buffer update orchestration and emits events to feature modules instead.

Move status, deleted preview, and current-line blame cleanup and update
behavior onto manager subscriptions, while keeping global highlight
setup eager.

Start manager runtime hooks from manager.setup() after a buffer passes
the attach gates. This keeps setup lean and avoids activating heavier
render subscribers for rejected buffers.

Assisted-by: Codex
