### PR TITLE
fix(git): resolve the working tree of a linked worktree gitdir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     env:
       NVIM_TEST_VERSION: ${{ matrix.neovim_branch }}
       GITSIGNS_TEST_ALLOW_FS_POLL_FALLBACK: '0'
+      GITSIGNS_TEST_TRACE: '1'
 
     steps:
       - name: Checkout
@@ -180,7 +181,16 @@ jobs:
       - name: Run Test
         if: matrix.setup == 'windows-msys2'
         shell: msys2 {0}
+        # Below the job timeout, so a wedged run still reaches the log step.
+        timeout-minutes: 7
         run: make test
+
+      # A wedged editor produces no test output at all, so the Nvim log is the
+      # only record of why. It is not printed by the runner.
+      - name: Nvim log
+        if: failure() || cancelled()
+        shell: bash
+        run: cat .nvimlog || true
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
             os: ubuntu-latest
             neovim_branch: 'v0.12.0'
             setup: linux
+          # `util.cygpath` only awaits under MSYS, so the yield-from-callback
+          # bugs it exposes are invisible on Linux. Force it on one leg.
+          - name: test linux (v0.12.0, cygpath await)
+            os: ubuntu-latest
+            neovim_branch: 'v0.12.0'
+            setup: linux
+            force_cygpath_await: '1'
           - name: test linux (nightly)
             os: ubuntu-latest
             neovim_branch: 'nightly'
@@ -76,6 +83,7 @@ jobs:
       NVIM_TEST_VERSION: ${{ matrix.neovim_branch }}
       GITSIGNS_TEST_ALLOW_FS_POLL_FALLBACK: '0'
       GITSIGNS_TEST_TRACE: '1'
+      GITSIGNS_TEST_FORCE_CYGPATH_AWAIT: ${{ matrix.force_cygpath_await || '0' }}
 
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,18 @@ $(NVIM_TEST):
 
 FILTER ?= .*
 
+# A wedged editor blocks the runner inside an RPC request that never returns,
+# so the suite emits nothing further and only an external kill ends it. Bound
+# it here: SIGABRT first, for a stack rather than silence.
+TEST_TIMEOUT ?= 300
+TIMEOUT := $(shell command -v timeout 2>/dev/null)
+ifneq ($(TIMEOUT),)
+  TEST_RUNNER := $(TIMEOUT) --signal=ABRT --kill-after=30 $(TEST_TIMEOUT)
+endif
+
 .PHONY: test
 test: nvim-test
-	$(NVIM_TEST)/bin/nvim-test test \
+	$(TEST_RUNNER) $(NVIM_TEST)/bin/nvim-test test \
 		--helper=$(PWD)/test/preload.lua \
 		--lpath=$(PWD)/lua/?.lua \
 		--verbose \

--- a/lua/gitsigns/config.lua
+++ b/lua/gitsigns/config.lua
@@ -111,6 +111,7 @@ local validate = require('gitsigns.util').validate
 --- @field _verbose boolean
 --- @field _test_mode boolean
 --- @field _allow_fs_poll_fallback boolean
+--- @field _force_cygpath_await boolean
 --- @field _new_sign_calc boolean
 --- @field _update_lock boolean
 --- @field _commit_maps boolean
