### PR TITLE
fix(qflist): include nested untracked files

### DIFF
--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -383,7 +383,12 @@ function M:files_changed(base, include_untracked)
     return ret
   end
 
-  local results = self:command({ 'status', '--porcelain', '--ignore-submodules' })
+  local results = self:command(util.flatten({
+    'status',
+    '--porcelain',
+    '--ignore-submodules',
+    include_untracked and '--untracked-files=all',
+  }))
 
   for _, line in ipairs(results) do
     local status = line:sub(1, 2)

--- a/test/qflist_spec.lua
+++ b/test/qflist_spec.lua
@@ -94,4 +94,28 @@ describe('qflist', function()
       eq(true, texts[1]:match('^Removed') ~= nil)
     end)
   end)
+
+  it('includes untracked files inside untracked directories in setqflist all', function()
+    setup_test_repo()
+    command('cd ' .. scratch)
+    setup_gitsigns(test_config)
+
+    local untracked = scratch .. '/newdir/untracked.lua'
+    helpers.write_to_file(untracked, { 'untracked' })
+
+    exec_lua(function()
+      require('gitsigns.actions').setqflist('all', { open = false })
+    end)
+
+    helpers.expectf(function()
+      local names = exec_lua(function()
+        return vim.tbl_map(function(item)
+          return item.filename or vim.api.nvim_buf_get_name(item.bufnr)
+        end, vim.fn.getqflist())
+      end) --- @type string[]
+
+      eq(1, #names)
+      eq_path(untracked, names[1])
+    end)
+  end)
 end)


### PR DESCRIPTION
Git status normally collapses wholly untracked directories. This makes
setqflist("all") discard the directory entry instead of inspecting the
files.

Request all untracked files when attach_to_untracked is enabled. Add a
regression test for files inside new directories.

Resolves #1551

Assisted-by: Codex
