### PR TITLE
fix(emmylua): support analyzer 0.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ else
     EMMYLUA_ARCH ?= x64
 endif
 
-EMMYLUA_REF := 0.22.0
+EMMYLUA_REF := 0.23.2
 EMMYLUA_OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 EMMYLUA_RELEASE_URL_BASE := https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/$(EMMYLUA_REF)

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -64,10 +64,10 @@ local C = {}
 
 local C_meta = {} --- @type table<string, Gitsigns.CmdMeta>
 
---- @generic T
+--- @generic T, R
 --- @param callback? fun(err?: string)
---- @param func async fun(...:T...) # The async function to wrap
---- @return Gitsigns.async.Task
+--- @param func async fun(...:T...): R... # The async function to wrap
+--- @return Gitsigns.async.Task<R>
 local function async_run(callback, func, ...)
   assert(type(func) == 'function')
 

--- a/lua/gitsigns/actions/blame_line.lua
+++ b/lua/gitsigns/actions/blame_line.lua
@@ -56,12 +56,12 @@ local function get_blame_hunk(repo, info)
     i = assert(i_next or i_prev, 'no hunks in commit')
   end
 
-  hunk = assert(hunks[i])
+  local fallback_hunk = assert(hunks[i])
   return {
-    hunk = hunk,
+    hunk = fallback_hunk,
     index = i,
     total = #hunks,
-    guess_offset = hunk.added.start - info.orig_lnum,
+    guess_offset = fallback_hunk.added.start - info.orig_lnum,
     removed_source = removed_source,
     added_source = added_source,
   }

--- a/lua/gitsigns/actions/nav.lua
+++ b/lua/gitsigns/actions/nav.lua
@@ -133,7 +133,7 @@ function M.nav_hunk(direction, opts)
       if opts.navigation_message then
         api.nvim_echo({ { 'No more hunks', 'WarningMsg' } }, false, {})
       end
-      local _, col = vim.fn.getline(line):find('^%s*')
+      local _, col = (vim.fn.getline(line) --[[@as string]]):find('^%s*')
       --- @cast col -?
       api.nvim_win_set_cursor(0, { line, col })
       return
