### PR TITLE
Allow 2 count characters and show count character options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,21 +156,22 @@ with most of the default settings:
 ```lua
 require('gitsigns').setup {
   signs = {
-    add          = { text = '┃' },
-    change       = { text = '┃' },
-    delete       = { text = '_' },
-    topdelete    = { text = '‾' },
-    changedelete = { text = '~' },
-    untracked    = { text = '┆' },
+    add          = { text = '┃', show_count = false },
+    change       = { text = '┃', show_count = false },
+    delete       = { text = '_', show_count = false },
+    topdelete    = { text = '‾', show_count = false },
+    changedelete = { text = '~', show_count = false },
+    untracked    = { text = '┆', show_count = false },
   },
   signs_staged = {
-    add          = { text = '┃' },
-    change       = { text = '┃' },
-    delete       = { text = '_' },
-    topdelete    = { text = '‾' },
-    changedelete = { text = '~' },
-    untracked    = { text = '┆' },
+    add          = { text = '┃', show_count = false },
+    change       = { text = '┃', show_count = false },
+    delete       = { text = '_', show_count = false },
+    topdelete    = { text = '‾', show_count = false },
+    changedelete = { text = '~', show_count = false },
+    untracked    = { text = '┆', show_count = false },
   },
+  count_chars = { "1", "2", "3", "4", "5", "6", "7", "8", "9", ["+"] = ">" },
   signs_staged_enable = true,
   signcolumn = true,  -- Toggle with `:Gitsigns toggle_signs`
   numhl      = false, -- Toggle with `:Gitsigns toggle_numhl`

--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -32,21 +32,22 @@ with most of the default settings:
 >lua
     require('gitsigns').setup {
       signs = {
-        add          = { text = '┃' },
-        change       = { text = '┃' },
-        delete       = { text = '_' },
-        topdelete    = { text = '‾' },
-        changedelete = { text = '~' },
-        untracked    = { text = '┆' },
+        add          = { text = '┃', show_count = false },
+        change       = { text = '┃', show_count = false },
+        delete       = { text = '_', show_count = false },
+        topdelete    = { text = '‾', show_count = false },
+        changedelete = { text = '~', show_count = false },
+        untracked    = { text = '┆', show_count = false },
       },
       signs_staged = {
-        add          = { text = '┃' },
-        change       = { text = '┃' },
-        delete       = { text = '_' },
-        topdelete    = { text = '‾' },
-        changedelete = { text = '~' },
-        untracked    = { text = '┆' },
+        add          = { text = '┃', show_count = false },
+        change       = { text = '┃', show_count = false },
+        delete       = { text = '_', show_count = false },
+        topdelete    = { text = '‾', show_count = false },
+        changedelete = { text = '~', show_count = false },
+        untracked    = { text = '┆', show_count = false },
       },
+      count_chars = { "1", "2", "3", "4", "5", "6", "7", "8", "9", ["+"] = ">" },
       signs_staged_enable = true,
       signcolumn = true,  -- Toggle with `:Gitsigns toggle_signs`
       numhl      = false, -- Toggle with `:Gitsigns toggle_numhl`

--- a/lua/gitsigns/signs.lua
+++ b/lua/gitsigns/signs.lua
@@ -106,7 +106,11 @@ function M:add(bufnr, signs, filter)
       if config.signcolumn and cs.show_count and sign.count then
         local cc = config.count_chars
         local count_char = cc[sign.count] or cc['+'] or ''
-        text = text .. count_char
+        if vim.fn.strdisplaywidth(count_char) > 1 then
+          text = count_char
+        else
+          text = text .. count_char
+        end
       end
 
       local sign_hl_group = self:hl(ty, 'hl')


### PR DESCRIPTION
## [feat] Allow 2 columns of count chars

Only 2 columns of sign chars are allowed by nvim. It makes sense to allow users to utilize both of these. Generally, for a diff where the count matters, the very first sign char (like `+`) isn't that important since the whole section will be marked with sign chars. For this reason, it makes sense to allow the use of that first char on the first line for another purpose.

For example, the UI might look like this normally if there are 3 lines changed

```
+3
+
+
```

I would argue that the first `+` is not strictly needed since the `3` is there and will also be subject to the same highlight group.

If there are 13 lines changed, the UI looks like this

```
+>
+
+
+
+
+
+
+
+
+
+
+
+
```

Notice that there is not enough space for the number `13`, meaning the best we can do is `+>`.

This pull request allows 2-digit `count_chars` entries, which end up looking like this

```
13
+
+
+
+
+
+
+
+
+
+
+
+
```

It's a little bit better since it allows for **proper counts on diffs of up to 99 lines**, not just 9 lines.

## [docs] Add `show_count` and `count_chars` options to README

 These options are documented in the docs, but are not in the README. Most users will look for configuration and settings in the README for a quick glance at what's available. It's nice to mention the settings there, even if they are already explained in the docs.