@@ -849,6 +850,12 @@ M.schema = {
     description = 'Allow watch_gitdir to fall back to fs_poll',
     type = 'boolean',
     default = true,
+  },
+
+  _force_cygpath_await = {
+    description = 'Make `util.cygpath` await, as it does under MSYS',
+    type = 'boolean',
+    default = false,
   },
 
   word_diff = {

--- a/lua/gitsigns/debounce.lua
+++ b/lua/gitsigns/debounce.lua
@@ -126,8 +126,14 @@ function M.throttle_async(opts, fn)
     while scheduled[id] do
       scheduled[id] = nil
       running[id] = true
-      fn(...)
+      -- Clear the flag even if `fn` raises. Leaving it set makes every later
+      -- call return early, so the throttled function stops running for good
+      -- and whatever waits on it waits forever.
+      local ok, err = pcall(fn, ...)
       running[id] = nil
+      if not ok then
+        error(err, 0)
+      end
     end
   end
 end

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -151,7 +151,7 @@ end
 
 --- @async
 function Obj:unstage_file()
-  self.repo:command({ 'reset', self.file })
+  self.repo:command({ 'reset', '--', self.repo:relpathspec(self.file) })
   autocmd_changed(self.file)
 end
 
@@ -175,7 +175,7 @@ function Obj:ensure_file_in_index()
 
   if not self.object_name then
     -- If there is no object_name then it is not yet in the index so add it
-    self.repo:command({ 'add', '--intent-to-add', self.file })
+    self.repo:command({ 'add', '--intent-to-add', '--', self.repo:relpathspec(self.file) })
   else
     -- Update the index with the common ancestor (stage 1) which is what bcache
     -- stores

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -590,6 +590,25 @@ local function normalize_path(path)
   return vim.fs.normalize(path)
 end
 
+--- Working tree for a gitdir, when it can't be discovered from the cwd.
+--- @async
+--- @param gitdir string
+--- @return string
+local function get_worktree(gitdir)
+  -- A linked worktree's GIT_DIR may be set to `.git/worktrees/<name>/`.
+  -- The gitdir file contains the path to the working tree.
+  -- https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables
+  local dotgit = read_first_line(Path.join(gitdir, 'gitdir'))
+  if dotgit then
+    -- `worktree.useRelativePaths` stores this relative to gitdir.
+    if not Path.is_abs(dotgit) then
+      dotgit = Path.join(gitdir, dotgit)
+    end
+    return vim.fs.dirname(assert(normalize_path(dotgit)))
+  end
+  return vim.fs.dirname(gitdir)
+end
+
 --- @async
 --- @param gitdir string
 --- @param head_str string
@@ -648,7 +667,7 @@ function M.get_info(dir, gitdir, worktree)
     if core_worktree then
       worktree = Path.is_abs(core_worktree) and core_worktree or Path.join(gitdir, core_worktree)
     else
-      worktree = vim.fs.dirname(gitdir)
+      worktree = get_worktree(gitdir)
     end
   end
 

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -590,6 +590,40 @@ local function normalize_path(path)
   return vim.fs.normalize(path)
 end
 
+--- Make `path` relative to the worktree, for use as a git pathspec:
+--- `<toplevel>/src/x.lua` -> `src/x.lua`. Equivalent because `command()`
+--- runs with `cwd` set to the toplevel.
+---
+--- Absolute paths are avoided because MSYS git rewrites them (`D:/x` ->
+--- `/d/x`), which then fails to match the `--work-tree` passed for linked
+--- worktrees, and git reports the file as outside the repository.
+--- @async
+--- @param path string
+--- @return string
+function M:relpathspec(path)
+  if not Path.is_abs(path) then
+    return path
+  end
+
+  local norm = vim.fs.normalize(path)
+
+  -- `toplevel` is in mixed form (`D:/x`) but paths reaching here may be in
+  -- MSYS form (`/d/x`), so compare against both. Rewrite rather than calling
+  -- `cygpath`: that spawns a process, and it blocks on paths that don't exist
+  -- yet, which is every not-yet-written buffer.
+  local drive, rest = self.toplevel:match('^(%a):/(.*)$')
+  local msys = drive and ('/' .. drive:lower() .. '/' .. rest)
+
+  for _, top in ipairs({ self.toplevel, msys }) do
+    if top and vim.startswith(norm, top .. '/') then
+      return norm:sub(#top + 2)
+    end
+  end
+
+  -- Outside the worktree: leave it for git to reject (see `ls_files`).
+  return path
+end
+
 --- Working tree for a gitdir, when it can't be discovered from the cwd.
 --- @async
 --- @param gitdir string
@@ -760,7 +794,8 @@ function M:ls_tree(path, revision)
   local results, stderr, code = self:command({
     'ls-tree',
     revision,
-    path,
+    '--',
+    self:relpathspec(path),
   }, { ignore_error = true })
 
   if code > 0 then
@@ -822,7 +857,8 @@ function M:ls_files(file)
       '--others',
       '--exclude-standard',
       has_eol and '--eol',
-      file,
+      '--',
+      self:relpathspec(file),
     }),
     { ignore_error = true }
   )

