### PR TITLE
fix(change_base): handle files missing from revision

### DIFF
--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -734,11 +734,16 @@ end
 --- @async
 --- @param bcache Gitsigns.CacheEntry
 --- @param base string?
+--- @return string? err
 local function update_buf_base(bcache, base)
-  bcache.file_mode = base == 'FILE'
-  if not bcache.file_mode then
-    bcache.git_obj:change_revision(base)
+  local file_mode = base == 'FILE'
+  if not file_mode then
+    local err = bcache.git_obj:change_revision(base)
+    if err then
+      return err
+    end
   end
+  bcache.file_mode = file_mode
   bcache:invalidate(true)
   update(bcache.bufnr)
 end
@@ -788,11 +793,13 @@ function M.change_base(base, global, callback)
     base = util.norm_base(base)
 
     if global then
-      config.base = base
-
       for _, bcache in pairs(cache) do
-        update_buf_base(bcache, base)
+        local err = update_buf_base(bcache, base)
+        if err then
+          error(err)
+        end
       end
+      config.base = base
     else
       local bufnr = current_buf()
       local bcache = cache[bufnr]
@@ -800,7 +807,10 @@ function M.change_base(base, global, callback)
         return
       end
 
-      update_buf_base(bcache, base)
+      local err = update_buf_base(bcache, base)
+      if err then
+        error(err)
+      end
     end
   end)
 end

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -18,8 +18,10 @@ M.Repo = Repo
 --- Revision the object is tracking against. Nil for index
 --- @field revision? string
 ---
---- The fixed object name to use. Nil for untracked.
+--- The base object name, or the index object when the selected base is missing.
+--- Nil for untracked.
 --- @field object_name? string
+--- @field object_missing? true File is missing from the selected revision
 ---
 --- The path of the file relative to toplevel. Used to
 --- perform git operations. Nil if file does not exist
@@ -39,11 +41,35 @@ Obj.__index = Obj
 M.Obj = Obj
 
 --- @async
+--- @param self Gitsigns.GitObj
+--- @param revision string?
+--- @return string? err
+local function refresh(self, revision)
+  local info, err = self.repo:file_info(self.file, revision)
+
+  if err then
+    log.eprint(err)
+  end
+
+  if not info then
+    return err
+  end
+
+  self.revision = revision
+  self.relpath = info.relpath
+  self.object_name = info.object_name
+  self.object_missing = info.object_missing
+  self.mode_bits = info.mode_bits
+  self.has_conflicts = info.has_conflicts
+  self.i_crlf = info.i_crlf
+  self.w_crlf = info.w_crlf
+end
+
+--- @async
 --- @param revision? string
 --- @return string? err
 function Obj:change_revision(revision)
-  self.revision = util.norm_base(revision)
-  return self:refresh()
+  return refresh(self, util.norm_base(revision))
 end
 
 --- @async
@@ -55,22 +81,7 @@ end
 --- @async
 --- @return string? err
 function Obj:refresh()
-  local info, err = self.repo:file_info(self.file, self.revision)
-
-  if err then
-    log.eprint(err)
-  end
-
-  if not info then
-    return err
-  end
-
-  self.relpath = info.relpath
-  self.object_name = info.object_name
-  self.mode_bits = info.mode_bits
-  self.has_conflicts = info.has_conflicts
-  self.i_crlf = info.i_crlf
-  self.w_crlf = info.w_crlf
+  return refresh(self, self.revision)
 end
 
 function Obj:close()
@@ -103,8 +114,8 @@ function Obj:get_show_text(revision, relpath)
     return {}
   end
 
-  if not revision and not self.object_name then
-    log.dprint('no revision or object_name')
+  if not revision and (self.object_missing or not self.object_name) then
+    log.dprint('no base object')
     return { '' }
   end
 
@@ -293,6 +304,7 @@ function Obj.new(file, revision, encoding, gitdir, toplevel)
 
   self.relpath = info.relpath
   self.object_name = info.object_name
+  self.object_missing = info.object_missing
   self.mode_bits = info.mode_bits
   self.has_conflicts = info.has_conflicts
   self.i_crlf = info.i_crlf

--- a/lua/gitsigns/git/blame.lua
+++ b/lua/gitsigns/git/blame.lua
@@ -226,11 +226,10 @@ end
 function M.run_blame(obj, contents, lnum, revision, opts)
   local ret = {} --- @type table<integer,Gitsigns.BlameInfo>
 
