### PR TITLE
fix(highlight): skip topdelete line highlights

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -1221,11 +1221,6 @@ GitSignsChangedeleteLn
     Used for buffer line (when `config.linehl == true`) of 'changedelete' signs.
 
     Fallbacks: `GitSignsChangeLn`
-                                                        *hl-GitSignsTopdeleteLn*
-GitSignsTopdeleteLn
-    Used for buffer line (when `config.linehl == true`) of 'topdelete' signs.
-
-    Fallbacks: `GitSignsDeleteLn`
                                                         *hl-GitSignsUntrackedLn*
 GitSignsUntrackedLn
     Used for buffer line (when `config.linehl == true`) of 'untracked' signs.
@@ -1336,11 +1331,6 @@ GitSignsStagedChangedeleteLn
     Used for buffer line (when `config.linehl == true`) of 'changedelete' staged signs.
 
     Fallbacks: `GitSignsChangedeleteLn` (fg=50%)
-                                                        *hl-GitSignsStagedTopdeleteLn*
-GitSignsStagedTopdeleteLn
-    Used for buffer line (when `config.linehl == true`) of 'topdelete' staged signs.
-
-    Fallbacks: `GitSignsTopdeleteLn` (fg=50%)
                                                         *hl-GitSignsStagedUntrackedLn*
 GitSignsStagedUntrackedLn
     Used for buffer line (when `config.linehl == true`) of 'untracked' staged signs.

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -30,7 +30,7 @@ local function gen_hl(staged, kind, ty)
   local cty = capitalise(ty)
   local hl = ('GitSigns%s%s%s'):format(staged and 'Staged' or '', cty, kind)
 
-  if kind == 'Ln' and (ty == 'delete' or 'ty' == 'topdelete') then
+  if kind == 'Ln' and (ty == 'delete' or ty == 'topdelete') then
     return
   end
 

--- a/test/highlights_spec.lua
+++ b/test/highlights_spec.lua
@@ -5,6 +5,7 @@ local clear = helpers.clear
 local command = helpers.api.nvim_command
 
 local cleanup = helpers.cleanup
+local exec_lua = helpers.exec_lua
 local test_config = helpers.test_config
 local expectf = helpers.expectf
 local match_dag = helpers.match_dag
@@ -82,6 +83,35 @@ describe('highlights', function()
     command('set termguicolors')
     config.linehl = true
     setup_gitsigns(config)
+  end)
+
+  it('does not define line highlights for delete-only signs', function()
+    helpers.setup_path()
+
+    local generated = exec_lua(function()
+      package.loaded['gitsigns.highlight'] = nil
+
+      local unwanted = {
+        GitSignsDeleteLn = true,
+        GitSignsTopdeleteLn = true,
+        GitSignsStagedDeleteLn = true,
+        GitSignsStagedTopdeleteLn = true,
+      }
+      local found = {} --- @type string[]
+
+      for _, entry in ipairs(require('gitsigns.highlight').hls) do
+        for name in pairs(entry) do
+          if unwanted[name] then
+            found[#found + 1] = name
+          end
+        end
+      end
+
+      table.sort(found)
+      return found
+    end)
+
+    eq({}, generated)
   end)
 
   it('get_temp_hl handles equal min/max', function()


### PR DESCRIPTION
The line-highlight generator meant to skip delete-style signs because
those signs do not map to changed buffer lines. A typo compared the
literal string "ty" instead of the sign type, so topdelete line
highlight groups were still generated and documented.

Compare the actual sign type, add a regression test, and update
generated help so topdelete matches delete.

Assisted-by: Codex