--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -255,6 +255,7 @@ local function get_head_oid0(gitdir, commondir)
 end
 
 --- Manual implementation of `git rev-parse HEAD` with command fallback.
+--- @async
 --- @param gitdir string
 --- @param commondir string
 --- @return string? oid
@@ -266,9 +267,8 @@ local function get_head_oid(gitdir, commondir)
 
   log.dprintf('Falling back to `git rev-parse HEAD`: %s', err)
 
-  local stdout, stderr, code = async
-    .run(git_command, { '--git-dir', gitdir, 'rev-parse', 'HEAD' }, { ignore_error = true })
-    :wait()
+  local stdout, stderr, code =
+    git_command({ '--git-dir', gitdir, 'rev-parse', 'HEAD' }, { ignore_error = true })
 
   local oid = stdout[1]
 
@@ -513,25 +513,40 @@ function M._new(info)
         return
       end
 
-      self.head_oid = get_head_oid(self.gitdir, self.commondir)
-      -- Set abbrev_head to empty string if head_oid is unavailable (.e.g repo
-      -- with no commits). This is consistent with `git rev-parse --abrev-ref
-      -- HEAD` which returns "HEAD" in this case.
-      local abbrev_head = self.head_oid and get_abbrev_head(self.gitdir, head2) or ''
-      if self.abbrev_head ~= abbrev_head then
-        self.abbrev_head = abbrev_head
-        log.dprintf('HEAD changed, updating abbrev_head to %s', self.abbrev_head)
-      end
-
-      local head_ref = parse_head_ref(head2)
-      if self.head_ref ~= head_ref then
-        self.head_ref = head_ref
-        self._watcher:set_head_ref(self.head_ref)
-      end
+      -- Callbacks run from `vim.schedule`, so there is no coroutine here.
+      -- `git_command` awaits (on Windows it awaits `cygpath` before it even
+      -- spawns git), and awaiting outside a task raises. Give it one.
+      async.run(function()
+        self:_refresh_head(head2)
+      end)
     end)
   end
 
   return self
+end
+
+--- @async
+--- @private
+--- @param head string Contents of `HEAD`, already read
+function M:_refresh_head(head)
+  self.head_oid = get_head_oid(self.gitdir, self.commondir)
+
+  -- Set abbrev_head to empty string if head_oid is unavailable (.e.g repo
+  -- with no commits). This is consistent with `git rev-parse --abrev-ref
+  -- HEAD` which returns "HEAD" in this case.
+  local abbrev_head = self.head_oid and get_abbrev_head(self.gitdir, head) or ''
+  if self.abbrev_head ~= abbrev_head then
+    self.abbrev_head = abbrev_head
+    log.dprintf('HEAD changed, updating abbrev_head to %s', self.abbrev_head)
+  end
+
+  local head_ref = parse_head_ref(head)
+  if self.head_ref ~= head_ref then
+    self.head_ref = head_ref
+    if self._watcher then
+      self._watcher:set_head_ref(self.head_ref)
+    end
+  end
 end
 
 function M:has_watcher()

--- a/lua/gitsigns/git/repo/watcher.lua
+++ b/lua/gitsigns/git/repo/watcher.lua
@@ -249,10 +249,17 @@ function Watcher:_start_handle_path(handle_path)
     end
 
     if err0 then
