### PR TITLE
fix(cli): sort completions and drop unwrapped commands

### DIFF
--- a/lua/gitsigns/cli.lua
+++ b/lua/gitsigns/cli.lua
@@ -2,13 +2,12 @@ local actions = require('gitsigns.actions')
 local argparse = require('gitsigns.cli.argparse')
 local cmdline = require('gitsigns.cli.context')
 local async = require('gitsigns.async')
-local attach = require('gitsigns.attach')
 local Debug = require('gitsigns.debug')
 local log = require('gitsigns.debug.log')
 local message = require('gitsigns.message')
 
 --- @type table<string,function>[]
-local sources = { actions, attach, Debug }
+local sources = { actions, Debug }
 
 --- try to parse each argument as a lua boolean, nil or number, if fails then
 --- keep argument as a string:
@@ -55,6 +54,7 @@ function M.complete(arglead, line)
       return cmp_func(arglead, line)
     end
   end
+  table.sort(matches)
   return matches
 end
 

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -209,6 +209,45 @@ describe('actions', function()
     eq({ 'true', 'false', 'nil' }, complete('', 'Gitsigns toggle_signs '))
   end)
 
+  it('sorts subcommand completion', function()
+    local subcmds = complete('', 'Gitsigns ')
+    assert(#subcmds > 0, 'expected some subcommand completions')
+
+    local sorted = vim.deepcopy(subcmds)
+    table.sort(sorted)
+    eq(sorted, subcmds)
+
+    eq({ 'debug_messages', 'detach', 'detach_all' }, complete('de', 'Gitsigns de'))
+    eq({
+      'toggle_current_line_blame',
+      'toggle_deleted',
+      'toggle_linehl',
+      'toggle_numhl',
+      'toggle_signs',
+      'toggle_word_diff',
+    }, complete('toggle', 'Gitsigns toggle'))
+  end)
+
+  it('does not complete unwrapped commands', function()
+    local subcmds = complete('', 'Gitsigns ')
+
+    -- `attach`, `detach` and `detach_all` are exposed by both `gitsigns.attach`
+    -- and `gitsigns.actions`. Only the wrapped `gitsigns.actions` variants are
+    -- completed, so each is offered exactly once.
+    local counts = {} --- @type table<string,integer>
+    for _, name in ipairs(subcmds) do
+      counts[name] = (counts[name] or 0) + 1
+    end
+
+    for _, name in ipairs({ 'attach', 'detach', 'detach_all' }) do
+      eq(1, counts[name], ('expected %s to be completed exactly once'):format(name))
+    end
+
+    for name, count in pairs(counts) do
+      assert(count == 1, ('duplicate subcommand completion: %s'):format(name))
+    end
+  end)
+
   it('parses named flag assignments', function()
     local result = exec_lua(function()
       local parse_args = require('gitsigns.cli.argparse').parse_args


### PR DESCRIPTION
Currently, main has a tab completion that looks like this, which includes two copies of attach, detach, and detach_all:
<img width="280" height="893" alt="image" src="https://github.com/user-attachments/assets/2b01f999-23fe-4ab9-8601-44d71efd572c" />

This change removes the unwrapped versions of attach, detach, and detach_all, and sorts tab completion alphabetically.