@@ -149,7 +149,7 @@ function M.nav_hunk(direction, opts)
 
   vim.cmd([[ normal! m' ]]) -- add current cursor position to the jump list
 
-  local _, col = vim.fn.getline(line):find('^%s*')
+  local _, col = (vim.fn.getline(line) --[[@as string]]):find('^%s*')
   --- @cast col -?
   api.nvim_win_set_cursor(0, { line, col })
 

--- a/lua/gitsigns/async.lua
+++ b/lua/gitsigns/async.lua
@@ -23,10 +23,10 @@ end
 local M = {}
 
 --- Weak table to keep track of running tasks
---- @type table<thread,Gitsigns.async.Task?>
+--- @type table<thread,Gitsigns.async.Task<any>?>
 local threads = setmetatable({}, { __mode = 'k' })
 
---- @return Gitsigns.async.Task?
+--- @return Gitsigns.async.Task<any>?
 local function running()
   --- @diagnostic disable-next-line: access-invisible
   local task = threads[assert(coroutine.running())]
@@ -65,11 +65,11 @@ Task.__index = Task
 
 --- @private
 --- @param func function
---- @return Gitsigns.async.Task
+--- @return Gitsigns.async.Task<any>
 function Task._new(func)
   local thread = coroutine.create(func)
 
-  --- @type Gitsigns.async.Task
+  --- @type Gitsigns.async.Task<any>
   local self = setmetatable({
     _closing = false,
     _thread = thread,
@@ -175,7 +175,7 @@ function Task:_traceback(msg, _lvl)
 
   local child = self._current_child
   if getmetatable(child) == Task then
-    --- @cast child Gitsigns.async.Task
+    --- @cast child Gitsigns.async.Task<any>
     msg = child:_traceback(msg, _lvl + 1)
   end
 
@@ -223,7 +223,6 @@ function Task:_finish(err, result)
 
   local errs = {} --- @type string[]
   for _, cb in pairs(self._callbacks) do
-    --- @type boolean
     local ok, cb_err = pcall(cb, err, unpack_len(result or {}))
     if not ok then
       errs[#errs + 1] = cb_err
@@ -368,7 +367,7 @@ end
 
 --- Returns the status of a task’s thread.
 ---
---- @param task? Gitsigns.async.Task
+--- @param task? Gitsigns.async.Task<any>
 --- @return 'running'|'suspended'|'normal'|'dead'?
 function M.status(task)
   task = task or running()
@@ -379,7 +378,7 @@ function M.status(task)
 end
 
 --- @async
---- @param task Gitsigns.async.Task
+--- @param task Gitsigns.async.Task<any>
 --- @return any ...
 local function await_task(task)
   --- @param callback fun(err?: string, ...: any)
@@ -440,7 +439,7 @@ end
 --- @async
 --- @overload fun(func: Gitsigns.async.CallbackFn): any ...
 --- @overload fun(argc: integer, func: Gitsigns.async.CallbackFn, ...:any): any ...
---- @overload fun(task: Gitsigns.async.Task): any ...
+--- @overload fun(task: Gitsigns.async.Task<any>): any ...
 function M.await(...)
   assert(running(), 'Not in async context')
 
@@ -493,11 +492,10 @@ function M.wrap(argc, func)
   end
 end
 
-if vim.schedule then
-  --- An async function that when called will yield to the Neovim scheduler to be
-  --- able to call the API.
-  M.schedule = M.wrap(1, vim.schedule)
-end
+--- An async function that when called will yield to the Neovim scheduler to be
+--- able to call the API.
+--- @type async fun()
+M.schedule = M.wrap(1, vim.schedule)
 
 do --- M.event()
   --- An event can be used to notify multiple tasks that some event has

--- a/lua/gitsigns/cache.lua
+++ b/lua/gitsigns/cache.lua
@@ -110,12 +110,23 @@ end)
 
 --- @async
 --- @private
-function CacheEntry:wait_for_hunks()
-  local loop_protect = 0
-  while not self.hunks and loop_protect < 10 do
-    loop_protect = loop_protect + 1
+--- @param staged? boolean
+--- @return boolean
+function CacheEntry:wait_for_hunks(staged)
+  if staged and not config.signs_staged_enable then
+    return false
+  end
+
+  local hunks_key = staged and 'hunks_staged' or 'hunks'
+
+  for _ = 1, 10 do
+    if self[hunks_key] ~= nil then
+      return true
+    end
     sleep(100)
   end
+
+  return self[hunks_key] ~= nil
 end
 
 -- If a file contains has up to this amount of lines, then
@@ -331,6 +342,10 @@ end
 --- @return Gitsigns.Hunk.Hunk?
 function CacheEntry:get_hunk(range, greedy, staged)
   local Hunks = require('gitsigns.hunks')
+
+  if not self:wait_for_hunks(staged) then
+    return
+  end
 
   local hunks = self:get_hunks(greedy, staged)
 

--- a/lua/gitsigns/diff_ext.lua
+++ b/lua/gitsigns/diff_ext.lua
@@ -1,6 +1,6 @@
 local Hunks = require('gitsigns.hunks')
 
-local scheduler = require('gitsigns.async').schedule
+local schedule = require('gitsigns.async').schedule
 local config = require('gitsigns.config').config
 local git_command = require('gitsigns.git.cmd')
 
@@ -28,8 +28,9 @@ function M.run_diff(text_cmp, text_buf)
   local results = {} --- @type Gitsigns.Hunk.Hunk[]
 
   -- tmpname must not be called in a callback
-  if vim.in_fast_event() then
-    scheduler()
+  local in_fast_event = vim.in_fast_event() --[[@as boolean]]
+  if in_fast_event then
+    schedule()
   end
 
   local file_buf = vim.fn.tempname()

--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -141,13 +141,14 @@ local function incremental_iter(readline, commits, result)
   then
     commit = vim.tbl_extend('force', commit, NOT_COMMITTED)
   end
-  commits[sha] = commit --[[@as Gitsigns.CommitInfo]]
+  local commit_info = commit --[[@as Gitsigns.CommitInfo]]
+  commits[sha] = commit_info
 
   for j = 0, size - 1 do
     result[final_lnum + j] = {
       final_lnum = final_lnum + j,
       orig_lnum = orig_lnum + j,
-      commit = commits[sha],
+      commit = commit_info,
       filename = filename,
       previous_filename = previous_filename,
       previous_sha = previous_sha,


### PR DESCRIPTION
The newer analyzer is stricter about task generics, Neovim API
return types, and casts through indexed values.

Bump the pinned EmmyLua release and tighten the affected LuaCATS
annotations so the checker can follow async task results, scheduler
usage, and blame/nav data without local type drift.

Assisted-by: Codex