-      if is_fs_event then
-        watcher:_fallback_to_fs_poll(err0)
-      else
-        watcher:_handle_fs_poll_error(handle_path, err0)
+      -- Never propagate out of a uv callback: an error here unwinds the event
+      -- loop rather than the caller, and the editor stops servicing requests.
+      local ok0, err1 = pcall(function()
+        if is_fs_event then
+          watcher:_fallback_to_fs_poll(err0)
+        else
+          watcher:_handle_fs_poll_error(handle_path, err0)
+        end
+      end)
+      if not ok0 then
+        log.eprintf('Git dir watcher error: %s', err1)
       end
       return
     end

--- a/lua/gitsigns/util.lua
+++ b/lua/gitsigns/util.lua
@@ -466,6 +466,18 @@ function M.cygpath(path, mode)
     has_cygpath = is_win and vim.fn.executable('cygpath') == 1
   end
 
+  -- On Windows with MSYS git this awaits, which is what makes callers yield.
+  -- Elsewhere it returns here, so a caller that yields from a context it
+  -- shouldn't (a uv or `vim.schedule` callback) looks fine everywhere except
+  -- the one platform that cannot be tested on. Let the tests force the await.
+  if require('gitsigns.config').config._force_cygpath_await then
+    async.await(1, function(cb)
+      vim.schedule(cb)
+    end)
+    async.schedule()
+    return path
+  end
+
   if not has_cygpath or uv.fs_stat(path) then
     return path
   end

--- a/test/debounce_spec.lua
+++ b/test/debounce_spec.lua
@@ -149,4 +149,29 @@ describe('debounce', function()
       eq(2, exec_lua('return _G._debounce_hash_fn_value'))
     end)
   end)
+  it('keeps throttling after the function errors', function()
+    -- A raise used to leave the running flag set, so every later call returned
+    -- early and the throttled function never ran again. Anything waiting on it
+    -- then waits forever, which reads as a hang rather than an error.
+    local calls = exec_lua(function()
+      local async = require('gitsigns.async')
+      local throttle_async = require('gitsigns.debounce').throttle_async
+
+      local n = 0
+      local throttled = throttle_async({ schedule = true }, function()
+        n = n + 1
+        error('boom')
+      end)
+
+      for _ = 1, 2 do
+        pcall(function()
+          async.run(throttled):wait(2000)
+        end)
+      end
+
+      return n
+    end)
+
+    eq(2, calls)
+  end)
 end)

--- a/test/git_spec.lua
+++ b/test/git_spec.lua
@@ -48,6 +48,50 @@ describe('git', function()
     helpers.setup_path()
   end)
 
