### PR TITLE
fix(config): parse diffopt across Neovim versions

### DIFF
--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -152,7 +152,7 @@ local function parse_diffopt()
     iwhiteall = 'ignore_whitespace',
   }
 
-  local diffopt = vim.opt.diffopt:get() --[[@as string[] ]]
+  local diffopt = vim.split(vim.o.diffopt, ',', { plain = true })
   for _, o in ipairs(diffopt) do
     if optmap[o] then
       r[optmap[o]] = true

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -681,6 +681,19 @@ describe('gitsigns (with screen)', function()
   end)
 
   describe('configuration', function()
+    it('reads defaults from diffopt', function()
+      helpers.setup_path()
+      command('set diffopt=internal,indent-heuristic,algorithm:histogram,linematch:30')
+
+      eq({
+        algorithm = 'histogram',
+        indent_heuristic = true,
+        internal = true,
+        linematch = 30,
+        vertical = true,
+      }, exec_lua("return require('gitsigns.config').config.diff_opts"))
+    end)
+
     it('validates union-typed fields', function()
       helpers.setup_path()
 


### PR DESCRIPTION
Neovim now exposes comma-list options as a map through vim.opt. This
caused the iterator to skip diffopt entries and disabled the internal
diff by default.

Read the raw option string before splitting it so parsing stays stable
across Neovim versions. Add coverage for boolean and keyed options.

Assisted-by: Codex
