### PR TITLE
fix(blame): don't run blame on a closed git object

### DIFF
--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -143,6 +143,12 @@ function CacheEntry:run_blame(lnum, opts)
     or (not self.git_obj:from_tree() and not require('gitsigns.git.version').check(2, 41))
 
   while true do
+    -- The buffer may have been detached (and the git object closed) while an
+    -- earlier blame was in flight, leaving git_obj.repo nil. Bail out instead
+    -- of running blame against a closed object.
+    if self.git_obj:closed() then
+      return {}, {}
+    end
     local contents = send_contents and util.buf_lines(bufnr) or nil
     local tick = vim.b[bufnr].changedtick
     local lnum0 = api.nvim_buf_line_count(bufnr) > BLAME_THRESHOLD_LEN and lnum or nil

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -83,6 +83,11 @@ function Obj:close()
   self.repo = nil
 end
 
+--- @return boolean
+function Obj:closed()
+  return self._closed
+end
+
 function Obj:from_tree()
   return Repo.from_tree(self.revision)
 end

--- a/test/git_spec.lua
+++ b/test/git_spec.lua
@@ -281,4 +281,28 @@ describe('git', function()
     eq_path(submodule_worktree, result.info.toplevel)
     eq_path(submodule_gitdir, result.info.gitdir)
   end)
+
+  it('blame does not crash when the git object was closed (#1557)', function()
+    setup_test_repo()
+    helpers.setup_gitsigns(helpers.test_config)
+    helpers.edit(helpers.test_file)
+    helpers.wait_for_attach()
+
+    local result = exec_lua(function()
+      local async = require('gitsigns.async')
+      local bcache = assert(require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()])
+
+      -- Detaching closes the git object (sets repo = nil). A debounced blame
+      -- that was already in flight can still reach run_blame afterwards.
+      bcache.git_obj:close()
+
+      return async
+        .run(function()
+          return bcache:run_blame(1)
+        end)
+        :wait(5000)
+    end)
+
+    eq({}, result)
+  end)
 end)


### PR DESCRIPTION
Fixes #1557.

When a buffer is detached mid-session its git object is closed, which sets `repo` to nil. A current-line-blame update that was already queued through the debounce/async path can still reach `run_blame` afterwards and crash on `obj.repo.abbrev_head` at blame.lua:228. The cache blame loop now bails out when the git object is closed, the same way it already gives up when the buffer becomes invalid.

Added a regression test in git_spec that reproduces the crash (it raises the exact `attempt to index field 'repo'` error without the guard).