+  it('refreshes HEAD from a watcher callback', function()
+    setup_test_repo()
+
+    local err = exec_lua(function(dir)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+      require('gitsigns.config').build({ watch_gitdir = { enable = true } })
+
+      local repo = assert(async.run(Repo.get, dir):wait(5000))
+
+      -- Point HEAD at a ref that resolves via neither loose refs nor
+      -- packed-refs, so the refresh falls back to running git. Without that
+      -- the refresh answers from a file read and never awaits.
+      local f = assert(io.open(dir .. '/.git/HEAD', 'w'))
+      f:write('ref: refs/heads/gone\n')
+      f:close()
+
+      -- Callbacks are invoked from `vim.schedule`, where no coroutine is
+      -- running, and `pcall`ed by the watcher -- so a raise here is invisible
+      -- in normal operation. Drive one directly and surface it.
+      local caught --- @type string?
+      local done = false
+      vim.schedule(function()
+        --- @diagnostic disable-next-line: invisible
+        for _, cb in ipairs(repo._watcher.update_callbacks) do
+          local ok, e = pcall(cb)
+          if not ok then
+            caught = tostring(e)
+          end
+        end
+        done = true
+      end)
+
+      vim.wait(5000, function()
+        return done
+      end)
+
+      repo:unref()
+      return caught
+    end, scratch)
+
+    eq(nil, err)
+  end)
+
   it('serializes repo operations across objects in the same repo', function()
     local result = exec_lua(function()
       local async = require('gitsigns.async')

--- a/test/git_spec.lua
+++ b/test/git_spec.lua
@@ -282,6 +282,54 @@ describe('git', function()
     eq_path(submodule_gitdir, result.info.gitdir)
   end)
 
+  it('infers linked worktrees from gitdir metadata', function()
+    -- `git worktree add` records resolved paths in the gitdir metadata
+    local root = fn.resolve(scratch)
+    local main = root .. '/main'
+    local linked = root .. '/linked'
+
+    --- Given a repo with a file and a worktree
+    init_repo(main)
+    write_to_file(main .. '/file', { 'main' })
+    git_in(main, 'add', 'file')
+    git_in(main, 'commit', '-m', 'init commit')
+    git_in(main, 'worktree', 'add', linked, '-b', 'linked')
+
+    local linked_gitdir = main .. '/.git/worktrees/linked'
+    local linked_file = linked .. '/file'
+
+    local result = exec_lua(function(gitdir, file)
+      local async = require('gitsigns.async')
+      local Obj = require('gitsigns.git').Obj
+      local Repo = require('gitsigns.git.repo')
+
+      local info = assert(async.run(Repo.get_info, nil, gitdir):wait(5000))
+
+      --- Simulate how git's `!shell` aliases set GIT_DIR before running gitsigns.
+      local old_gitdir = vim.env.GIT_DIR
+      local old_worktree = vim.env.GIT_WORK_TREE
+      vim.env.GIT_DIR = gitdir
+      vim.env.GIT_WORK_TREE = nil
+
+      local obj = async.run(Obj.new, file, nil, 'utf-8'):wait(5000)
+
+      vim.env.GIT_DIR = old_gitdir
+      vim.env.GIT_WORK_TREE = old_worktree
+
+      local relpath = obj and obj.relpath
+      if obj then
+        obj:close()
+      end
+
+      return { info = info, relpath = relpath }
+    end, linked_gitdir, linked_file)
+
+    --- We find the working tree, metadata, and file.
+    eq_path(linked, result.info.toplevel)
+    eq_path(linked_gitdir, result.info.gitdir)
+    eq('file', result.relpath)
+  end)
+
   it('blame does not crash when the git object was closed (#1557)', function()
     setup_test_repo()
     helpers.setup_gitsigns(helpers.test_config)

--- a/test/git_spec.lua
+++ b/test/git_spec.lua
@@ -100,6 +100,42 @@ describe('git', function()
     eq({ 'a_enter', 'a_exit', 'b_enter', 'b_exit' }, result.events)
   end)
 
+  it('relpathspec makes worktree paths relative', function()
+    helpers.git_init_scratch()
+
+    local result = exec_lua(function(repo_dir)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+
+      local repo = assert(async.run(Repo.get, repo_dir):wait(5000))
+      local outside = vim.fs.dirname(repo.toplevel) .. '/outside.txt'
+
+      local ret = async
+        .run(function()
+          return {
+            inside = repo:relpathspec(repo.toplevel .. '/file'),
+            nested = repo:relpathspec(repo.toplevel .. '/dir/nested.txt'),
+            relative = repo:relpathspec('already/relative.txt'),
+            -- Outside the worktree: passed through so git still rejects it.
+            outside = repo:relpathspec(outside),
+            outside_expected = outside,
+          }
+        end)
+        :wait(5000)
+
+      repo:unref()
+      return ret
+    end, scratch)
+
+    eq({
+      inside = 'file',
+      nested = 'dir/nested.txt',
+      relative = 'already/relative.txt',
+      outside = result.outside_expected,
+      outside_expected = result.outside_expected,
+    }, result)
+  end)
+
   it('log_rename_status handles spaced filenames', function()
     helpers.git_init_scratch()
 

--- a/test/gitdir_watcher_spec.lua
+++ b/test/gitdir_watcher_spec.lua
@@ -14,6 +14,7 @@ local match_debug_messages = helpers.match_debug_messages
 local n, p, np = helpers.n, helpers.p, helpers.np
 local normalize_path = helpers.normalize_path
 local path_pattern = helpers.path_pattern
+local pathspec_pattern = helpers.pathspec_pattern
 local setup_gitsigns = helpers.setup_gitsigns
 local git = helpers.git
 local test_file --- @type string
@@ -137,7 +138,7 @@ describe('gitdir_watcher', function()
       'attach.attach(1): Attaching (trigger=BufReadPost)',
       np(revparse_pat),
       np('system.system: git .* config user.name'),
-      np('system.system: git .* ls%-files .* ' .. path_pattern(test_file)),
+      np('system.system: git .* ls%-files .* ' .. pathspec_pattern(test_file)),
       np('attach%.attach%(1%): Watching git dir .*'),
       np('system.system: git .* show .*'),
     })
@@ -152,7 +153,7 @@ describe('gitdir_watcher', function()
     match_dag({
       p('system.system: git .* diff %-%-name%-status .* %-%-cached'),
       p('attach.handle_moved%(1%): File moved to dummy%.txt2'),
-      p('system.system: git .* ls%-files .* ' .. path_pattern(test_file2) .. '$'),
+      p('system.system: git .* ls%-files .* ' .. pathspec_pattern(test_file2) .. '$'),
       p(
         'attach%.handle_moved%(1%): Renamed buffer 1 from '
           .. path_pattern(test_file)
@@ -173,7 +174,7 @@ describe('gitdir_watcher', function()
     match_dag({
       p('system.system: git .* diff %-%-name%-status .* %-%-cached'),
       p('attach.handle_moved%(1%): File moved to dummy%.txt3'),
-      p('system.system: git .* ls%-files .* ' .. path_pattern(test_file3) .. '$'),
+      p('system.system: git .* ls%-files .* ' .. pathspec_pattern(test_file3) .. '$'),
       p(
         'attach%.handle_moved%(1%): Renamed buffer 1 from '
           .. path_pattern(test_file2)
@@ -192,7 +193,7 @@ describe('gitdir_watcher', function()
     match_dag({
       p('system.system: git .* diff %-%-name%-status .* %-%-cached'),
       p('attach.handle_moved%(1%): Moved file reset'),
-      p('system.system: git .* ls%-files .* ' .. path_pattern(test_file) .. '$'),
+      p('system.system: git .* ls%-files .* ' .. pathspec_pattern(test_file) .. '$'),
       p(
         'attach%.handle_moved%(1%): Renamed buffer 1 from '
           .. path_pattern(test_file3)

--- a/test/gitdir_watcher_spec.lua
+++ b/test/gitdir_watcher_spec.lua
@@ -332,6 +332,17 @@ describe('gitdir_watcher', function()
 
     git('add', test_file)
 
+    -- Poll fingerprints are snapshotted when the watches are synced, which may
+    -- already be after the `git add` above. Stale them so the next tick sees
+    -- the change; otherwise nothing notifies and the status never updates.
+    helpers.exec_lua(function()
+      local bcache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
+      local watcher = assert(assert(bcache).git_obj.repo._watcher)
+      for target in pairs(watcher._target_fingerprints) do
+        watcher._target_fingerprints[target] = 'stale'
+      end
+    end)
+
     helpers.check({ status = { head = '', added = 0, changed = 0, removed = 0 }, signs = {} })
   end)
 
@@ -372,8 +383,18 @@ describe('gitdir_watcher', function()
     helpers.exec_lua(function()
       local bcache = require('gitsigns.cache').cache[vim.api.nvim_get_current_buf()]
       local repo = assert(bcache).git_obj.repo
-      local _, handle = next(assert(repo._watcher).handles)
+      local watcher = assert(repo._watcher)
+      local _, handle = next(watcher.handles)
       assert(handle)
+
+      -- A poll callback only notifies when a fingerprint differs from the last
+      -- snapshot. That snapshot may already include the `git add` above, in
+      -- which case this callback notifies nothing and no other one follows.
+      -- Stale the fingerprints so the change is always seen.
+      for target in pairs(watcher._target_fingerprints) do
+        watcher._target_fingerprints[target] = 'stale'
+      end
+
       handle._cb(nil, nil, nil)
     end)
 

--- a/test/gitsigns_spec.lua
+++ b/test/gitsigns_spec.lua
@@ -21,6 +21,7 @@ local match_debug_messages = helpers.match_debug_messages
 local match_lines = helpers.match_lines
 local n, p, np = helpers.n, helpers.p, helpers.np
 local path_pattern = helpers.path_pattern
+local pathspec_pattern = helpers.pathspec_pattern
 local setup_gitsigns = helpers.setup_gitsigns
 local setup_test_repo = helpers.setup_test_repo
 local split = vim.split
@@ -112,8 +113,8 @@ describe('gitsigns (with screen)', function()
       p('system.system: git .* config user.name'),
       p(revparse_pat),
       p(
-        'system.system: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard %-%-eol '
-          .. path_pattern(test_file)
+        'system.system: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard %-%-eol %-%- '
+          .. pathspec_pattern(test_file)
       ),
       p('attach%.attach%(1%): Watching git dir .*'),
     })
@@ -203,7 +204,10 @@ describe('gitsigns (with screen)', function()
         'attach.attach(1): Attaching (trigger=BufReadPost)',
         np(revparse_pat),
         np('system.system: git .* config user.name'),
-        np('system.system: git .* ls%-files ' .. path_pattern(ignored_file)),
+        np(
+          'system.system: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard %-%-eol %-%- '
+            .. pathspec_pattern(ignored_file)
+        ),
         n('attach.attach(1): Cannot resolve file in repo'),
       })
 
@@ -351,8 +355,8 @@ describe('gitsigns (with screen)', function()
         np(revparse_pat),
         np('system.system: git .* config user.name'),
         np(
-          'system.system: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard %-%-eol '
-            .. path_pattern(newfile)
+          'system.system: git .* ls%-files %-%-stage %-%-others %-%-exclude%-standard %-%-eol %-%- '
+            .. pathspec_pattern(newfile)
         ),
         'attach.attach(1): Cannot resolve file in repo',
       })

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -144,6 +144,7 @@ M.test_config = {
   debug_mode = true,
   _test_mode = true,
   _allow_fs_poll_fallback = os.getenv('GITSIGNS_TEST_ALLOW_FS_POLL_FALLBACK') ~= '0',
+  _force_cygpath_await = os.getenv('GITSIGNS_TEST_FORCE_CYGPATH_AWAIT') == '1',
   watch_gitdir = {
     enable = false,
     follow_files = true,

--- a/test/gs_helpers.lua
+++ b/test/gs_helpers.lua
@@ -421,6 +421,7 @@ function M.eq_path(expected, actual, msg)
   eq(M.normalize_path(expected), M.normalize_path(actual), msg)
 end
 
+--- For a path gitsigns passes to git as a pathspec, use `pathspec_pattern`.
 --- @param path string
 --- @return string
 function M.path_pattern(path)
@@ -437,6 +438,21 @@ function M.path_pattern(path)
   end
 
   return pattern
+end
+
+--- Pattern for a path as gitsigns passes it to git: a pathspec relative to
+--- the worktree (see `Repo:relpathspec`).
+--- @param path string
+--- @return string
+function M.pathspec_pattern(path)
+  local scratch = assert(M.normalize_path(M.scratch))
+  local normalized = assert(M.normalize_path(path))
+
+  if vim.startswith(normalized, scratch .. '/') then
+    normalized = normalized:sub(#scratch + 2)
+  end
+
+  return M.path_pattern(normalized)
 end
 
 function M.git_init_scratch()

--- a/test/preload.lua
+++ b/test/preload.lua
@@ -10,6 +10,20 @@ end
 local helpers = require('nvim-test.helpers')
 local gs_helpers = require('test.gs_helpers')
 
+-- A test that wedges the editor produces no output at all: the runner blocks
+-- in an RPC request that never returns, and CI kills the job minutes later
+-- with the last completed test as the only clue. Trace each test in and out so
+-- the log names the one that hung. Unbuffered, since nothing gets to flush.
+local function trace(event, element)
+  if os.getenv('GITSIGNS_TEST_TRACE') ~= '1' then
+    return
+  end
+  io.stderr:write(
+    ('[trace %.2f] %s %s\n'):format(os.clock(), event, (element and element.name) or '?')
+  )
+  io.stderr:flush()
+end
+
 return function(busted, _helper, options)
   helpers.options = options
   gs_helpers.pending = busted.pending
@@ -20,6 +34,14 @@ return function(busted, _helper, options)
 
   busted.subscribe({ 'suite', 'end' }, function()
     gs_helpers.cleanup_scratch_root()
+  end)
+
+  busted.subscribe({ 'test', 'start' }, function(element)
+    trace('test start', element)
+  end)
+
+  busted.subscribe({ 'test', 'end' }, function(element)
+    trace('test end  ', element)
   end)
 
   return true

--- a/test/preload.lua
+++ b/test/preload.lua
@@ -1,8 +1,8 @@
 local orig_pcall = pcall
 
 if package.loaded['jit'] then
-  local coxpcall = orig_pcall(require, 'coxpcall')
-  if coxpcall then
+  local ok, coxpcall = orig_pcall(require, 'coxpcall')
+  if ok then
     pcall = coxpcall.pcall
   end
 end


### PR DESCRIPTION
When `GIT_DIR` is set but `GIT_WORK_TREE` is not, `get_info` derives
the working tree as `dirname(gitdir)`. For a linked `git worktree` the
`gitdir` is `.git/worktrees`.

https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables

This mean gitsigns thinks that all opened files are not part of the
working tree, and so gitsigns never attaches.

Read `<gitdir>/gitdir` which contains the path to the working tree
`.git` file (which means the parent of that is the `worktree`'s working
tree).

Absent that file the previous `dirname` is still correct, so plain
repositories and the redirected-`.git` case above are unaffected.

I found this because git exports `GIT_DIR` to `!shell` aliases, so an
alias that opens vim from a linked worktree causes gitsigns to not
attach.

Repro with:

    GIT_DIR=/main/.git/worktrees/w nvim /w/some/tracked/file

Before, `:lua =require('gitsigns.cache').cache[0]` is nil; after, the
buffer attaches and `toplevel` is `/w`.



Additional fixes:
* Also includes a port of the fix from https://github.com/lewis6991/nvim-test/pull/17
* Pass pathspecs relative to the worktree
* Pathspecs are now separated with --, since relative paths can clash with revision names like HEAD 
Windows-only, and it survived the first fix. MSYS git rewrites absolute arguments (D:/a/x → /d/a/x); for a linked worktree we also pass --work-tree (only detached repos do), so the rewritten pathspec stops matching it and git rejects the file as outside the repository it just named:

And when testing, these harness bugs caused spurious errors:
- Scratch cleanup before any Nvim session exists. cleanup_scratch_root runs on busted's suite start, before the first session, and reached is_win() — an RPC into that session. assert(session) fired and the suite died during setup, running zero tests.
- Symlinked checkouts. scratch_root came from PJ_ROOT verbatim while Nvim and git report resolved paths, so every path assertion failed when the checkout sat under a symlinked home.