-  if not obj.object_name or obj.repo.abbrev_head == '' then
-    assert(contents, 'contents must be provided for untracked files')
-    -- As we support attaching to untracked files we need to return something if
-    -- the file isn't isn't tracked in git.
-    -- If abbrev_head is empty, then assume the repo has no commits
+  if obj.object_missing or not obj.object_name or obj.repo.abbrev_head == '' then
+    assert(contents, 'contents must be provided for files without a base object')
+    -- Untracked files and files missing from the selected revision have no
+    -- blame source, so report their contents as uncommitted.
     local commit = not_committed(obj.file)
     for i in ipairs(contents) do
       ret[i] = {

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -754,7 +754,8 @@ function M:ls_tree(path, revision)
       return self:ls_tree(old_path, revision)
     end
 
-    return nil, ('%s not found in %s'):format(path, revision)
+    -- The revision is valid but may predate the file.
+    return
   end
 
   local info, relpath = unpack(vim.split(res, '\t'))
@@ -774,6 +775,7 @@ end
 --- @field relpath? string nil if file is not in working tree
 --- @field mode_bits? string
 --- @field object_name? string nil if file is untracked
+--- @field object_missing? true File is missing from the selected revision
 --- @field i_crlf? boolean (requires git version >= 2.9)
 --- @field w_crlf? boolean (requires git version >= 2.9)
 --- @field has_conflicts? true
@@ -869,6 +871,18 @@ function M:file_info(file, revision)
         mode_bits = info.mode_bits,
         object_name = info.object_name,
       }
+    end
+
+    if not info then
+      local worktree_info, err2 = self:ls_files(file)
+      if err2 or not worktree_info or not worktree_info.relpath then
+        return nil, err2
+      end
+
+      -- Keep current path metadata for tracked-file handling, but mark the
+      -- selected base as empty.
+      worktree_info.object_missing = true
+      return worktree_info
     end
   else
     return self:ls_files(file)

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -764,6 +764,109 @@ describe('gitsigns (with screen)', function()
         signs = { added = 1 },
       })
     end)
+
+    it('treats a file missing at the base as added', function()
+      setup_test_repo()
+      write_to_file(newfile, { 'line one', 'line two' })
+      git('add', newfile)
+      git('commit', '-m', 'add new file')
+
+      setup_gitsigns(config)
+      edit(newfile)
+
+      check({
+        status = { head = 'main', added = 0, changed = 0, removed = 0 },
+        signs = {},
+      })
+
+      command('Gitsigns change_base HEAD~1')
+
+      check({
+        status = { head = 'main', added = 2, changed = 0, removed = 0 },
+        signs = { added = 2 },
+      })
+
+      local sha = exec_lua(function()
+        local async = require('gitsigns.async')
+        return async
+          .run(function()
+            local bcache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+            local git_obj = bcache.git_obj
+            local blame = git_obj:run_blame(
+              vim.api.nvim_buf_get_lines(0, 0, -1, false),
+              nil,
+              git_obj.revision,
+              {}
+            )
+            return blame[1].commit.sha
+          end)
+          :wait(5000)
+      end)
+      eq(string.rep('0', 40), sha)
+    end)
+
+    it('attaches to a file missing at the configured base', function()
+      setup_test_repo()
+      write_to_file(newfile, { 'line one', 'line two' })
+      git('add', newfile)
+      git('commit', '-m', 'add new file')
+
+      config.base = 'HEAD~1'
+      setup_gitsigns(config)
+      edit(newfile)
+
+      check({
+        status = { head = 'main', added = 2, changed = 0, removed = 0 },
+        signs = { added = 2 },
+      })
+    end)
+
+    it('preserves the current base when the new revision is invalid', function()
+      setup_test_repo()
+      edit(test_file)
+      feed('oEDIT<esc>')
+      command('write')
+      git('add', test_file)
+      git('commit', '-m', 'commit on main')
+
+      setup_gitsigns(config)
+      check({
+        status = { head = 'main', added = 0, changed = 0, removed = 0 },
+        signs = {},
+      })
+      command('Gitsigns change_base HEAD~1')
+
+      check({
+        status = { head = 'main', added = 1, changed = 0, removed = 0 },
+        signs = { added = 1 },
+      })
+
+      local err = exec_lua(function()
+        local async = require('gitsigns.async')
+        return async
+          .run(function()
+            return async.await(
+              3,
+              require('gitsigns').change_base,
+              '__gitsigns_missing_ref__',
+              false
+            )
+          end)
+          :wait(5000)
+      end)
+
+      eq(true, err:find('__gitsigns_missing_ref__', 1, true) ~= nil)
+      eq(
+        'HEAD~1',
+        exec_lua(
+          "return require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()].git_obj.revision"
+        )
+      )
+      check({
+        status = { head = 'main', added = 1, changed = 0, removed = 0 },
+        signs = { added = 1 },
+      })
+    end)
   end)
 
   local function testsuite(internal_diff)


### PR DESCRIPTION
Treat a tracked file that is absent from the selected base revision as
an empty base rather than failing to attach. Preserve the current base
when a new revision is invalid, and report missing-base blame as
uncommitted.

Resolves #1524

Assisted-by: Codex
