### PR TITLE
feat(jj): add support for jj workspaces and uncolocated repos

### DIFF
--- a/lua/gitsigns/git/repo.lua
+++ b/lua/gitsigns/git/repo.lua
@@ -15,7 +15,7 @@ local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 --- @field gitdir string
 --- @field toplevel string
 --- @field detached boolean
---- @field abbrev_head string
+--- @field abbrev_head? string
 
 --- @class Gitsigns.Repo : Gitsigns.RepoInfo
 ---
@@ -683,6 +683,18 @@ function M.get_info(dir, gitdir, worktree)
   end
 
   if code > 0 then
+    if not gitdir and not worktree and dir then
+      local jj_gitdir, jj_worktree = require('gitsigns.jj.detect').resolve(dir)
+      if jj_gitdir then
+        local info, jerr = M.get_info(dir, jj_gitdir, jj_worktree)
+        if info then
+          -- HEAD in jj's backing git store cannot be trusted to reflect
+          -- the repo's actually HEAD. Setting
+          info.abbrev_head = nil
+        end
+        return info, jerr
+      end
+    end
     return nil, string.format('got stderr: %s', stderr or '')
   end
 

--- a/lua/gitsigns/jj/detect.lua
+++ b/lua/gitsigns/jj/detect.lua
@@ -1,0 +1,135 @@
+-- Jujutsu (vcs) detection utilities
+
+local Path = require('gitsigns.util').Path
+local uv = vim.uv or vim.loop
+
+local M = {}
+
+-- Walk up from `dir` looking for a `.jj` directory.
+-- This should only be called after the git discovery.
+-- The walk stops when a `.jj` directory is found or when a `.git` dir is found.
+-- When a `.git` dir is found then there will not be a `.jj` dir in the repo
+-- (the git discovery should have already run).
+--
+-- Returns the path to the jj_dir (nil if none was found)
+--
+--- @param dir string
+--- @return string? jj_dir
+local function find_jj_dir(dir)
+  local cur = dir
+  while cur do
+    if uv.fs_stat(Path.join(cur, '.jj')) then
+      return Path.join(cur, '.jj')
+    end
+    if uv.fs_stat(Path.join(cur, '.git')) then
+      return nil
+    end
+    local parent = vim.fs.dirname(cur)
+    if not parent or parent == cur then
+      return nil
+    end
+    cur = parent
+  end
+end
+
+-- Resolve the authoritative `.jj/repo` directory for a given local `.jj`
+-- directory. A `.jj` repo can refer to three situations.
+-- 1. A colocated repo.
+--    There is a `.git` repo alongside it the `.jj` dir.
+--    We can ignore it, because gitsigns can work off the `.git` dir.
+-- 2. An uncolocated repo.
+--    The `.jj` dir has an internal (bare) git repo (usually) in `.jj/repo/store/git`
+-- 3. A workspace. A `jj` workspace is similar to a git worktree.
+--    There, the `.jj` dir has a pointer to the authoritative checkout in `.jj/repo`
+--
+-- In summary. If `<jj_dir>/repo` is itself a directory, that's it.
+-- If it's a file (a workspace), its contents are a path (relative to
+-- `jj_dir`, or absolute) pointing at the authoritative `.jj/repo` directory
+-- elsewhere.
+--
+--- @param jj_dir string
+--- @return string? repo_dir
+local function resolve_repo_dir(jj_dir)
+  local repo_path = Path.join(jj_dir, 'repo')
+  local stat = uv.fs_stat(repo_path)
+  if not stat then
+    return nil
+  end
+  if stat.type == 'directory' then
+    return repo_path
+  end
+  if stat.type ~= 'file' then
+    return nil
+  end
+  local fd = io.open(repo_path, 'r')
+  if not fd then
+    return nil
+  end
+  local raw = fd:read('*a')
+  fd:close()
+  local target = raw and vim.trim(raw) or ''
+  if target == '' then
+    return nil
+  end
+  if not Path.is_abs(target) then
+    target = Path.join(jj_dir, target)
+  end
+  if uv.fs_stat(target) then
+    return target
+  end
+  return nil
+end
+
+-- Read `store/git_target` inside a `.jj/repo` directory and resolve it into
+-- an absolute path to the backing git directory. The file's content is the
+-- source of truth a path relative to the `store` directory it lives in (this
+-- matches jj's documented on-disk layout), or occasionally absolute;
+-- handle both.
+--- @param repo_dir string
+--- @return string? gitdir
+local function resolve_git_target(repo_dir)
+  local store_dir = Path.join(repo_dir, 'store')
+  local target_path = Path.join(store_dir, 'git_target')
+  local fd = io.open(target_path, 'r')
+  if not fd then
+    return nil
+  end
+  local raw = fd:read('*a')
+  fd:close()
+  local target = raw and vim.trim(raw) or ''
+  if target == '' then
+    return nil
+  end
+  local gitdir = Path.is_abs(target) and target or Path.join(store_dir, target)
+  gitdir = uv.fs_realpath(gitdir)
+  if not gitdir or not uv.fs_stat(gitdir) then
+    return nil
+  end
+  return gitdir
+end
+
+--- Resolve a jj-backed git directory and worktree for `dir`, without ever
+--- invoking the `jj` binary. Returns nil (both values) if `dir` is not
+--- inside a jj repo, or if any expected file is missing, unreadable, or
+--- dangling (e.g. a non-git jj backend, a stale workspace pointer).
+--- @param dir string
+--- @return string? gitdir
+--- @return string? worktree
+function M.resolve(dir)
+  local jj_dir = find_jj_dir(dir)
+  if not jj_dir then
+    return nil
+  end
+  local repo_dir = resolve_repo_dir(jj_dir)
+  if not repo_dir then
+    return nil
+  end
+  local gitdir = resolve_git_target(repo_dir)
+  if not gitdir then
+    return nil
+  end
+  local worktree = vim.fs.dirname(jj_dir)
+  return gitdir, worktree
+end
+
+return M

--- a/test/jj_spec.lua
+++ b/test/jj_spec.lua
@@ -1,0 +1,265 @@
+local helpers = require('test.gs_helpers')
+
+local clear = helpers.clear
+local eq = helpers.eq
+local eq_path = helpers.eq_path
+local exec_lua = helpers.exec_lua
+local fn = helpers.fn
+local mkdir = helpers.mkdir
+local write_to_file = helpers.write_to_file
+local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
+local tmpdir --- @type string
+
+helpers.env()
+
+-- Join path segments with '/' and normalize.
+--- @param ... string
+--- @return string
+local function join(...)
+  return (vim.fs.normalize(table.concat({ ... }, '/')))
+end
+
+-- Need to use tmpdir instead of scratch to avoid confusion with the actual git
+-- repo present. This allows us to test the jj path.
+local function refresh_paths()
+  tmpdir = join(uv.os_tmpdir() or '/tmp', 'jj-test-' .. tostring(uv.hrtime()))
+  mkdir(tmpdir)
+  -- On Windows, os_tmpdir() can return a short (8.3) path alias (e.g.
+  -- `RUNNER~1` on GitHub Actions runners) that doesn't string-match the
+  -- long-form paths git and the OS report elsewhere. Canonicalize once here
+  -- so every path built from `tmpdir` agrees with what git returns.
+  tmpdir = join(uv.fs_realpath(tmpdir) or tmpdir)
+end
+
+local function cleanup_tmpdir()
+  if tmpdir then
+    fn.delete(tmpdir, 'rf')
+  end
+end
+
+--- @param cmd string[]
+--- @param errmsg string
+local function system_ok(cmd, errmsg)
+  local output = fn.system(cmd)
+  eq(0, exec_lua('return vim.v.shell_error'), ('%s\n%s'):format(errmsg, output))
+end
+
+--- @param path string
+local function git_in(path, ...)
+  system_ok(
+    vim.list_extend({ 'git', '-C', path }, { ... }),
+    ('git command failed in %s'):format(path)
+  )
+end
+
+--- @param path string
+local function init_repo(path)
+  mkdir(path)
+  git_in(path, 'init', '-b', 'main')
+  git_in(path, 'config', 'user.email', 'tester@com.com')
+  git_in(path, 'config', 'user.name', 'tester')
+end
+
+describe('jj', function()
+  before_each(function()
+    clear()
+    refresh_paths()
+    helpers.setup_path()
+  end)
+
+  after_each(function()
+    cleanup_tmpdir()
+  end)
+
+  it('resolves gitdir for an uncolocated jj repo', function()
+    local backing = join(tmpdir, 'uncolocated-backing')
+    local workspace = join(tmpdir, 'uncolocated')
+    local backing_gitdir = join(backing, '.git')
+
+    -- Create backing git repo with an initial commit
+    init_repo(backing)
+    write_to_file(join(backing, 'file.txt'), { 'test content' })
+    git_in(backing, 'add', 'file.txt')
+    git_in(backing, 'commit', '-m', 'init commit')
+
+    -- Create workspace with jj structure pointing to backing repo
+    mkdir(workspace)
+    write_to_file(join(workspace, '.jj', 'repo', 'store', 'git_target'), { backing_gitdir })
+
+    local result = exec_lua(function(dir)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+
+      -- Discover from workspace directory
+      local info = async.run(Repo.get_info, dir):wait(5000)
+      return info
+    end, workspace)
+
+    assert(result, 'get_info should succeed for uncolocated jj repo')
+    eq_path(backing_gitdir, result.gitdir)
+    eq_path(workspace, result.toplevel)
+    eq(true, result.detached)
+    eq(nil, result.abbrev_head)
+  end)
+
+  it('resolves a secondary jj workspace to its own toplevel', function()
+    local backing = join(tmpdir, 'workspace-backing')
+    local primary = join(tmpdir, 'workspace-primary')
+    local secondary = join(tmpdir, 'workspace-secondary')
+    local backing_gitdir = join(backing, '.git')
+    local primary_jj_repo = join(primary, '.jj', 'repo')
+
+    -- Create backing git repo
+    init_repo(backing)
+    write_to_file(join(backing, 'file.txt'), { 'test content' })
+    git_in(backing, 'add', 'file.txt')
+    git_in(backing, 'commit', '-m', 'init commit')
+
+    -- Create primary workspace pointing to backing repo
+    mkdir(primary)
+    write_to_file(join(primary_jj_repo, 'store', 'git_target'), { backing_gitdir })
+
+    -- Create secondary workspace with nested subdir, .jj/repo as a file
+    -- pointing to primary's .jj/repo directory
+    local nested_dir = join(secondary, 'nested', 'buffer', 'dir')
+    mkdir(nested_dir)
+    write_to_file(join(secondary, '.jj', 'repo'), { primary_jj_repo })
+
+    local result = exec_lua(function(dir)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+
+      -- Discover from nested dir inside secondary workspace
+      local info = async.run(Repo.get_info, dir):wait(5000)
+      return info
+    end, nested_dir)
+
+    assert(result, 'get_info should succeed for secondary jj workspace')
+    eq_path(backing_gitdir, result.gitdir)
+    -- CRITICAL ASSERTION (D3): toplevel should be secondary, NOT primary
+    eq_path(secondary, result.toplevel)
+    eq(nil, result.abbrev_head)
+  end)
+
+  it('ignores a broken .jj when .git is already present (colocated)', function()
+    local repo = join(tmpdir, 'colocated')
+    local repo_gitdir = join(repo, '.git')
+    -- Absolute, but guaranteed not to exist on any platform: a path nested
+    -- under tmpdir that we never create.
+    local dangling_gitdir = join(tmpdir, 'nonexistent-backing', '.git')
+
+    -- Create a normal git repo
+    init_repo(repo)
+    write_to_file(join(repo, 'file.txt'), { 'test content' })
+    git_in(repo, 'add', 'file.txt')
+    git_in(repo, 'commit', '-m', 'init commit')
+
+    -- Add a deliberately broken .jj structure to test that native discovery
+    -- takes priority (D1 — regression guard)
+    write_to_file(join(repo, '.jj', 'repo', 'store', 'git_target'), { dangling_gitdir })
+
+    local result = exec_lua(function(dir)
+      local async = require('gitsigns.async')
+      local Repo = require('gitsigns.git.repo')
+
+      local info = async.run(Repo.get_info, dir):wait(5000)
+      return info
+    end, repo)
+
+    assert(result, 'get_info should succeed (native discovery, not jj)')
+    eq_path(repo_gitdir, result.gitdir)
+    eq_path(repo, result.toplevel)
+    eq(false, result.detached)
+    -- native discovery succeeds, so abbrev_head is non-nil (the actual branch name)
+    assert(
+      result.abbrev_head ~= nil,
+      'abbrev_head should be non-nil when native discovery succeeds'
+    )
+  end)
+
+  describe('jj.resolve graceful failure', function()
+    it('returns nil when no .jj directory exists', function()
+      local dir = join(tmpdir, 'no-jj')
+      mkdir(dir)
+
+      local result = exec_lua(function(d)
+        return { require('gitsigns.jj.detect').resolve(d) }
+      end, dir)
+
+      eq(nil, result[1])
+      eq(nil, result[2])
+    end)
+
+    it('returns nil when .jj/repo is a directory but store/git_target is missing', function()
+      local dir = join(tmpdir, 'missing-git-target')
+      mkdir(dir)
+      -- Create .jj/repo directory but don't create store/git_target
+      mkdir(join(dir, '.jj', 'repo'))
+
+      local result = exec_lua(function(d)
+        return { require('gitsigns.jj.detect').resolve(d) }
+      end, dir)
+
+      eq(nil, result[1])
+      eq(nil, result[2])
+    end)
+
+    it('returns nil when .jj/repo is a file pointing to nonexistent directory', function()
+      local dir = join(tmpdir, 'dangling-workspace')
+      mkdir(dir)
+      -- Create .jj/repo as a file pointing to a nonexistent location
+      write_to_file(join(dir, '.jj', 'repo'), { join(tmpdir, 'nonexistent-repo', 'dir') })
+
+      local result = exec_lua(function(d)
+        return { require('gitsigns.jj.detect').resolve(d) }
+      end, dir)
+
+      eq(nil, result[1])
+      eq(nil, result[2])
+    end)
+
+    it('returns nil when store/git_target points to nonexistent path', function()
+      local dir = join(tmpdir, 'dangling-git-target')
+      mkdir(dir)
+      -- Create .jj/repo directory with git_target pointing to nonexistent git store
+      write_to_file(
+        join(dir, '.jj', 'repo', 'store', 'git_target'),
+        { join(tmpdir, 'nonexistent-target', '.git') }
+      )
+
+      local result = exec_lua(function(d)
+        return { require('gitsigns.jj.detect').resolve(d) }
+      end, dir)
+
+      eq(nil, result[1])
+      eq(nil, result[2])
+    end)
+
+    it(
+      'does not cross into an unrelated outer .jj when dir is inside a nested repo .git',
+      function()
+        -- Regression test: an outer directory has a .jj (as if the whole tree
+        -- were itself a jj-colocated repo), but `dir` is inside a *different*,
+        -- inner git repo's own .git directory. The walk must stop at that
+        -- inner .git boundary and never misattribute the file to the outer
+        -- .jj, even though one exists further up.
+        local outer = join(tmpdir, 'outer')
+        mkdir(join(outer, '.jj', 'repo'))
+        write_to_file(
+          join(outer, '.jj', 'repo', 'store', 'git_target'),
+          { join(tmpdir, 'should-never-be-used', '.git') }
+        )
+
+        local inner = join(outer, 'inner-repo')
+        init_repo(inner)
+
+        local result = exec_lua(function(d)
+          return { require('gitsigns.jj.detect').resolve(d) }
+        end, join(inner, '.git'))
+
+        eq(nil, result[1])
+        eq(nil, result[2])
+      end
+    )
+  end)
+end)


### PR DESCRIPTION
This PR relates to discussion #1330.
It adds some support for `jj` detection by trying to find a `jj` dir after the git resolution fails.
It finds the relevant internal git repo (even across workspaces).
No more changes were needed.

The tests were made without requiring adding a test-dependency on `jj` but I have another commit that would fall on top of these that does add support for real `jj` tests.

--
AI Disclaimer: This PR was made with the assistance of AI