### PR TITLE
Added sorting to CLI and removed unwrapped commands

### DIFF
--- a/lua/gitsigns/cli.lua
+++ b/lua/gitsigns/cli.lua
@@ -8,7 +8,7 @@ local log = require('gitsigns.debug.log')
 local message = require('gitsigns.message')
 
 --- @type table<string,function>[]
-local sources = { actions, attach, Debug }
+local sources = { actions, Debug }
 
 --- try to parse each argument as a lua boolean, nil or number, if fails then
 --- keep argument as a string:
@@ -55,6 +55,7 @@ function M.complete(arglead, line)
       return cmp_func(arglead, line)
     end
   end
+  table.sort(matches)
   return matches
 end
 


### PR DESCRIPTION
Currently, main has a tab completion that looks like this, which includes two copies of attach, detach, and detach_all: 
<img width="25%" height="25%" alt="image" src="https://github.com/user-attachments/assets/b6b7823c-5cf5-4cda-9db1-62c2014b076e" />

This change removes the unwrapped versions of attach, detach, and detach_all, and sorts tab completion alphabetically.