### PR TITLE
fix(attach): guard buffer validity after on_attach_pre yields

### DIFF
--- a/lua/gitsigns/attach.lua
+++ b/lua/gitsigns/attach.lua
@@ -303,6 +303,16 @@ M.attach = throttle_async({ hash = attach_hash }, function(opts)
     assert(ctx)
   end
 
+  -- get_buf_context() -> on_attach_pre() awaits config._on_attach_pre, which
+  -- yields control. The buffer may be deleted while we're suspended there
+  -- (e.g. a plugin opens a scratch buffer, writes it, then force-wipes it
+  -- before this coroutine resumes), so re-validate before touching cbuf
+  -- again, matching the checks already done after this function's other two
+  -- yield points below.
+  if not api.nvim_buf_is_valid(cbuf) then
+    return
+  end
+
   local encoding = vim.bo[cbuf].fileencoding
   if encoding == '' then
     encoding = 'utf-8'

--- a/test/attach_race_spec.lua
+++ b/test/attach_race_spec.lua
@@ -1,0 +1,86 @@
+local helpers = require('test.gs_helpers')
+
+local eq = helpers.eq
+
+helpers.env()
+
+describe('attach', function()
+  before_each(function()
+    helpers.clear()
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  it(
+    'does not crash when the buffer is wiped while attach is suspended in on_attach_pre',
+    function()
+      helpers.setup_test_repo()
+
+      -- Can't build `_on_attach_pre` on the test-runner side and hand it to
+      -- setup_gitsigns(): functions aren't msgpack-serializable, so a closure
+      -- can't cross the RPC boundary as a plain argument. Construct it inside
+      -- the exec_lua body instead, which runs directly in the remote Nvim.
+      -- setup_path() is required first (mirroring setup_gitsigns()) so that
+      -- require('gitsigns') resolves via an absolute package.path rather than
+      -- the relative one set on the command line.
+      helpers.setup_path()
+      helpers.exec_lua(function(config0)
+        -- Freeze instead of resolving immediately. This simulates a slow (or,
+        -- as here, indefinitely delayed) `_on_attach_pre` integration -- e.g.
+        -- a worktree/yadm lookup -- racing against something that deletes the
+        -- buffer, such as a plugin that opens a scratch buffer and force-wipes
+        -- it (`:bwipeout!`) once done with it.
+        config0._on_attach_pre = function(_bufnr, callback)
+          _G.gitsigns_test_attach_cb = callback
+        end
+
+        local maps = config0.on_attach --[[@as [string,string,string][] ]]
+        config0.on_attach = function(bufnr)
+          for _, map in ipairs(maps) do
+            vim.keymap.set(map[1], map[2], map[3], { buffer = bufnr })
+          end
+        end
+
+        require('gitsigns').setup(config0)
+        vim.o.diffopt = 'internal,filler,closeoff'
+      end, vim.deepcopy(helpers.test_config))
+
+      helpers.edit(helpers.test_file)
+
+      helpers.expectf(function()
+        return helpers.exec_lua(function()
+          return _G.gitsigns_test_attach_cb ~= nil
+        end)
+      end)
+
+      local result = helpers.exec_lua(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+
+        -- Wipe the buffer while gitsigns' attach coroutine is suspended.
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        -- Resume it: this must not raise "Invalid buffer id".
+        local ok, err = pcall(_G.gitsigns_test_attach_cb)
+        _G.gitsigns_test_attach_cb = nil
+
+        local stale_cache_bufnr --- @type integer?
+        for cached_bufnr in pairs(require('gitsigns.cache').cache) do
+          if not vim.api.nvim_buf_is_valid(cached_bufnr) then
+            stale_cache_bufnr = cached_bufnr
+          end
+        end
+
+        return {
+          ok = ok,
+          err = err and tostring(err) or nil,
+          stale_cache_bufnr = stale_cache_bufnr,
+        }
+      end)
+
+      eq(true, result.ok, result.err)
+      eq(nil, result.stale_cache_bufnr, 'a deleted buffer must not remain in the attach cache')
+    end
+  )
+end)


### PR DESCRIPTION
### Description

`get_buf_context()` calls `on_attach_pre()` which awaits `config._on_attach_pre` (attach.lua:94), an async yield point. If the buffer is deleted while that coroutine is suspended there, resuming it reads `vim.bo[cbuf]` against the now-invalid buffer id and crashes with "Invalid buffer id: N".

The function already re-validates `cbuf` with `nvim_buf_is_valid()` after its other two yield points (the `async.schedule()` calls further down); this adds the same guard after the yield inside `on_attach_pre`, which was missing it.

Resolves the crash reported when nvim-orgmode's refile/archive force-wipes a scratch buffer while gitsigns' auto-attach is still resolving via a slow _on_attach_pre integration (e.g. a worktree/yadm lookup when using https://github.com/purarue/gitsigns-yadm.nvim).

### Reproduction

Unzip [repro.lua.gz](https://github.com/user-attachments/files/31658492/repro.lua.gz), then

```
nvim -l repro.lua /path/to/gitsigns.nvim/checkout
```

### AI Diligence Statement

I used Claude Code (Sonnet 5) to debug the issue and prepare a fix, after experiencing this bug while using nvim-orgmode/orgmode (and gitsigns-yadm.nvim). While I understand the bug and its fix in principle, I cannot vouch for the code quality of the test since I am no neovim/lua developer.

Edit: Corrected used model from Opus 5 to Sonnet 5.