### PR TITLE
feat(diff): add staging and preserve cursor positions

### DIFF
--- a/doc/gitsigns.txt
+++ b/doc/gitsigns.txt
@@ -180,7 +180,7 @@ diff({revision}, {paths}, {callback})                        *gitsigns.diff()*
 
     >text
       :Gitsigns diff           Compare HEAD with the working tree.
-      :Gitsigns diff <commit>  Compare <commit> with its first parent.
+      :Gitsigns diff <commit>  Compare <commit> with the working tree.
       :Gitsigns diff A..B      Compare A with B.
       :Gitsigns diff A...B     Compare the merge base of A and B with B.
 <
@@ -195,12 +195,30 @@ diff({revision}, {paths}, {callback})                        *gitsigns.diff()*
     otherwise they are relative to the repository root. Escape spaces with
     backslashes (see |<f-args>|).
 
-    For a single commit, press `<CR>` on its header to show the author, date,
-    and full message beside the panel. Press `q` to close the message.
+    Use |gitsigns.show_commit()| to view the changes introduced by a commit.
 
-    Press `g?` in the panel for keys. Directories use standard fold commands.
+    Press `g?` in the panel for keys. Directories sort before files at each
+    level and use standard fold commands. Closed directories show their changed
+    file count and total diffstat, including nested files.
+    Click or press `<CR>` on an entry to open it or toggle its directory fold.
+    Newly loaded diff buffers open at their first change. Already loaded
+    buffers keep their cursor position using Neovim's normal buffer behaviour.
+    Reviewed buffers stay loaded until the panel closes. Cleanup preserves
+    buffers that were already loaded, modified, or open in other windows.
     In either diff buffer, `]f` / `[f` select the next / previous file without
     changing windows. A count skips files; navigation stops at either end.
+
+    Working-tree comparisons list each file once. The two status columns show
+    index changes (relative to HEAD) and working-tree changes (relative to the
+    index). A blank means unchanged and `?` means untracked. For example,
+    `M ` is staged, ` M` is unstaged, and `MM` has both kinds of changes.
+    Fully staged filenames use |hl-GitSignsDiffStaged|.
+    Press `s` to stage a file, `u` to unstage it, or `<Space>` to toggle
+    staging. This stages remaining working-tree changes; otherwise it
+    unstages the file. On a directory, these keys act on all listed files
+    beneath it, including nested directories.
+    These actions operate on saved files and leave unsaved buffer edits intact.
+    Staging refreshes the panel and keeps the displayed diff.
 
     Regular working-tree files are editable; revision buffers are read-only.
     See |diff-mode| for diff navigation.
@@ -211,11 +229,23 @@ diff({revision}, {paths}, {callback})                        *gitsigns.diff()*
         {callback} (`(fun(err: string?))?`)
 
 show_commit({revision}, {open}, {callback})              *gitsigns.show_commit()*
-    Show revision {base} commit in split or tab
+    Show the changes introduced by a commit with a file tree and diff windows.
+    Compare the commit with its first parent, or the empty tree for a root
+    commit. See |gitsigns.diff()| for panel navigation and file actions.
+
+    The SHA and wrapped summary appear above the file tree. Press `<CR>` on
+    either to show the author, date, and full message beside the panel.
+    Press `q` to close the message.
+
+    Use `vsplit` or `tabnew` to show the full commit as text instead:
+    >text
+      :Gitsigns show_commit HEAD
+      :Gitsigns show_commit HEAD vsplit
+<
 
     Parameters: ~
         {revision} (`string?`): (default: 'HEAD')
-        {open}     (`("vsplit"|"tabnew")?`)
+        {open}     (`("diff"|"vsplit"|"tabnew")?`): (default: 'diff')
         {callback} (`(fun(err: string?))?`)
 
 show({revision}, {callback})                                 *gitsigns.show()*
@@ -1403,6 +1433,11 @@ GitSignsStagedUntrackedCul
     Used for the text (when the cursor is on the same line as the sign) of 'untracked' staged signs.
 
     Fallbacks: `GitSignsUntrackedCul` (fg=50%)
+                                                        *hl-GitSignsDiffStaged*
+GitSignsDiffStaged
+    Used for fully staged filenames in the diff panel.
+
+    Fallbacks: `Normal` (fg=15%)
                                                         *hl-GitSignsAddPreview*
 GitSignsAddPreview
     Used for added lines in previews.

--- a/lua/gitsigns/actions.lua
+++ b/lua/gitsigns/actions.lua
@@ -940,13 +940,29 @@ function C.show(args)
   M.show(revision)
 end
 
---- Show revision {base} commit in split or tab
+--- Show the changes introduced by a commit with a file tree and diff windows.
+--- Compare the commit with its first parent, or the empty tree for a root
+--- commit. See [[gitsigns.diff()]] for panel navigation and file actions.
+---
+--- The SHA and wrapped summary appear above the file tree. Press `<CR>` on
+--- either to show the author, date, and full message beside the panel.
+--- Press `q` to close the message.
+---
+--- Use `vsplit` or `tabnew` to show the full commit as text instead:
+--- ```text
+---   :Gitsigns show_commit HEAD
+---   :Gitsigns show_commit HEAD vsplit
+--- ```
 ---
 --- @param revision string? (default: 'HEAD')
---- @param open ('vsplit'|'tabnew')?
+--- @param open ('diff'|'vsplit'|'tabnew')? (default: 'diff')
 --- @param callback? fun(err?: string)
 function M.show_commit(revision, open, callback)
-  async_run(callback, require('gitsigns.actions.show_commit').show_commit, revision, open)
+  if not open or open == 'diff' then
+    async_run(callback, require('gitsigns.actions.diff'), revision, nil, true)
+  else
+    async_run(callback, require('gitsigns.actions.show_commit').show_commit, revision, open)
+  end
 end
 
 function C.show_commit(args)
@@ -959,7 +975,7 @@ end
 ---
 --- ```text
 ---   :Gitsigns diff           Compare HEAD with the working tree.
----   :Gitsigns diff <commit>  Compare <commit> with its first parent.
+---   :Gitsigns diff <commit>  Compare <commit> with the working tree.
 ---   :Gitsigns diff A..B      Compare A with B.
 ---   :Gitsigns diff A...B     Compare the merge base of A and B with B.
 --- ```
@@ -974,12 +990,30 @@ end
 --- otherwise they are relative to the repository root. Escape spaces with
 --- backslashes (see [[<f-args>]]).
 ---
---- For a single commit, press `<CR>` on its header to show the author, date,
---- and full message beside the panel. Press `q` to close the message.
+--- Use [[gitsigns.show_commit()]] to view the changes introduced by a commit.
 ---
---- Press `g?` in the panel for keys. Directories use standard fold commands.
+--- Press `g?` in the panel for keys. Directories sort before files at each
+--- level and use standard fold commands. Closed directories show their changed
+--- file count and total diffstat, including nested files.
+--- Click or press `<CR>` on an entry to open it or toggle its directory fold.
+--- Newly loaded diff buffers open at their first change. Already loaded
+--- buffers keep their cursor position using Neovim's normal buffer behaviour.
+--- Reviewed buffers stay loaded until the panel closes. Cleanup preserves
+--- buffers that were already loaded, modified, or open in other windows.
 --- In either diff buffer, `]f` / `[f` select the next / previous file without
 --- changing windows. A count skips files; navigation stops at either end.
+---
+--- Working-tree comparisons list each file once. The two status columns show
+--- index changes (relative to HEAD) and working-tree changes (relative to the
+--- index). A blank means unchanged and `?` means untracked. For example,
+--- `M ` is staged, ` M` is unstaged, and `MM` has both kinds of changes.
+--- Fully staged filenames use [[hl-GitSignsDiffStaged]].
+--- Press `s` to stage a file, `u` to unstage it, or `<Space>` to toggle
+--- staging. This stages remaining working-tree changes; otherwise it
+--- unstages the file. On a directory, these keys act on all listed files
+--- beneath it, including nested directories.
+--- These actions operate on saved files and leave unsaved buffer edits intact.
+--- Staging refreshes the panel and keeps the displayed diff.
 ---
 --- Regular working-tree files are editable; revision buffers are read-only.
 --- See [[diff-mode]] for diff navigation.

--- a/lua/gitsigns/actions/blame.lua
+++ b/lua/gitsigns/actions/blame.lua
@@ -568,7 +568,7 @@ function M.blame(opts)
     local lnum0 = api.nvim_win_get_cursor(blm_win)[1]
     local sha = assert(blame.entries[lnum0]).commit.sha
     api.nvim_set_current_win(win)
-    require('gitsigns.actions').diff(sha)
+    require('gitsigns.actions').show_commit(sha)
   end, {
     desc = 'Diff commit (tab)',
     buffer = blm_bufnr,

--- a/lua/gitsigns/actions/diff.lua
+++ b/lua/gitsigns/actions/diff.lua
@@ -1,6 +1,7 @@
 local async = require('gitsigns.async')
 local cache = require('gitsigns.cache').cache
 local diffthis = require('gitsigns.actions.diffthis')
+local git_diff = require('gitsigns.git.diff')
 local message = require('gitsigns.message')
 local Repo = require('gitsigns.git.repo')
 
@@ -9,12 +10,23 @@ local fn = vim.fn
 local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 local ns = api.nvim_create_namespace('gitsigns_diff')
 local ns_selection = api.nvim_create_namespace('gitsigns_diff_selection')
+local ns_header = api.nvim_create_namespace('gitsigns_diff_header')
+
+--- @class Gitsigns.DiffBufferRef
+--- @field refs integer
+--- @field bufhidden ''|'hide'|'unload'|'delete'|'wipe'
+--- @field loaded boolean
+--- @field created boolean
+
+-- Buffers can belong to more than one review panel.
+local buffer_refs = {} --- @type table<integer, Gitsigns.DiffBufferRef>
 
 local HIGHLIGHTS = {
   A = 'GitSignsAdd',
   D = 'GitSignsDelete',
   M = 'GitSignsChange',
   ['?'] = 'GitSignsUntracked',
+  [' '] = 'Comment',
 }
 
 local MODES = {
@@ -23,107 +35,204 @@ local MODES = {
   gitlink = '160000',
 }
 
---- Bind file navigation while a diff window is current, restoring mappings on leave.
---- Shared buffers then use their normal mappings in every other window or panel.
---- @param panel integer
---- @param windows Gitsigns.DiffWindows
---- @param navigate fun(count: integer)
---- @return fun() cleanup
-local function setup_navigation(panel, windows, navigate)
-  local group = api.nvim_create_augroup('gitsigns_diff_' .. panel, {})
-  local restore = {} --- @type fun()[]
-  local mapped_win --- @type integer?
-  local directions = { [']f'] = 1, ['[f'] = -1 } --- @type table<string, integer>
-
-  --- Restore this window's mappings before entering another buffer or window.
-  local function unmap()
-    for _, undo in ipairs(restore) do
-      undo()
-    end
-    restore = {}
-    mapped_win = nil
-  end
-
-  api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
-    group = group,
-    callback = function()
-      -- Buffer operations in another window must not remove the current mappings.
-      if api.nvim_get_current_win() == mapped_win then
-        unmap()
-      end
-    end,
-  })
-  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
-    group = group,
-    callback = function()
-      local win = api.nvim_get_current_win()
-      if
-        #restore > 0
-        or not windows.left
-        or not api.nvim_win_is_valid(windows.left)
-        or (win ~= windows.left and win ~= windows.right)
-      then
-        return
-      end
-      local buf = api.nvim_get_current_buf()
-      mapped_win = win
-      for key, direction in pairs(directions) do
-        local previous = fn.maparg(key, 'n', false, true)
-        local callback = function()
-          navigate(direction * vim.v.count1)
-        end
-        vim.keymap.set('n', key, callback, {
-          buffer = buf,
-          desc = direction == 1 and 'Next file' or 'Previous file',
-        })
-        restore[#restore + 1] = function()
-          if not api.nvim_buf_is_valid(buf) then
-            return
-          end
-          api.nvim_buf_call(buf, function()
-            -- Leave a mapping installed by the user after entering the window alone.
-            if fn.maparg(key, 'n', false, true).callback == callback then
-              vim.keymap.del('n', key, { buffer = buf })
-              if previous.buffer == 1 then
-                fn.mapset('n', false, previous)
-              end
-            end
-          end)
-        end
-      end
-    end,
-  })
-
-  return function()
-    api.nvim_del_augroup_by_id(group)
-    unmap()
+--- Delete a buffer created for an abandoned read, provided no window displays it.
+--- @param buf integer?
+--- @param created boolean?
+local function discard(buf, created)
+  if buf and created and api.nvim_buf_is_valid(buf) and #fn.win_findbuf(buf) == 0 then
+    api.nvim_buf_delete(buf, { force = true })
   end
 end
 
+--- @param added integer?
+--- @param removed integer?
+--- @param binary? boolean
+--- @return Gitsigns.VirtTextChunk[]
+local function diffstat(added, removed, binary)
+  local stats = {} --- @type Gitsigns.VirtTextChunk[]
+  if added and added > 0 then
+    stats[1] = { '+' .. added, 'GitSignsAdd' }
+  end
+
+  if removed and removed > 0 then
+    stats[#stats + 1] = { (#stats > 0 and ' -' or '-') .. removed, 'GitSignsDelete' }
+  end
+
+  if not added or binary then
+    stats[#stats + 1] = { (#stats > 0 and ' ' or '') .. 'Bin', 'Comment' }
+  end
+
+  return stats
+end
+
+--- @class Gitsigns.DiffNode
+--- @field path string
+--- @field lnum integer
+--- @field first integer First entry in the sorted file list.
+--- @field last integer Last entry; equal to first for a file.
+--- @field directory? boolean
+
+--- @class Gitsigns.DiffDirectory : Gitsigns.DiffNode
+--- @field name string
+--- @field added integer
+--- @field removed integer
+--- @field binary boolean
+
+--- Fit closed directories and the header separator to the panel width.
+--- @param win integer
+--- @param header_lines integer
+--- @param dirs table<string, Gitsigns.DiffDirectory>
+local function resize_panel(win, header_lines, dirs)
+  local panel, width = api.nvim_win_get_buf(win), api.nvim_win_get_width(win)
+
+  -- Reserve space for counts and stats before clipping each closed directory label.
+  local folds = {} --- @type table<string, Gitsigns.VirtTextChunk[]>
+  for _, dir in pairs(dirs) do
+    local count = ('(%d)'):format(dir.last - dir.first + 1)
+    local stats = diffstat(dir.added, dir.removed, dir.binary)
+    local stats_width = 0
+    for _, chunk in ipairs(stats) do
+      stats_width = stats_width + fn.strdisplaywidth(chunk[1])
+    end
+
+    -- %S clips by display cells, including wide characters and folder icons.
+    local name_width = math.max(0, width - #count - stats_width - 2)
+    local name = fn.printf('%.' .. name_width .. 'S', dir.name)
+    local padding = math.max(1, width - fn.strdisplaywidth(name) - #count - stats_width - 1)
+    folds[tostring(dir.lnum)] = vim.list_extend({
+      { name .. ' ', 'Directory' },
+      { count, 'Comment' },
+      { string.rep(' ', padding), 'Normal' },
+    }, stats)
+  end
+
+  vim.b[panel].gitsigns_diff_foldtext = folds
+
+  -- A virtual separator follows the header without adding a selectable row.
+  api.nvim_buf_set_extmark(panel, ns_header, header_lines - 1, 0, {
+    id = 1,
+    virt_lines = { { { string.rep('─', width), 'WinSeparator' } } },
+  })
+end
+
+--- Compare each tree level separately: directories first, then names.
+--- @param a Gitsigns.DiffEntry
+--- @param b Gitsigns.DiffEntry
+--- @return boolean
+local function compare_entries(a, b)
+  local ap = vim.split(a.path, '/', { plain = true })
+  local bp = vim.split(b.path, '/', { plain = true })
+
+  for i = 1, math.min(#ap, #bp) do
+    if (i < #ap) ~= (i < #bp) then
+      return i < #ap
+    end
+    if ap[i] ~= bp[i] then
+      return ap[i] < bp[i]
+    end
+  end
+
+  return a.path < b.path
+end
+
+--- @alias Gitsigns.DiffAction 'diff'|'target'|'base'|'stage'|'unstage'|'toggle'
+
+--- Show panel and diff-buffer mappings in a focused popup.
+--- @param panel integer
+local function show_help(panel)
+  local popup = require('gitsigns.popup')
+  popup.close('diff_help')
+
+  local lines = { { { 'File panel', 'Title' } } } --- @type Gitsigns.LineSpec[]
+  for _, map in ipairs(api.nvim_buf_get_keymap(panel, 'n')) do
+    local key = map.lhs == ' ' and '<Space>' or map.lhs
+    lines[#lines + 1] = { { ('%-8s %s'):format(key, map.desc or map.rhs), 'Normal' } }
+  end
+
+  vim.list_extend(lines, {
+    { { '', 'Normal' } },
+    { { 'Diff buffers', 'Title' } },
+    { { ']f / [f  Next / previous file (accepts count)', 'Normal' } },
+    { { ']c / [c  Next / previous change', 'Normal' } },
+    { { '', 'Normal' } },
+    { { 'q / <Esc> / g?  Close this help', 'Comment' } },
+  })
+
+  local win, buf =
+    popup.create(lines, require('gitsigns.config').config.preview_config, 'diff_help')
+  for _, key in ipairs({ '<Esc>', 'g?' }) do
+    vim.keymap.set('n', key, '<cmd>close<CR>', { buffer = buf, silent = true })
+  end
+
+  api.nvim_set_current_win(win)
+end
+
+--- Repository review panel.
+--- @class Gitsigns.DiffPanel
+--- @field buf integer
+--- @field tab integer
+--- @field panel_win integer
+--- @field right_win integer
+--- @field left_win? integer
+--- @field repo Gitsigns.Repo
+--- @field revision? string
+--- @field paths? string[]
+--- @field cwd string
+--- @field show_commit? boolean
+--- @field base? string
+--- @field target? string
+--- @field entries Gitsigns.DiffEntry[]
+--- @field commit? string[]
+--- @field file_lnums integer[]
+--- @field rows table<integer, Gitsigns.DiffNode> Nodes indexed by panel line.
+--- @field nodes table<string, Gitsigns.DiffNode> Nodes indexed by repository path.
+--- @field header_lines integer
+--- @field dirs table<string, Gitsigns.DiffDirectory>
+--- @field current_file integer
+--- @field scratch table<string, integer>
+--- @field retained table<integer, boolean>
+--- @field busy boolean
+local DiffPanel = {}
+DiffPanel.__index = DiffPanel
+
 --- Get one side of a file diff, reusing working buffers to preserve unsaved edits.
 --- Missing files, gitlinks, and working-tree symlinks use scratch buffers.
+--- @private
 --- @async
---- @param repo Gitsigns.Repo
---- @param revision string? Nil selects the working tree for the target side.
 --- @param entry Gitsigns.DiffEntry
---- @param old boolean Use the entry's base path and mode.
+--- @param side 'base'|'target'
 --- @return integer? bufnr
 --- @return boolean? created Whether this call created a disposable buffer.
-local function file_buffer(repo, revision, entry, old)
+--- @return boolean? loaded Whether the buffer was already loaded.
+function DiffPanel:file_buffer(entry, side)
+  local repo = self.repo
+  local revision = self[side]
+  local old = side == 'base'
   local mode = old and entry.old_mode or entry.mode
   local path = old and (entry.oldpath or entry.path) or entry.path
   local worktree = not old and not revision
   local symlink = worktree and mode == MODES.symlink
 
+  -- Ordinary files use named buffers so edits and native cursor state survive revisits.
   if mode ~= MODES.missing and mode ~= MODES.gitlink and not symlink then
     if worktree then
       local buf = fn.bufadd(repo.toplevel .. '/' .. path)
+      local loaded = api.nvim_buf_is_loaded(buf)
+
       fn.bufload(buf)
       vim.bo[buf].buflisted = true
-      return buf, false
+      return buf, false, loaded
     end
-    local _, bufnr, created = diffthis.create_revision_buf(repo, assert(revision), path)
-    return bufnr, created
+
+    local _, bufnr, created, loaded = diffthis.create_revision_buf(repo, assert(revision), path)
+    return bufnr, created, loaded
+  end
+
+  -- Special file types need synthetic contents, retained for the same review lifetime.
+  local key = table.concat({ revision or '', mode, path }, '\0')
+  local bufnr = self.scratch[key] --- @type integer?
+  if bufnr and api.nvim_buf_is_loaded(bufnr) and not worktree then
+    return bufnr, false, true
   end
 
   local text = {} --- @type string[]
@@ -146,115 +255,186 @@ local function file_buffer(repo, revision, entry, old)
         subrepo:unref()
       end
     end
+
     text = { 'Subproject commit ' .. oid }
   elseif symlink then
     -- Git compares the link target, not the contents of the file it points to.
     text = vim.split(assert(uv.fs_readlink(repo.toplevel .. '/' .. path)), '\n', { plain = true })
   end
 
-  local bufnr = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_lines(bufnr, 0, -1, false, text)
-  vim.bo[bufnr].bufhidden = 'wipe'
-  vim.bo[bufnr].modifiable = false
-  return bufnr, true
-end
-
---- Delete a buffer created for an abandoned read, provided no window displays it.
---- @param buf integer?
---- @param created boolean?
-local function discard(buf, created)
-  if buf and created and api.nvim_buf_is_valid(buf) and #fn.win_findbuf(buf) == 0 then
-    api.nvim_buf_delete(buf, { force = true })
+  local created = not bufnr or not api.nvim_buf_is_valid(bufnr)
+  local loaded = not created and api.nvim_buf_is_loaded(assert(bufnr))
+  if created then
+    bufnr = api.nvim_create_buf(false, true)
+    self.scratch[key] = bufnr
+    vim.bo[bufnr].bufhidden = 'wipe'
   end
+
+  -- Working-tree symlinks and gitlinks can change while their buffers stay loaded.
+  -- Leave unchanged text alone so revisits preserve the buffer's cursor state.
+  assert(bufnr)
+  if not loaded or not vim.deep_equal(api.nvim_buf_get_lines(bufnr, 0, -1, false), text) then
+    vim.bo[bufnr].modifiable = true
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, text)
+    vim.bo[bufnr].modifiable = false
+    vim.bo[bufnr].modified = false
+  end
+
+  return bufnr, created, loaded
 end
 
---- Render the file tree and configure its window, sorting entries in place by path.
---- @param panel_win integer
---- @param revision string?
---- @param entries Gitsigns.DiffEntry[]
---- @param commit string[]?
---- @return integer[] file_lnums Panel line numbers in the sorted entry order.
-local function render_panel(panel_win, revision, entries, commit)
-  local panel = api.nvim_win_get_buf(panel_win)
-  local lines = {
-    commit and fn.strtrans(assert(commit[1]))
-      or 'Diff: ' .. fn.strtrans(revision or 'working tree'),
-    'g? help  <CR> open/fold  q close',
-    '',
-  }
+--- Build panel lines and fold levels, updating the file and directory lookup tables.
+--- @private
+--- @return string[] lines
+--- @return string[] folds
+function DiffPanel:build_tree()
+  -- Keep the commit metadata outside the file folds.
+  local lines = {} --- @type string[]
+  if self.commit then
+    local sha, summary = assert(self.commit[1]):match('^(%S+) (.*)$')
+    lines[1] = assert(sha)
+    lines[2] = fn.strtrans(assert(summary))
+  else
+    lines[1] = 'Diff: ' .. fn.strtrans(self.revision or 'working tree')
+  end
+  self.header_lines = #lines
 
-  local directories = {} --- @type table<string, integer>
-  local file_lnums = {} --- @type integer[]
+  local folds = {} --- @type string[]
+  for i = 1, self.header_lines do
+    folds[i] = '0'
+  end
 
-  -- Sorting keeps each directory's descendants contiguous, giving it one fold range.
-  table.sort(entries, function(a, b)
-    return a.path < b.path
-  end)
+  -- Every lookup must refer to the same nodes and sorted entry ranges after a render.
+  self.dirs = {}
+  self.file_lnums = {}
+  self.rows = {}
+  self.nodes = {}
+  table.sort(self.entries, compare_entries)
 
-  for _, entry in ipairs(entries) do
+  for i, entry in ipairs(self.entries) do
     local parts = vim.split(entry.path, '/', { plain = true })
     local dir = ''
+
+    -- Emit each ancestor once, then accumulate this file into its directory totals.
     for depth = 1, #parts - 1 do
       local name = assert(parts[depth])
       dir = dir .. name .. '/'
-      if not directories[dir] then
-        -- Escape a leading space so foldexpr sees only the tree's indentation.
+
+      if not self.dirs[dir] then
+        -- Keep leading spaces in directory names visible.
         name = fn.strtrans(name):gsub('^ ', '\\ ')
         lines[#lines + 1] = string.rep('  ', depth - 1) .. ' ' .. name .. '/'
-        directories[dir] = #lines
+
+        local node = {
+          path = dir,
+          lnum = #lines,
+          first = i,
+          last = i,
+          directory = true,
+          name = lines[#lines],
+          added = 0,
+          removed = 0,
+          binary = false,
+        }
+        self.dirs[dir] = node
+        self.rows[#lines] = node
+        self.nodes[dir] = node
+        folds[#lines] = '>' .. depth
       end
+
+      local stats = self.dirs[dir]
+
+      -- Directory-first sorting keeps each directory's listed files contiguous.
+      stats.last = i
+      stats.added = stats.added + (entry.added or 0)
+      stats.removed = stats.removed + (entry.removed or 0)
+      stats.binary = stats.binary or not entry.added
     end
 
+    -- Display rename origins in the label, but index the node by its destination.
     local path = fn.strtrans(parts[#parts])
     if entry.oldpath then
       path = fn.strtrans(entry.oldpath) .. ' -> ' .. path
     end
+
     lines[#lines + 1] = string.rep('  ', #parts - 1) .. ' ' .. entry.status .. ' ' .. path
-    file_lnums[#file_lnums + 1] = #lines
+    self.file_lnums[#self.file_lnums + 1] = #lines
+
+    local node = { path = entry.path, lnum = #lines, first = i, last = i }
+    self.rows[#lines] = node
+    self.nodes[entry.path] = node
+    folds[#lines] = tostring(#parts - 1)
   end
 
-  if #entries == 0 then
+  -- The empty-state message and key legend also stay outside the tree folds.
+  if #self.entries == 0 then
     lines[#lines + 1] = 'No changes'
   end
+  vim.list_extend(lines, { '', 'g? help  <CR> open/fold  q close' })
 
-  api.nvim_buf_set_lines(panel, 0, -1, false, lines)
+  for i = #folds + 1, #lines do
+    folds[i] = '0'
+  end
 
-  if commit then
+  return lines, folds
+end
+
+--- Add header, status, icon, and diffstat decorations to the rendered lines.
+--- @private
+--- @param lines string[]
+function DiffPanel:highlight_tree(lines)
+  local panel = self.buf
+  api.nvim_buf_set_extmark(panel, ns, #lines - 1, 0, {
+    end_row = #lines,
+    end_col = 0,
+    hl_group = 'Comment',
+  })
+
+  if self.commit then
     api.nvim_buf_set_extmark(panel, ns, 0, 0, {
       end_row = 1,
+      end_col = 0,
+      hl_group = 'Identifier',
+    })
+    api.nvim_buf_set_extmark(panel, ns, 1, 0, {
+      end_row = 2,
       end_col = 0,
       hl_group = 'Title',
     })
   end
 
+  -- Decorate status columns independently; attach each file's diffstat only once.
   local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
-  for i, lnum in ipairs(file_lnums) do
-    local entry = assert(entries[i])
-    local col = assert(assert(lines[lnum]):find('%S')) - 1
-    local stats = {} --- @type Gitsigns.VirtTextChunk[]
-    if not entry.added then
-      stats[1] = { 'Bin', 'Comment' }
-    elseif entry.added > 0 then
-      stats[1] = { '+' .. entry.added, 'GitSignsAdd' }
+  for i, lnum in ipairs(self.file_lnums) do
+    local entry = assert(self.entries[i])
+    local col = select(2, entry.path:gsub('/', '')) * 2 + 1
+
+    for j = 1, #entry.status do
+      local hl = HIGHLIGHTS[entry.status:sub(j, j)] or 'GitSignsChange'
+      if j == 1 and #entry.status == 2 then
+        hl = hl:gsub('GitSigns', 'GitSignsStaged')
+      end
+      api.nvim_buf_set_extmark(panel, ns, lnum - 1, col + j - 1, {
+        end_col = col + j,
+        hl_group = hl,
+        virt_text = j == 1 and diffstat(entry.added, entry.removed) or nil,
+        virt_text_pos = 'right_align',
+        hl_mode = 'combine',
+      })
     end
-    if entry.removed and entry.removed > 0 then
-      stats[#stats + 1] = {
-        (#stats > 0 and ' -' or '-') .. entry.removed,
-        'GitSignsDelete',
-      }
+
+    if entry.status:match('^%S $') then -- Fully staged: a clean working-tree column.
+      api.nvim_buf_set_extmark(panel, ns, lnum - 1, col + 3, {
+        end_col = #assert(lines[lnum]),
+        hl_group = 'GitSignsDiffStaged',
+      })
     end
-    api.nvim_buf_set_extmark(panel, ns, lnum - 1, col, {
-      end_col = col + 1,
-      hl_group = HIGHLIGHTS[entry.status] or 'GitSignsChange',
-      virt_text = stats,
-      virt_text_pos = 'right_align',
-      hl_mode = 'combine',
-    })
+
     if has_devicons then
       local icon, hl = devicons.get_icon(fn.fnamemodify(entry.path, ':t'), nil, { default = true })
       if icon then
         -- Place icons after the status without changing the tree's text or indentation.
-        api.nvim_buf_set_extmark(panel, ns, lnum - 1, col + 2, {
+        api.nvim_buf_set_extmark(panel, ns, lnum - 1, col + #entry.status + 1, {
           virt_text = { { icon .. ' ', hl } },
           virt_text_pos = 'inline',
           hl_mode = 'combine',
@@ -263,32 +443,10 @@ local function render_panel(panel_win, revision, entries, commit)
     end
   end
 
-  vim.bo[panel].bufhidden = 'wipe'
-  vim.bo[panel].modifiable = false
-  vim.bo[panel].filetype = 'gitsigns-diff'
-
-  local wo = vim.wo[panel_win][0]
-  wo.number = false
-  wo.relativenumber = false
-  wo.signcolumn = 'no'
-  wo.foldcolumn = '0'
-  -- Each tree level adds two spaces. Start a separate fold at each parent row,
-  -- including adjacent parents at the same depth, and leave the header unfolded.
-  wo.foldexpr = 'v:lnum <= 3 ? 0 : indent(v:lnum + 1) > indent(v:lnum)'
-    .. ' ? ">" . (indent(v:lnum + 1) / 2) : indent(v:lnum) / 2'
-  wo.foldmethod = 'expr'
-  wo.foldminlines = 0
-  wo.wrap = false
-  wo.spell = false
-  wo.list = false
-  wo.cursorline = true
-  wo.winfixbuf = true
-  wo.winfixwidth = true
-
-  --- @diagnostic disable-next-line: deprecated
-  api.nvim_win_set_width(panel_win, 36)
-  for _, lnum in pairs(directories) do
-    local col = assert(assert(lines[lnum]):find('%S')) - 1
+  -- Fold labels use the same directory icon as the expanded tree.
+  for _, dir in pairs(self.dirs) do
+    local col = assert(dir.name:find('%S')) - 1
+    local lnum = dir.lnum
     api.nvim_buf_set_extmark(panel, ns, lnum - 1, col, {
       end_row = lnum,
       end_col = 0,
@@ -298,96 +456,488 @@ local function render_panel(panel_win, revision, entries, commit)
       virt_text_pos = 'inline',
       hl_mode = 'combine',
     })
-  end
-  wo.foldenable = true
-  vim.cmd('normal! zR')
-  api.nvim_win_set_cursor(panel_win, { file_lnums[1] or (commit and 1 or 4), 0 })
 
-  return file_lnums
+    if has_devicons then
+      dir.name = dir.name:sub(1, col) .. ' ' .. dir.name:sub(col + 1)
+    end
+  end
 end
 
---- @class Gitsigns.DiffWindows
---- @field panel integer
---- @field right integer
---- @field left integer?
+--- Render the panel and configure its window.
+--- @package
+function DiffPanel:render()
+  local panel, panel_win = self.buf, self.panel_win
+  local initial = vim.bo[panel].filetype ~= 'gitsigns-diff'
+
+  -- Replace the text, lookup tables, and decorations as one render.
+  local lines, folds = self:build_tree()
+  vim.b[panel].gitsigns_diff_folds = folds
+
+  vim.bo[panel].modifiable = true
+  api.nvim_buf_clear_namespace(panel, ns, 0, -1)
+  api.nvim_buf_clear_namespace(panel, ns_selection, 0, -1)
+  api.nvim_buf_set_lines(panel, 0, -1, false, lines)
+  self:highlight_tree(lines)
+
+  vim.bo[panel].bufhidden = 'wipe'
+  vim.bo[panel].modifiable = false
+  if initial then
+    vim.bo[panel].filetype = 'gitsigns-diff'
+  end
+
+  -- Hide editor furniture and use tree depth for folding, independent of status text.
+  local wo = vim.wo[panel_win][0]
+  wo.number = false
+  wo.relativenumber = false
+  wo.signcolumn = 'no'
+  wo.foldcolumn = '0'
+
+  wo.foldexpr = 'get(b:gitsigns_diff_folds, v:lnum - 1, 0)'
+  wo.foldtext = 'b:gitsigns_diff_foldtext[v:foldstart]'
+  wo.foldmethod = 'expr'
+  wo.foldminlines = 0
+
+  wo.wrap = true
+  wo.linebreak = true
+  wo.breakindent = true
+  wo.spell = false
+  wo.list = false
+
+  wo.cursorline = true
+  wo.winfixbuf = true
+  wo.winfixwidth = true
+
+  if initial then
+    --- @diagnostic disable-next-line: deprecated
+    api.nvim_win_set_width(panel_win, 36)
+  end
+
+  -- Begin with all files visible; refresh restores any selected closed directory.
+  resize_panel(panel_win, self.header_lines, self.dirs)
+  wo.foldenable = true
+  vim.cmd('normal! zR')
+  api.nvim_win_set_cursor(
+    panel_win,
+    { self.file_lnums[1] or (self.commit and 1 or self.header_lines + 1), 0 }
+  )
+end
 
 --- Show a commit message or file diff beside the panel, recreating closed splits.
 --- Disable the previous diff before switching buffers and update window IDs in place.
---- @param windows Gitsigns.DiffWindows
+--- @private
 --- @param buf integer
 --- @param base_buf integer? Omit to show only the commit message.
-local function show_buffers(windows, buf, base_buf)
-  -- Hidden buffers keep participating in the diff unless removed before switching.
-  for _, win in ipairs({ windows.right, windows.left }) do
+--- @param jump? boolean Jump to the first hunk for a newly loaded buffer.
+function DiffPanel:show_buffers(buf, base_buf, jump)
+  -- Stop cursor/scroll binding before either window switches buffers, so the
+  -- previous file cannot move the next file's restored cursor.
+  for _, win in ipairs({ self.right_win, self.left_win }) do
     if api.nvim_win_is_valid(win) then
-      vim.wo[win].diff = false
+      api.nvim_win_call(win, function()
+        vim.cmd.diffoff()
+      end)
     end
   end
 
+  -- A commit message uses only the right pane. Recreate missing panes for file diffs.
   if not base_buf then
-    if windows.left and api.nvim_win_is_valid(windows.left) then
-      api.nvim_win_close(windows.left, false)
+    if self.left_win and api.nvim_win_is_valid(self.left_win) then
+      api.nvim_win_close(self.left_win, false)
     end
-    windows.left = nil
+    self.left_win = nil
   end
 
-  if not api.nvim_win_is_valid(windows.right) then
-    api.nvim_set_current_win(windows.panel)
+  if not api.nvim_win_is_valid(self.right_win) then
+    api.nvim_set_current_win(self.panel_win)
     vim.cmd.vsplit({ mods = { split = 'botright', keepalt = true } })
-    windows.right = api.nvim_get_current_win()
+    self.right_win = api.nvim_get_current_win()
   end
 
-  api.nvim_win_set_buf(windows.right, buf)
-  api.nvim_set_current_win(windows.right)
+  api.nvim_set_current_win(self.right_win)
+  if base_buf then
+    if not self.left_win or not api.nvim_win_is_valid(self.left_win) then
+      vim.cmd.vsplit({ mods = { split = 'aboveleft', keepalt = true } })
+      self.left_win = api.nvim_get_current_win()
+    end
+  end
+
+  api.nvim_win_set_buf(self.right_win, buf)
+  api.nvim_set_current_win(self.right_win)
   if not base_buf then
     return
   end
 
-  if not windows.left or not api.nvim_win_is_valid(windows.left) then
-    vim.cmd.vsplit({ mods = { split = 'aboveleft', keepalt = true } })
-    windows.left = api.nvim_get_current_win()
-  end
-  api.nvim_win_set_buf(windows.left, base_buf)
-  for _, win in ipairs({ windows.left, windows.right }) do
+  -- Re-enable diff binding only after both windows show the new buffers.
+  assert(self.left_win)
+  api.nvim_win_set_buf(self.left_win, base_buf)
+  for _, win in ipairs({ self.left_win, self.right_win }) do
     api.nvim_win_call(win, function()
       vim.cmd.diffthis()
-      vim.cmd('normal! gg')
     end)
   end
-  api.nvim_set_current_win(windows.right)
+
+  api.nvim_set_current_win(self.right_win)
   vim.cmd.diffupdate()
+
+  if jump then
+    vim.cmd('normal! gg')
+    -- Do not skip a change or deletion at the first line.
+    if fn.diff_hlID(1, 1) == 0 and fn.diff_filler(1) == 0 then
+      vim.cmd('silent! normal! ]c')
+    end
+  end
 end
 
---- Show panel and diff-buffer mappings in a focused popup.
---- @param panel integer
-local function show_help(panel)
-  local popup = require('gitsigns.popup')
-  popup.close('diff_help')
-  local lines = { { { 'File panel', 'Title' } } } --- @type Gitsigns.LineSpec[]
-  for _, map in ipairs(api.nvim_buf_get_keymap(panel, 'n')) do
-    lines[#lines + 1] = { { ('%-8s %s'):format(map.lhs, map.desc or map.rhs), 'Normal' } }
+--- Keep this buffer loaded until the last panel using it closes.
+--- @private
+--- @param buf integer
+--- @param created boolean?
+--- @param loaded boolean?
+function DiffPanel:retain(buf, created, loaded)
+  if not self.retained[buf] then
+    local ref = buffer_refs[buf]
+    if not ref then
+      -- Remember the original state once, even if several panels share this buffer.
+      ref = {
+        refs = 0,
+        bufhidden = vim.bo[buf].bufhidden,
+        loaded = loaded or false,
+        created = created or false,
+      }
+      buffer_refs[buf] = ref
+    end
+
+    ref.refs = ref.refs + 1
+    self.retained[buf] = true
   end
-  vim.list_extend(lines, {
-    { { '', 'Normal' } },
-    { { 'Diff buffers', 'Title' } },
-    { { ']f / [f  Next / previous file (accepts count)', 'Normal' } },
-    { { ']c / [c  Next / previous change', 'Normal' } },
-    { { '', 'Normal' } },
-    { { 'q / <Esc> / g?  Close this help', 'Comment' } },
+
+  vim.bo[buf].bufhidden = 'hide'
+end
+
+--- @package
+function DiffPanel:release()
+  for buf in pairs(self.retained) do
+    local ref = buffer_refs[buf]
+    ref.refs = ref.refs - 1
+
+    -- The last panel restores buffer policy without overriding a later user change.
+    if ref.refs == 0 then
+      buffer_refs[buf] = nil
+      if api.nvim_buf_is_valid(buf) then
+        if vim.bo[buf].bufhidden == 'hide' then
+          vim.bo[buf].bufhidden = ref.bufhidden
+        end
+
+        -- Preserve pre-existing buffers, unsaved edits, and windows in every tab.
+        if not ref.loaded and not vim.bo[buf].modified and #fn.win_findbuf(buf) == 0 then
+          api.nvim_buf_delete(buf, { unload = not ref.created })
+        end
+      end
+    end
+  end
+end
+
+--- Mark the displayed file without moving the panel cursor.
+--- @private
+--- @param index integer
+function DiffPanel:mark_current_file(index)
+  self.current_file = index
+  local entry = assert(self.entries[index])
+  local lnum = assert(self.file_lnums[index])
+  local line = assert(api.nvim_buf_get_lines(self.buf, lnum - 1, lnum, false)[1])
+
+  -- Skip the indentation, status columns, and their separator.
+  local col = select(2, entry.path:gsub('/', '')) * 2 + #entry.status + 2
+  api.nvim_buf_set_extmark(self.buf, ns_selection, lnum - 1, col, {
+    id = 1, -- Move the panel's single selection mark after a successful open.
+    end_col = #line,
+    hl_group = 'QuickFixLine',
+    priority = 50, -- Preserve file icon colors above the filename highlight.
   })
-  local win, buf =
-    popup.create(lines, require('gitsigns.config').config.preview_config, 'diff_help')
-  for _, key in ipairs({ '<Esc>', 'g?' }) do
-    vim.keymap.set('n', key, '<cmd>close<CR>', { buffer = buf, silent = true })
+end
+
+--- Reload the tree, restoring the displayed file and selected node.
+--- @private
+--- @async
+--- @param node Gitsigns.DiffNode
+--- @param folded? boolean
+function DiffPanel:refresh(node, folded)
+  local new_base, new_target, new_entries, new_commit =
+    git_diff(self.repo, self.revision, self.paths, self.cwd, self.show_commit)
+  if not api.nvim_win_is_valid(self.panel_win) or api.nvim_get_current_tabpage() ~= self.tab then
+    return
   end
-  api.nvim_set_current_win(win)
+
+  local current_entry = self.entries[self.current_file]
+
+  -- Replace the row data together with its rendering.
+  self.base, self.target, self.entries, self.commit = new_base, new_target, new_entries, new_commit
+  api.nvim_set_current_win(self.panel_win)
+  self:render()
+
+  -- The displayed diff and the panel cursor can refer to different files.
+  self.current_file = 0
+  local current = current_entry and self.nodes[current_entry.path]
+  if current then
+    self:mark_current_file(current.first)
+  end
+
+  -- Keep the selected path when it survives; otherwise select a nearby file.
+  if #self.entries > 0 then
+    local selected = self.nodes[node.path]
+    local index = math.max(1, math.min(node.directory and 1 or node.first, #self.entries))
+    api.nvim_win_set_cursor(
+      self.panel_win,
+      { selected and selected.lnum or assert(self.file_lnums[index]), 0 }
+    )
+
+    if selected and selected.directory and folded then
+      vim.cmd('normal! zc')
+    end
+  end
+end
+
+--- Stage or unstage the selected file or directory, then refresh the panel.
+--- @private
+--- @async
+--- @param how 'stage'|'unstage'|'toggle'
+function DiffPanel:stage_files(how)
+  local lnum = api.nvim_win_get_cursor(self.panel_win)[1]
+  local node = self.rows[lnum]
+  if not node or self.target then
+    return
+  end
+
+  local folded = node.directory and fn.foldclosed(lnum) == lnum
+
+  -- Pass only listed descendants so directory actions respect panel filters.
+  local entries = vim.list_slice(self.entries, node.first, node.last)
+  local files = require('gitsigns.git').stage_files(self.repo, entries, how)
+  if not files then
+    return
+  end
+
+  -- Refresh attached buffers even when the Git watcher is disabled. Read the new
+  -- object ID before invalidating the cached index text used to calculate hunks.
+  for bufnr, bcache in pairs(cache) do
+    local git_obj = bcache.git_obj
+    if git_obj.repo == self.repo and vim.tbl_contains(files, bcache.file) then
+      git_obj:refresh()
+      if bcache:schedule() then
+        bcache:invalidate(true)
+        require('gitsigns.manager').update(bufnr)
+      end
+    end
+  end
+
+  self:refresh(node, folded)
+end
+
+--- Open the selected commit message, file diff, or one side in a new tab.
+--- Discard newly created buffers if the panel closes or the user changes tabs during a read.
+--- @private
+--- @async
+--- @param how Gitsigns.DiffAction
+function DiffPanel:open_file(how)
+  local lnum = api.nvim_win_get_cursor(self.panel_win)[1]
+  if lnum <= 2 and self.commit and how == 'diff' then
+    local buf, created, loaded = require('gitsigns.actions.show_commit').create_buf(
+      self.repo,
+      assert(self.target),
+      self.commit
+    )
+
+    self:retain(buf, created, loaded)
+    self:show_buffers(buf)
+    api.nvim_buf_clear_namespace(self.buf, ns_selection, 0, -1)
+    return
+  end
+
+  local node = self.rows[lnum]
+  if not node or node.directory then
+    return
+  end
+
+  local index = node.first
+  local entry = assert(self.entries[index])
+
+  -- Read both sides before changing windows; either read may yield to the user.
+  local buf, created, loaded = self:file_buffer(entry, how == 'base' and 'base' or 'target')
+  local old_buf, old_created, old_loaded
+  if buf and how == 'diff' then
+    old_buf, old_created, old_loaded = self:file_buffer(entry, 'base')
+  end
+
+  -- Abandoned reads must not retain buffers or change a different tab.
+  if
+    not buf
+    or (how == 'diff' and not old_buf)
+    or not api.nvim_win_is_valid(self.panel_win)
+    or api.nvim_get_current_tabpage() ~= self.tab
+  then
+    discard(buf, created)
+    discard(old_buf, old_created)
+    return
+  end
+
+  self:retain(buf, created, loaded)
+  if old_buf then
+    self:retain(old_buf, old_created, old_loaded)
+  end
+
+  if how == 'diff' then
+    self:show_buffers(buf, old_buf, not loaded)
+    self:mark_current_file(index)
+  else
+    vim.cmd.tabnew()
+    api.nvim_win_set_buf(0, buf)
+  end
+end
+
+--- Serialize panel actions, retaining the repository until each action finishes.
+--- @package
+--- @async
+--- @param how Gitsigns.DiffAction
+--- @param keep_focus? boolean
+function DiffPanel:run_action(how, keep_focus)
+  if self.busy then
+    return
+  end
+
+  self.busy = true
+  local focus_win = api.nvim_get_current_win()
+
+  -- Keep the repository alive if the panel is closed while Git is reading a file.
+  self.repo:ref()
+  local action = (how == 'stage' or how == 'unstage' or how == 'toggle') and self.stage_files
+    or self.open_file
+  local opened, open_err = pcall(action, self, how)
+
+  -- Release action state even when a read or index update failed.
+  self.repo:unref()
+  self.busy = false
+
+  if
+    keep_focus
+    and api.nvim_win_is_valid(focus_win)
+    and api.nvim_get_current_tabpage() == self.tab
+  then
+    api.nvim_set_current_win(focus_win)
+  end
+
+  if not opened then
+    message.error(open_err)
+  end
+end
+
+--- Move through this panel's files while keeping focus in the current diff window.
+--- @private
+--- @param count integer Signed file offset, clamped to the first and last entries.
+function DiffPanel:navigate(count)
+  if self.busy or #self.file_lnums == 0 then
+    return
+  end
+
+  local next_file = math.max(1, math.min(#self.file_lnums, self.current_file + count))
+  if next_file == self.current_file then
+    return
+  end
+
+  api.nvim_win_call(self.panel_win, function()
+    api.nvim_win_set_cursor(self.panel_win, { assert(self.file_lnums[next_file]), 0 })
+    vim.cmd('normal! zv')
+  end)
+
+  async.run(self.run_action, self, 'diff', true):raise_on_error()
+end
+
+--- Bind file navigation while a diff window is current, restoring mappings on leave.
+--- Shared buffers then use their normal mappings in every other window or panel.
+--- @package
+--- @return fun() cleanup
+function DiffPanel:setup_navigation()
+  local group = api.nvim_create_augroup('gitsigns_diff_' .. self.buf, {})
+  local restore = {} --- @type fun()[]
+  local mapped_win --- @type integer?
+  local directions = { [']f'] = 1, ['[f'] = -1 } --- @type table<string, integer>
+
+  --- Restore this window's mappings before entering another buffer or window.
+  local function unmap()
+    for _, undo in ipairs(restore) do
+      undo()
+    end
+
+    restore = {}
+    mapped_win = nil
+  end
+
+  api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
+    group = group,
+    callback = function()
+      -- Buffer operations in another window must not remove the current mappings.
+      if api.nvim_get_current_win() == mapped_win then
+        unmap()
+      end
+    end,
+  })
+
+  -- Install mappings only while one of this panel's diff windows is current.
+  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+    group = group,
+    callback = function()
+      local win = api.nvim_get_current_win()
+      if
+        #restore > 0
+        or not self.left_win
+        or not api.nvim_win_is_valid(self.left_win)
+        or (win ~= self.left_win and win ~= self.right_win)
+      then
+        return
+      end
+
+      local buf = api.nvim_get_current_buf()
+      mapped_win = win
+      for key, direction in pairs(directions) do
+        local previous = fn.maparg(key, 'n', false, true)
+        local callback = function()
+          self:navigate(direction * vim.v.count1)
+        end
+
+        vim.keymap.set('n', key, callback, {
+          buffer = buf,
+          desc = direction == 1 and 'Next file' or 'Previous file',
+        })
+
+        restore[#restore + 1] = function()
+          if not api.nvim_buf_is_valid(buf) then
+            return
+          end
+
+          api.nvim_buf_call(buf, function()
+            -- Leave a mapping installed by the user after entering the window alone.
+            if fn.maparg(key, 'n', false, true).callback == callback then
+              vim.keymap.del('n', key, { buffer = buf })
+              if previous.buffer == 1 then
+                fn.mapset('n', false, previous)
+              end
+            end
+          end)
+        end
+      end
+    end,
+  })
+
+  return function()
+    api.nvim_del_augroup_by_id(group)
+    unmap()
+  end
 end
 
 --- Bind panel actions for files, directory folds, commit metadata, and help.
---- @param open fun(how: 'diff'|'target'|'base', keep_focus?: boolean)
---- @param panel_buf integer
---- @param panel_win integer
-local function setup_keymaps(open, panel_buf, panel_win)
+--- @package
+function DiffPanel:setup_keymaps()
+  local panel_buf, panel_win = self.buf, self.panel_win
+
   --- Bind a normal-mode action to the panel buffer with its description.
   --- @param key string
   --- @param desc string
@@ -396,26 +946,52 @@ local function setup_keymaps(open, panel_buf, panel_win)
     vim.keymap.set('n', key, callback, { buffer = panel_buf, desc = desc })
   end
 
-  map('<CR>', 'Open file, show commit message, or toggle directory fold', function()
+  local function open_selected()
     local lnum = api.nvim_win_get_cursor(panel_win)[1]
-    if lnum > 3 and fn.indent(lnum + 1) > fn.indent(lnum) then
+    local node = self.rows[lnum]
+    if node and node.directory then
       vim.cmd('normal! za')
     else
-      async.run(open, 'diff'):raise_on_error()
+      async.run(self.run_action, self, 'diff'):raise_on_error()
+    end
+  end
+
+  map('<CR>', 'Open file, show commit message, or toggle directory fold', open_selected)
+
+  -- The press first enters the panel, even when another buffer had focus.
+  map('<LeftRelease>', 'Open clicked entry or toggle directory fold', function()
+    local mouse = fn.getmousepos()
+    if mouse.winid == panel_win and mouse.line > 0 then
+      open_selected()
     end
   end)
 
   map('<S-CR>', 'Diff file and keep focus in the panel', function()
-    async.run(open, 'diff', true):raise_on_error()
+    async.run(self.run_action, self, 'diff', true):raise_on_error()
   end)
 
   map('o', 'View target file (tab)', function()
-    async.run(open, 'target'):raise_on_error()
+    async.run(self.run_action, self, 'target'):raise_on_error()
   end)
 
   map('O', 'View file at base revision (tab)', function()
-    async.run(open, 'base'):raise_on_error()
+    async.run(self.run_action, self, 'base'):raise_on_error()
   end)
+
+  -- Only working-tree comparisons can stage or unstage files.
+  if not self.target then
+    map('s', 'Stage file or directory', function()
+      async.run(self.run_action, self, 'stage', true):raise_on_error()
+    end)
+
+    map('u', 'Unstage file or directory', function()
+      async.run(self.run_action, self, 'unstage', true):raise_on_error()
+    end)
+
+    map('<Space>', 'Toggle file or directory staging', function()
+      async.run(self.run_action, self, 'toggle', true):raise_on_error()
+    end)
+  end
 
   map('g?', 'Show available keys', function()
     show_help(panel_buf)
@@ -451,7 +1027,8 @@ end
 --- @async
 --- @param revision? string Commit or revision range; nil compares HEAD with the working tree.
 --- @param paths? string[] Git pathspecs, relative to the current directory in the repository.
-return function(revision, paths)
+--- @param show_commit? boolean Compare a commit with its first parent.
+return function(revision, paths, show_commit)
   local source_win = api.nvim_get_current_win()
   local cwd = fn.getcwd()
   local repo, err = get_repo()
@@ -460,8 +1037,8 @@ return function(revision, paths)
     return
   end
 
-  local ok, base, target, entries, commit =
-    pcall(require('gitsigns.git.diff'), repo, revision, paths, cwd)
+  -- Read the comparison before creating any review windows.
+  local ok, base, target, entries, commit = pcall(git_diff, repo, revision, paths, cwd, show_commit)
   if not ok then
     repo:unref()
     message.error(base or 'Unable to read revision')
@@ -473,6 +1050,7 @@ return function(revision, paths)
     return
   end
 
+  -- Reuse only a pristine startup window; existing work keeps its own tab.
   if
     #api.nvim_list_tabpages() > 1
     or fn.winlayout()[1] ~= 'leaf' -- Floating UI does not count as an existing split.
@@ -484,134 +1062,79 @@ return function(revision, paths)
   then
     vim.cmd.tabnew()
   end
+
+  -- Reserve the initial window for file contents and add the tree on its left.
   local tab = api.nvim_get_current_tabpage()
   local right_win = api.nvim_get_current_win()
   vim.bo.bufhidden = 'wipe'
 
   vim.cmd.vsplit({ mods = { split = 'topleft', keepalt = true } })
   local panel_win = api.nvim_get_current_win()
-  local windows = { panel = panel_win, right = right_win } --- @type Gitsigns.DiffWindows
   local panel = api.nvim_create_buf(false, true)
   api.nvim_win_set_buf(panel_win, panel)
   api.nvim_buf_set_name(panel, ('gitsigns-diff://%s//%d'):format(repo.gitdir, tab))
 
-  local file_lnums = render_panel(panel_win, revision, entries, commit)
-  local current_file = 1
+  local self = setmetatable({
+    buf = panel,
+    tab = tab,
+    panel_win = panel_win,
+    right_win = right_win,
 
-  --- Open the selected commit message, file diff, or one side in a new tab.
-  --- Discard newly created buffers if the panel closes or the user changes tabs during a read.
-  --- @async
-  --- @param how 'diff'|'target'|'base'
-  local function open_file(how)
-    local lnum = api.nvim_win_get_cursor(panel_win)[1]
-    if lnum == 1 and commit and how == 'diff' then
-      local buf = require('gitsigns.actions.show_commit').create_buf(repo, assert(target), commit)
-      show_buffers(windows, buf)
-      api.nvim_buf_clear_namespace(panel, ns_selection, 0, -1)
-      return
-    end
+    repo = repo,
+    revision = revision,
+    paths = paths,
+    cwd = cwd,
+    show_commit = show_commit,
 
-    local index = fn.index(file_lnums, lnum) + 1
-    local entry = entries[index]
-    if not entry then
-      return
-    end
+    base = base,
+    target = target,
+    entries = entries,
+    commit = commit,
 
-    local old = how == 'base'
-    local buf, created = file_buffer(repo, old and base or target, entry, old)
-    local old_buf, old_created
-    if buf and how == 'diff' then
-      old_buf, old_created = file_buffer(repo, base, entry, true)
-    end
-    if
-      not buf
-      or (how == 'diff' and not old_buf)
-      or not api.nvim_win_is_valid(panel_win)
-      or api.nvim_get_current_tabpage() ~= tab
-    then
-      discard(buf, created)
-      discard(old_buf, old_created)
-      return
-    end
+    -- Tree lookups are rebuilt together during rendering.
+    file_lnums = {},
+    rows = {},
+    nodes = {},
+    header_lines = 0,
+    dirs = {},
+    current_file = 1,
 
-    if how == 'diff' then
-      show_buffers(windows, buf, old_buf)
-      current_file = index
-      local line = assert(api.nvim_buf_get_lines(panel, lnum - 1, lnum, false)[1])
-      -- Skip the indentation, status letter, and its separator.
-      local col = assert(line:find('%S')) + 1
-      api.nvim_buf_set_extmark(panel, ns_selection, lnum - 1, col, {
-        id = 1, -- Move the panel's single selection mark after a successful open.
-        end_col = #line,
-        hl_group = 'QuickFixLine',
-        priority = 50, -- Preserve file icon colors above the filename highlight.
-      })
-    else
-      vim.cmd.tabnew()
-      api.nvim_win_set_buf(0, buf)
-    end
-  end
+    -- Kept across file switches until this review closes.
+    scratch = {},
+    retained = {},
+    busy = false,
+  }, DiffPanel)
 
-  local busy = false
-  --- Ignore overlapping opens; retain the repository during reads and report errors.
-  --- @async
-  --- @param how 'diff'|'target'|'base'
-  --- @param keep_focus? boolean
-  local function open(how, keep_focus)
-    if busy then
-      return
-    end
-    busy = true
-    local focus_win = api.nvim_get_current_win()
-    -- Keep the repository alive if the panel is closed while Git is reading a file.
-    repo:ref()
-    local opened, open_err = pcall(open_file, how)
-    repo:unref()
-    busy = false
-    if
-      keep_focus
-      and api.nvim_win_is_valid(focus_win)
-      and api.nvim_get_current_tabpage() == tab
-    then
-      api.nvim_set_current_win(focus_win)
-    end
-    if not opened then
-      message.error(open_err)
-    end
-  end
+  self:render()
 
-  --- Move through this panel's files while keeping focus in the current diff window.
-  --- @param count integer Signed file offset, clamped to the first and last entries.
-  local unmap = setup_navigation(panel, windows, function(count)
-    if busy then
-      return
-    end
+  -- Tie window updates, temporary mappings, and retained buffers to the panel.
+  local resize = api.nvim_create_autocmd('WinResized', {
+    callback = function()
+      if api.nvim_win_is_valid(panel_win) then
+        resize_panel(panel_win, self.header_lines, self.dirs)
+      end
+    end,
+  })
 
-    local next_file = math.max(1, math.min(#file_lnums, current_file + count))
-    if next_file == current_file then
-      return
-    end
-
-    api.nvim_win_call(panel_win, function()
-      api.nvim_win_set_cursor(panel_win, { assert(file_lnums[next_file]), 0 })
-      vim.cmd('normal! zv')
-    end)
-
-    async.run(open, 'diff', true):raise_on_error()
-  end)
-
+  local unmap = self:setup_navigation()
   api.nvim_create_autocmd('BufWipeout', {
     buffer = panel,
     once = true,
     callback = function()
       unmap()
+      api.nvim_del_autocmd(resize)
       repo:unref()
+
+      -- Wait for tab closure to remove its windows before checking other users.
+      vim.schedule(function()
+        self:release()
+      end)
     end,
   })
 
-  setup_keymaps(open, panel, panel_win)
+  self:setup_keymaps()
 
   if #entries > 0 then
-    open('diff', true)
+    self:run_action('diff', true)
   end
 end

--- a/lua/gitsigns/actions/diff.lua
+++ b/lua/gitsigns/actions/diff.lua
@@ -719,9 +719,10 @@ function DiffPanel:stage_files(how)
 
   -- Refresh attached buffers even when the Git watcher is disabled. Read the new
   -- object ID before invalidating the cached index text used to calculate hunks.
+  -- Match Git object paths because native buffer paths can use backslashes.
   for bufnr, bcache in pairs(cache) do
     local git_obj = bcache.git_obj
-    if git_obj.repo == self.repo and vim.tbl_contains(files, bcache.file) then
+    if git_obj.repo == self.repo and vim.tbl_contains(files, git_obj.file) then
       git_obj:refresh()
       if bcache:schedule() then
         bcache:invalidate(true)

--- a/lua/gitsigns/actions/diffthis.lua
+++ b/lua/gitsigns/actions/diffthis.lua
@@ -21,11 +21,14 @@ local function read_revision(bufnr, text)
   local ok, err = pcall(function()
     vim.fn.writefile(text, path, 'b')
     api.nvim_buf_call(bufnr, function()
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { '' })
       vim.cmd('silent noautocmd keepalt 0read ++edit ' .. vim.fn.fnameescape(path))
+
       -- :read leaves the empty buffer's original line after the inserted text.
       api.nvim_buf_set_lines(bufnr, -2, -1, false, {})
     end)
   end)
+
   vim.fn.delete(path)
   if not ok then
     error(err)
@@ -41,6 +44,8 @@ end
 local function bufread(repo, dbufnr, base, relpath, bufnr)
   local bcache = bufnr and cache[bufnr]
   base = util.norm_base(base)
+
+  -- Reuse the attached buffer's comparison text when it describes this revision.
   local text --- @type string[]
   if bcache and base == bcache.git_obj.revision and relpath == bcache.git_obj.relpath then
     text = assert(bcache.compare_text)
@@ -60,6 +65,9 @@ local function bufread(repo, dbufnr, base, relpath, bufnr)
     end
   end
 
+  -- Match the source file's format before replacing text and restoring protection.
+  local modifiable = vim.bo[dbufnr].modifiable
+  vim.bo[dbufnr].modifiable = true
   vim.bo[dbufnr].fileformat = bcache
       and relpath == bcache.git_obj.relpath
       and vim.bo[assert(bufnr)].fileformat
@@ -68,8 +76,6 @@ local function bufread(repo, dbufnr, base, relpath, bufnr)
   vim.bo[dbufnr].filetype = vim.filetype.match({ buf = dbufnr })
   vim.bo[dbufnr].bufhidden = 'wipe'
 
-  local modifiable = vim.bo[dbufnr].modifiable
-  vim.bo[dbufnr].modifiable = true
   Status.update(dbufnr, { head = base })
 
   if bcache then
@@ -80,6 +86,7 @@ local function bufread(repo, dbufnr, base, relpath, bufnr)
 
   vim.bo[dbufnr].modifiable = modifiable
   vim.bo[dbufnr].modified = false
+
   -- TODO(lewis6991): make this blocking
   require('gitsigns.attach').attach({
     bufnr = dbufnr,
@@ -123,28 +130,42 @@ end
 --- @return string? bufname Buffer name
 --- @return integer? bufnr Buffer number
 --- @return boolean? created Whether a new buffer was created.
+--- @return boolean? loaded Whether the buffer was already loaded.
 function M.create_revision_buf(repo, base, relpath, bufnr)
   base = util.norm_base(base)
 
   local name_base = base or (bufnr and assert(cache[bufnr]).git_obj.revision) or ':0'
   local bufname = ('gitsigns://%s//%s:%s'):format(repo.gitdir, name_base, relpath)
 
-  if util.bufexists(bufname) then
-    return bufname, vim.fn.bufnr(bufname), false
+  local exists = util.bufexists(bufname)
+  local dbuf = exists and vim.fn.bufnr(bufname) or api.nvim_create_buf(false, true)
+  local loaded = exists and api.nvim_buf_is_loaded(dbuf)
+
+  -- Editable index buffers already have a BufReadCmd to reload them.
+  if exists and (loaded or vim.bo[dbuf].buftype == 'acwrite') then
+    return bufname, dbuf, false, loaded
   end
 
-  local dbuf = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_name(dbuf, bufname)
+  if not exists then
+    api.nvim_buf_set_name(dbuf, bufname)
+  end
 
+  -- An unloaded historical buffer needs its contents populated again.
   local ok, err = pcall(bufread, repo, dbuf, base, relpath, bufnr)
   if not ok then
     message.error(err --[[@as string]])
     async.schedule()
-    api.nvim_buf_delete(dbuf, { force = true })
+
+    -- A failed reload must not delete a buffer that already belonged to the user.
+    if exists then
+      vim.bo[dbuf].modifiable = false
+    else
+      api.nvim_buf_delete(dbuf, { force = true })
+    end
     return
   end
 
-  -- allow editing the index revision
+  -- Index buffers write back to Git; historical revisions remain read-only.
   if not base then
     assert(bufnr, 'Index revisions need a source buffer')
     vim.bo[dbuf].buftype = 'acwrite'
@@ -169,7 +190,7 @@ function M.create_revision_buf(repo, base, relpath, bufnr)
     vim.bo[dbuf].modifiable = false
   end
 
-  return bufname, dbuf, true
+  return bufname, dbuf, not exists, loaded
 end
 
 --- @async

--- a/lua/gitsigns/actions/show_commit.lua
+++ b/lua/gitsigns/actions/show_commit.lua
@@ -41,21 +41,33 @@ local M = {}
 --- @param base string
 --- @param message? string[]
 --- @return integer commit_buf
+--- @return boolean created
+--- @return boolean loaded
 function M.create_buf(repo, base, message)
   local lines = message or require('gitsigns.git.commit')(repo, base, 'full')
+
   -- Message and full commit views must not reuse each other's contents or mappings.
   local buffer_name = ('gitsigns%s://%s//%s'):format(message and '-commit' or '', repo.gitdir, base)
-  if Util.bufexists(buffer_name) then
-    return vim.fn.bufnr(buffer_name)
+  local exists = Util.bufexists(buffer_name)
+  local commit_buf = exists and vim.fn.bufnr(buffer_name) or api.nvim_create_buf(true, true)
+  local loaded = exists and api.nvim_buf_is_loaded(commit_buf)
+
+  if loaded then
+    return commit_buf, false, true
   end
 
-  local commit_buf = api.nvim_create_buf(true, true)
-  api.nvim_buf_set_name(commit_buf, buffer_name)
+  if not exists then
+    api.nvim_buf_set_name(commit_buf, buffer_name)
+  end
+
+  -- Populate new or unloaded buffers before restoring their read-only presentation.
+  vim.bo[commit_buf].modifiable = true
   api.nvim_buf_set_lines(commit_buf, 0, -1, false, lines)
   vim.bo[commit_buf].modifiable = false
   vim.bo[commit_buf].buftype = 'nofile'
   vim.bo[commit_buf].filetype = message and 'gitcommit' or 'git'
   vim.bo[commit_buf].bufhidden = 'wipe'
+
   if message then
     vim.keymap.set('n', 'q', '<cmd>close<CR>', {
       buffer = commit_buf,
@@ -63,7 +75,8 @@ function M.create_buf(repo, base, message)
       desc = 'Close commit message',
     })
   end
-  return commit_buf
+
+  return commit_buf, not exists, loaded
 end
 
 --- Follow a parent or tree reference, or open a file at the selected patch line.

--- a/lua/gitsigns/cli/completion/generated.lua
+++ b/lua/gitsigns/cli/completion/generated.lua
@@ -148,7 +148,7 @@ return {
         {
           name = 'open',
           required = true,
-          values = { 'vsplit', 'tabnew' },
+          values = { 'diff', 'vsplit', 'tabnew' },
         },
       },
     },

--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -155,6 +155,61 @@ function Obj:unstage_file()
   autocmd_changed(self.file)
 end
 
+--- Stage saved files, or restore their index entries to HEAD.
+--- @async
+--- @param repo Gitsigns.Repo
+--- @param entries Gitsigns.DiffEntry[]
+--- @param how 'stage'|'unstage'|'toggle'
+--- @return string[]? files Updated absolute paths, or nil if there was nothing to do.
+function M.stage_files(repo, entries, how)
+  -- A directory may contain both staged and unstaged files. Gather both operations.
+  local stage_paths = {} --- @type string[]
+  local unstage_paths = {} --- @type string[]
+
+  for _, entry in ipairs(entries) do
+    local index_status, worktree_status = entry.status:match('(.)(.)')
+
+    -- Include both sides of renames so Git also updates the old path.
+    if worktree_status ~= ' ' then
+      vim.list_extend(stage_paths, entry.worktree_paths or { entry.path })
+    end
+    if index_status ~= ' ' and index_status ~= '?' then
+      vim.list_extend(unstage_paths, entry.index_paths or { entry.path })
+    end
+  end
+
+  -- Toggling stages any remaining worktree changes before it unstages the selection.
+  local stage = how == 'stage' or (how == 'toggle' and #stage_paths > 0)
+  local paths = stage and stage_paths or unstage_paths
+  if #paths == 0 then
+    return
+  end
+
+  -- Update the whole selection in one command, serialized with other index writes.
+  repo:lock(function()
+    local _, err, code = repo:command(
+      util.flatten({
+        '--literal-pathspecs',
+        stage and 'add' or 'reset',
+        not stage and '-q',
+        '--',
+        paths,
+      }),
+      { ignore_error = true }
+    )
+    if code ~= 0 then
+      error(err or 'Unable to update index', 0)
+    end
+  end)
+
+  for i, path in ipairs(paths) do
+    paths[i] = util.Path.join(repo.toplevel, path)
+    autocmd_changed(paths[i])
+  end
+
+  return paths
+end
+
 --- @async
 --- @param contents? string[]
 --- @param lnum? integer|[integer, integer]

--- a/lua/gitsigns/git/diff.lua
+++ b/lua/gitsigns/git/diff.lua
@@ -4,7 +4,9 @@ local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 --- @class (exact) Gitsigns.DiffEntry
 --- @field path string
 --- @field oldpath? string
---- @field status string
+--- @field status string One column for revisions; index and worktree columns otherwise.
+--- @field index_paths? string[]
+--- @field worktree_paths? string[]
 --- @field old_mode string
 --- @field mode string
 --- @field old_oid string
@@ -20,101 +22,70 @@ local uv = vim.uv or vim.loop ---@diagnostic disable-line: deprecated
 local function command(repo, args, opts)
   opts = opts or {}
   opts.ignore_error = true
+
   -- Normalize line endings in metadata; raw filename records opt out.
   local out, err, code = repo:command(args, opts)
   if code ~= 0 then
     error(err or 'Unable to read revision', 0)
   end
+
   return out
 end
 
 --- @async
 --- @param repo Gitsigns.Repo
---- @param revision string
+--- @param revision? string Defaults to HEAD.
 --- @return string
 local function resolve(repo, revision)
   revision = util.norm_base(revision == '' and 'HEAD' or revision) or 'HEAD'
+
   -- Avoid brace expansion by MSYS2 when Neovim launches Git.
   return assert(command(repo, { 'rev-parse', '--verify', revision .. '^0' })[1])
 end
 
+--- Read raw changes and their diffstats from the same Git invocation.
 --- @async
 --- @param repo Gitsigns.Repo
---- @param revision? string
---- @param paths? string[] Git pathspecs.
---- @param cwd? string Directory from which paths were supplied.
---- @return string? left
---- @return string? right Nil for the working tree.
---- @return Gitsigns.DiffEntry[] entries
---- @return string[]? commit Summary, author, date, and message for a single commit.
-return function(repo, revision, paths, cwd)
-  paths = paths or {}
-  -- Use Git's path format (POSIX for MSYS2) so it can find cwd within the
-  -- worktree and apply pathspec prefixes when running from a subdirectory.
-  local git_opts = #paths > 0
-      and {
-        '--no-literal-pathspecs',
-        '--work-tree',
-        assert(command(repo, { '--work-tree', '.', 'rev-parse', '--show-toplevel' })[1]),
-        '-C',
-        cwd or vim.fn.getcwd(),
-      }
-    or {}
-  local from, dots, to
-  if revision then
-    from, dots, to = revision:match('^(.-)(%.%.%.?)(.-)$')
-  end
-  local left, right --- @type string?, string?
-  local commit --- @type string[]?
-  if not revision then
-    local head, _, code = repo:command({ 'rev-parse', '--verify', 'HEAD' }, { ignore_error = true })
-    -- Hash the empty tree without writing an object, for repositories without commits.
-    left = code == 0 and head[1]
-      or repo:command({ 'hash-object', '-t', 'tree', '--stdin' }, { stdin = '' })[1]
-  elseif from then
-    left, right = resolve(repo, from), resolve(repo, assert(to))
-    if dots == '...' then
-      left = assert(command(repo, { 'merge-base', left, right })[1])
-    end
-  else
-    right = resolve(repo, revision)
-    -- A merge is reviewed against its first parent. A root commit has no left side.
-    commit, left = require('gitsigns.git.commit')(repo, right, 'message')
-  end
-
+--- @param args string[]
+--- @param paths string[]
+--- @return Gitsigns.DiffEntry[]
+--- @return table<string, Gitsigns.DiffEntry>
+local function read_diff(repo, args, paths)
   local out = command(
     repo,
     util.flatten({
-      git_opts,
-      revision and { 'diff-tree', '--root', '--no-commit-id', '-r' } or 'diff',
+      args,
       '--raw',
       '--numstat',
       '-z',
       '--no-abbrev',
       '--find-renames',
       '--no-relative',
-      left,
-      right,
       '--',
       paths,
     }),
     { text = false }
   )
+
   -- The command helper splits on newlines; restore them before parsing NUL records.
   local fields = vim.split(table.concat(out, '\n'), '\0', { plain = true, trimempty = true })
   local entries = {} --- @type Gitsigns.DiffEntry[]
   local by_path = {} --- @type table<string, Gitsigns.DiffEntry>
+
+  -- First build entries from raw records, including both paths for renames.
   local i = 1
   while i <= #fields and assert(fields[i]):sub(1, 1) == ':' do
     local old_mode, mode, old_oid, oid, status =
       assert(fields[i]):match('^:(%d+) (%d+) (%x+) (%x+) (%w+)$')
     assert(status, 'Invalid diff record')
+
     local path, oldpath = assert(fields[i + 1]), nil
     i = i + 2
     if status:sub(1, 1) == 'R' or status:sub(1, 1) == 'C' then
       oldpath, path = path, assert(fields[i])
       i = i + 1
     end
+
     local entry = {
       path = path,
       oldpath = oldpath,
@@ -137,73 +108,249 @@ return function(repo, revision, paths, cwd)
       path = assert(fields[i + 2])
       i = i + 2
     end
+
     local entry = by_path[path]
     entry.added, entry.removed = tonumber(added), tonumber(removed)
     i = i + 1
   end
 
-  if not revision then
-    local untracked = command(
-      repo,
-      util.flatten({
-        git_opts,
-        'ls-files',
-        '--full-name',
-        '--others',
-        '--exclude-standard',
-        '-z',
-        '--',
-        paths,
-      }),
-      { text = false }
+  return entries, by_path
+end
+
+--- Read staging status independently of the revision being compared.
+--- @async
+--- @param repo Gitsigns.Repo
+--- @param git_opts string[]
+--- @param paths string[]
+--- @return {path:string, status:string, mode?:string, oldpath?:string}[]
+local function read_status(repo, git_opts, paths)
+  local out = command(
+    repo,
+    util.flatten({
+      git_opts,
+      'status',
+      '--porcelain=v2',
+      '-z',
+      '--untracked-files=all',
+      '--renames',
+      '--',
+      paths,
+    }),
+    { text = false }
+  )
+
+  -- NUL delimiters preserve whitespace and newlines within filenames.
+  local records = vim.split(table.concat(out, '\n'), '\0', { plain = true, trimempty = true })
+  local entries = {}
+  local i = 1
+
+  while i <= #records do
+    local record = assert(records[i])
+    local kind = record:sub(1, 1)
+
+    if kind == '?' then
+      -- Nested repositories are listed with a trailing slash.
+      entries[#entries + 1] = { path = record:sub(3):gsub('/$', ''), status = '??' }
+    elseif kind == '1' or kind == '2' or kind == 'u' then
+      -- Ordinary/renamed records contain HEAD/index modes and hashes; unmerged
+      -- records contain three stages. Retain the worktree mode and status.
+      local pattern = kind == 'u' and '^u (..) %S+ %d+ %d+ %d+ (%d+) %x+ %x+ %x+ (.*)$'
+        or '^[12] (..) %S+ %d+ %d+ (%d+) %x+ %x+ (.*)$'
+      local status, mode, path = record:match(pattern)
+      assert(status and mode and path, 'Invalid status record')
+
+      -- Renames have a score before the path and the origin in the next NUL record.
+      local oldpath
+      if kind == '2' then
+        path = assert(path:match('^%S+ (.*)$')) -- Skip the rename/copy score.
+        i = i + 1
+        oldpath = assert(records[i])
+      end
+
+      -- Use the panel's blank status columns instead of porcelain's dots.
+      entries[#entries + 1] = {
+        path = path,
+        status = status:gsub('%.', ' '),
+        mode = mode,
+        oldpath = oldpath,
+      }
+    end
+    i = i + 1
+  end
+
+  return entries
+end
+
+--- Add an untracked path, including a replacement for a staged deletion.
+--- @async
+--- @param repo Gitsigns.Repo
+--- @param path string
+--- @param entries Gitsigns.DiffEntry[]
+--- @param by_path table<string, Gitsigns.DiffEntry>
+local function add_untracked(repo, path, entries, by_path)
+  local stat = uv.fs_lstat(repo.toplevel .. '/' .. path)
+  if not stat then
+    return
+  end
+
+  local mode = stat.type == 'link' and '120000' or stat.type == 'directory' and '160000' or '100644'
+  local entry = by_path[path]
+  if entry then
+    -- A staged deletion can have an untracked replacement at the same path.
+    entry.mode = mode
+    entry.status = entry.status:sub(1, 1) .. '?'
+  else
+    entry = {
+      path = path,
+      status = '??',
+      old_mode = '000000',
+      mode = mode,
+      old_oid = '',
+      oid = '',
+    }
+    entries[#entries + 1] = entry
+    by_path[path] = entry
+  end
+
+  if stat.type == 'directory' then
+    -- Untracked repositories are displayed as one added gitlink line.
+    entry.added, entry.removed = 1, entry.removed or 0
+  else
+    -- The index omits these paths. Compare replacements directly with
+    -- their old blob, and new files with an empty file.
+    local sides = entry.old_mode ~= '000000' and { entry.old_oid, '--', './' .. path }
+      or { '--no-index', '--', '/dev/null', './' .. path }
+    local stats, stats_err, code = repo:command(
+      util.flatten({ 'diff', '--numstat', '-z', sides }),
+      { text = false, ignore_error = true }
     )
-    for _, name in
-      ipairs(vim.split(table.concat(untracked, '\n'), '\0', { plain = true, trimempty = true }))
-    do
-      local path = name:gsub('/$', '') -- Git lists nested repositories with a trailing slash.
-      local stat = uv.fs_lstat(repo.toplevel .. '/' .. path)
-      if stat then
-        local mode = stat.type == 'link' and '120000'
-          or stat.type == 'directory' and '160000'
-          or '100644'
+    if code > 1 then -- --no-index returns 1 when files differ.
+      error(stats_err or 'Unable to read diffstat', 0)
+    end
+
+    local record = stats[1] ~= '' and assert(stats[1]) or '0\t0\t'
+    local added, removed = record:match('^([%d-]+)\t([%d-]+)\t')
+    entry.added, entry.removed = tonumber(added), tonumber(removed)
+  end
+end
+
+--- @async
+--- @param repo Gitsigns.Repo
+--- @param revision? string
+--- @param paths? string[] Git pathspecs.
+--- @param cwd? string Directory from which paths were supplied.
+--- @param show_commit? boolean Compare a commit with its first parent.
+--- @return string? base Base revision; nil when showing a root commit.
+--- @return string? target Target revision; nil for the working tree.
+--- @return Gitsigns.DiffEntry[] entries
+--- @return string[]? commit Summary, author, date, and message for a single commit.
+return function(repo, revision, paths, cwd, show_commit)
+  paths = paths or {}
+
+  -- Use Git's path format (POSIX for MSYS2) so it can find cwd within the
+  -- worktree and apply pathspec prefixes when running from a subdirectory.
+  local git_opts = #paths > 0
+      and {
+        '--no-literal-pathspecs',
+        '--work-tree',
+        assert(command(repo, { '--work-tree', '.', 'rev-parse', '--show-toplevel' })[1]),
+        '-C',
+        cwd or vim.fn.getcwd(),
+      }
+    or {}
+
+  -- Resolve revision arguments before reading the compared paths.
+  local from, dots, to
+  if revision then
+    from, dots, to = revision:match('^(.-)(%.%.%.?)(.-)$')
+  end
+
+  local base, target --- @type string?, string?
+  local commit --- @type string[]?
+  if show_commit then
+    target = resolve(repo, revision)
+
+    -- A merge is reviewed against its first parent. A root commit has no parent.
+    commit, base = require('gitsigns.git.commit')(repo, target, 'message')
+  elseif not revision then
+    local head, _, code = repo:command({ 'rev-parse', '--verify', 'HEAD' }, { ignore_error = true })
+
+    -- Hash the empty tree without writing an object, for repositories without commits.
+    base = code == 0 and head[1]
+      or repo:command({ 'hash-object', '-t', 'tree', '--stdin' }, { stdin = '' })[1]
+  elseif from then
+    base, target = resolve(repo, from), resolve(repo, assert(to))
+    if dots == '...' then
+      base = assert(command(repo, { 'merge-base', base, target })[1])
+    end
+  else
+    base = resolve(repo, revision)
+  end
+
+  -- This diff supplies the file list and stats for the selected comparison.
+  local entries, by_path = read_diff(
+    repo,
+    util.flatten({
+      git_opts,
+      target and { 'diff-tree', '--root', '--no-commit-id', '-r', base, target }
+        or { 'diff', base },
+    }),
+    paths
+  )
+
+  -- Staging status is always relative to HEAD/index, even for an older display base.
+  if not target then
+    for _, entry in ipairs(entries) do
+      entry.status = '  '
+    end
+
+    for _, change in ipairs(read_status(repo, git_opts, paths)) do
+      local path = change.path
+      if change.status == '??' then
+        add_untracked(repo, path, entries, by_path)
+      else
         local entry = by_path[path]
-        if entry then
-          -- A staged deletion can have an untracked replacement at the same path.
-          entry.mode = mode
-          entry.status = 'M'
-        else
+        if not entry then
+          -- Changes can cancel out in the displayed diff. Keep these files
+          -- available for staging, using the selected base rather than HEAD.
+          local tree = command(repo, {
+            '--literal-pathspecs',
+            'ls-tree',
+            '-z',
+            assert(base),
+            '--',
+            path,
+          }, { text = false })
+          local mode, oid = table.concat(tree, '\n'):match('^(%d+) %w+ (%x+)\t')
+
           entry = {
             path = path,
-            status = '?',
-            old_mode = '000000',
-            mode = mode,
-            old_oid = '',
+            status = change.status,
+            old_mode = mode or '000000',
+            old_oid = oid or '',
+            mode = assert(change.mode),
             oid = '',
+            added = 0,
+            removed = 0,
           }
           entries[#entries + 1] = entry
+          by_path[path] = entry
         end
 
-        if stat.type == 'directory' then
-          -- Untracked repositories are displayed as one added gitlink line.
-          entry.added, entry.removed = 1, entry.removed or 0
-        else
-          -- The index omits these paths. Compare replacements directly with
-          -- their old blob, and new files with an empty file.
-          local sides = entry.old_mode ~= '000000' and { entry.old_oid, '--', './' .. path }
-            or { '--no-index', '--', '/dev/null', './' .. path }
-          local stats, stats_err, code = repo:command(
-            util.flatten({ 'diff', '--numstat', '-z', sides }),
-            { text = false, ignore_error = true }
-          )
-          if code > 1 then -- --no-index returns 1 when files differ.
-            error(stats_err or 'Unable to read diffstat', 0)
+        entry.status = change.status
+
+        -- A staging action must include the origin on the side that contains the rename.
+        if change.oldpath then
+          if change.status:sub(1, 1):match('[RC]') then
+            entry.index_paths = { path, change.oldpath }
           end
-          local record = stats[1] ~= '' and assert(stats[1]) or '0\t0\t'
-          local added, removed = record:match('^([%d-]+)\t([%d-]+)\t')
-          entry.added, entry.removed = tonumber(added), tonumber(removed)
+          if change.status:sub(2, 2):match('[RC]') then
+            entry.worktree_paths = { path, change.oldpath }
+          end
         end
       end
     end
   end
-  return left, right, entries, commit
+
+  return base, target, entries, commit
 end

--- a/lua/gitsigns/highlight.lua
+++ b/lua/gitsigns/highlight.lua
@@ -111,6 +111,14 @@ end
 
 vim.list_extend(M.hls, {
   {
+    GitSignsDiffStaged = {
+      'Normal',
+      fg_factor = 0.15,
+      desc = 'Used for fully staged filenames in the diff panel.',
+    },
+  },
+
+  {
     GitSignsAddPreview = {
       'GitGutterAddLine',
       'SignifyLineAdd',

--- a/test/actions_spec.lua
+++ b/test/actions_spec.lua
@@ -194,7 +194,7 @@ describe('actions', function()
       '--split=topleft',
       '--split=botright',
     }, complete('--split=', 'Gitsigns diffthis --split='))
-    eq({ 'vsplit', 'tabnew' }, complete('', 'Gitsigns show_commit main '))
+    eq({ 'diff', 'vsplit', 'tabnew' }, complete('', 'Gitsigns show_commit main '))
     eq({ 'next' }, complete('n', 'Gitsigns nav_hunk n'))
     eq(
       { '--target=unstaged', '--target=staged', '--target=all' },

--- a/test/diff_spec.lua
+++ b/test/diff_spec.lua
@@ -6,39 +6,47 @@ local git = helpers.git
 
 helpers.env()
 
+--- @param action 'diff'|'show_commit'
 --- @param revision? string
 --- @param paths? string[]
-local function open_diff(revision, paths)
+local function open_panel(action, revision, paths)
   exec_lua(function(opts)
     local done = false
-    --- @param err? string
-    local function callback(err)
+    require('gitsigns')[opts.action](opts.revision, opts.paths, function(err)
       assert(not err, err)
       done = true
-    end
-    if opts.paths then
-      require('gitsigns').diff(opts.revision, opts.paths, callback)
-    else
-      require('gitsigns').diff(opts.revision, callback)
-    end
+    end)
+
     assert(vim.wait(5000, function()
       return done
     end))
-  end, { revision = revision, paths = paths })
-  eq(
-    'gitsigns-diff',
-    exec_lua('return vim.bo.filetype'),
-    api.nvim_exec2('messages', { output = true }).output
-  )
+  end, { action = action, revision = revision, paths = paths })
+  eq('gitsigns-diff', exec_lua('return vim.bo.filetype'))
 end
 
---- Open a diff through the user command and wait for its panel.
+--- @param revision? string
+--- @param paths? string[]
+local function open_diff(revision, paths)
+  open_panel('diff', revision, paths)
+end
+
+--- @param revision? string
+local function open_commit(revision)
+  open_panel('show_commit', revision)
+end
+
 --- @param args string
 local function open_diff_command(args)
   api.nvim_command('Gitsigns diff ' .. args)
   helpers.expectf(function()
     eq('gitsigns-diff', exec_lua('return vim.bo.filetype'))
   end)
+end
+
+--- @param ... string
+--- @return string[]
+local function git_output(...)
+  return helpers.fn.systemlist(vim.list_extend({ 'git', '-C', helpers.scratch }, { ... }))
 end
 
 --- @return table
@@ -67,7 +75,7 @@ end
 local function expect_diff(...)
   local expected = { ... }
   helpers.expectf(function()
-    eq(expected, diff_state())
+    eq(expected, diff_state(), api.nvim_exec2('messages', { output = true }).output)
   end)
 end
 
@@ -90,25 +98,32 @@ local function diffstat()
   end)
 end
 
---- @param line string
+--- @param pattern string Lua pattern matching the panel line.
 --- @param key? string
-local function select_file(line, key)
-  exec_lua(function(text)
+local function select_line(pattern, key)
+  exec_lua(function(match)
     for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
       local buf = vim.api.nvim_win_get_buf(win)
       if vim.bo[buf].filetype == 'gitsigns-diff' then
         vim.api.nvim_set_current_win(win)
         for i, value in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
-          if value == text then
+          if value:match(match) then
             vim.api.nvim_win_set_cursor(win, { i, 0 })
             return
           end
         end
       end
     end
-    error('No entry: ' .. text)
-  end, line)
+    error('No entry matching: ' .. match)
+  end, pattern)
   helpers.feed(key or '<CR>')
+end
+
+--- Select a filename at the end of its row, ignoring status and rename origins.
+--- @param name string
+--- @param key? string
+local function select_file(name, key)
+  select_line('^%s+.- ' .. vim.pesc(name) .. '$', key)
 end
 
 describe('diff panel', function()
@@ -118,6 +133,86 @@ describe('diff panel', function()
     helpers.setup_gitsigns(helpers.test_config)
     helpers.setup_test_repo({ test_file_text = { 'original' } })
     api.nvim_set_current_dir(helpers.scratch)
+  end)
+
+  it('compares explicit revisions with the editable working tree', function()
+    helpers.write_to_file(helpers.test_file, { 'committed' })
+    git('commit', '-am', 'Change the file')
+
+    helpers.write_to_file(helpers.test_file, { 'working tree' })
+
+    for _, case in ipairs({ { 'HEAD', 'committed' }, { 'HEAD~1', 'original' } }) do
+      open_diff_command(case[1] .. ' -- dummy.txt')
+      expect_diff({ case[2] }, { 'working tree' })
+
+      select_file('dummy.txt')
+      helpers.eq_path(helpers.test_file, api.nvim_buf_get_name(0))
+      eq(true, exec_lua('return vim.bo.modifiable'))
+
+      select_file('dummy.txt', 'q')
+    end
+  end)
+
+  for _, mode in ipairs({ 'worktree', 'commit' }) do
+    it('preserves cursors until unloaded: ' .. mode, function()
+      api.nvim_command('set nostartofline')
+      local lines = { 'one', 'two', 'three', 'four' }
+      for _, name in ipairs({ 'a.txt', 'b.txt' }) do
+        helpers.write_to_file(helpers.scratch .. '/' .. name, lines)
+      end
+      git('add', '.')
+      git('commit', '-m', 'Add files')
+
+      helpers.write_to_file(helpers.scratch .. '/a.txt', { 'one', 'changed', 'three', 'four' })
+      helpers.write_to_file(helpers.scratch .. '/b.txt', { 'changed', 'two', 'three', 'changed' })
+      if mode == 'commit' then
+        git('commit', '-am', 'Change files')
+        open_commit()
+      else
+        open_diff()
+      end
+
+      -- A first visit starts at the hunk, including changes at line one.
+      select_file('a.txt')
+      local win, buf = api.nvim_get_current_win(), api.nvim_get_current_buf()
+      eq({ 2, 0 }, api.nvim_win_get_cursor(win))
+
+      api.nvim_win_set_cursor(win, { 4, 1 })
+      select_file('b.txt')
+      expect_diff(lines, { 'changed', 'two', 'three', 'changed' })
+      eq({ 1, 0 }, api.nvim_win_get_cursor(win)) -- Do not skip a first-line hunk.
+      eq(true, api.nvim_buf_is_loaded(buf))
+
+      -- Returning to a loaded buffer preserves the position chosen above.
+      select_file('a.txt')
+      helpers.expectf(function()
+        eq({ 4, 1 }, api.nvim_win_get_cursor(win))
+      end)
+
+      -- Explicit unloading makes the next visit start at the hunk again.
+      select_file('b.txt')
+      expect_diff(lines, { 'changed', 'two', 'three', 'changed' })
+      api.nvim_buf_delete(buf, { unload = true })
+      select_file('a.txt')
+      helpers.expectf(function()
+        eq({ 2, 0 }, api.nvim_win_get_cursor(win))
+      end)
+    end)
+  end
+
+  it('does not jump to a hunk for a file loaded before opening the panel', function()
+    helpers.write_to_file(helpers.test_file, { 'first', 'middle', 'last' })
+    git('commit', '-am', 'Add lines')
+    helpers.write_to_file(helpers.test_file, { 'first', 'changed', 'last' })
+    helpers.edit(helpers.test_file)
+    helpers.wait_for_attach()
+    api.nvim_win_set_cursor(0, { 3, 0 })
+
+    open_diff('HEAD')
+    select_file('dummy.txt')
+
+    -- The new window starts at line 1; do not jump it to the hunk on line 2.
+    eq({ 1, 0 }, api.nvim_win_get_cursor(0))
   end)
 
   it('filters tracked and untracked paths relative to the current directory', function()
@@ -132,9 +227,9 @@ describe('diff panel', function()
     api.nvim_set_current_dir(helpers.scratch .. '/src')
 
     open_diff_command('-- *.lua :(exclude)skip.lua')
-    eq({ ' src/', '   M a.lua', '   ? new.lua' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    eq({ ' src/', '    M a.lua', '   ?? new.lua' }, api.nvim_buf_get_lines(0, 1, -3, false))
     expect_diff({ 'before' }, { 'after' })
-    select_file('   ? new.lua')
+    select_file('new.lua')
     expect_diff({ '' }, { 'untracked' })
   end)
 
@@ -145,15 +240,19 @@ describe('diff panel', function()
     end
     helpers.write_to_file(helpers.scratch .. '/not-selected', { 'outside' })
     open_diff_command('-- --flag 001 a=b nil with\\ space.txt {one,two}.txt')
-    eq(
-      { ' ? --flag', ' ? 001', ' ? a=b', ' ? nil', ' ? with space.txt', ' ? {one,two}.txt' },
-      api.nvim_buf_get_lines(0, 3, -1, false)
-    )
-    select_file(' ? with space.txt')
+    eq({
+      ' ?? --flag',
+      ' ?? 001',
+      ' ?? a=b',
+      ' ?? nil',
+      ' ?? with space.txt',
+      ' ?? {one,two}.txt',
+    }, api.nvim_buf_get_lines(0, 1, -3, false))
+    select_file('with space.txt')
     expect_diff({ '' }, { 'with space.txt' })
   end)
 
-  it('filters commits and ranges by historical paths missing from the working tree', function()
+  it('filters ranges by historical paths missing from the working tree', function()
     helpers.write_to_file(helpers.test_file, { 'after' })
     helpers.write_to_file(helpers.scratch .. '/noise.txt', { 'noise' })
     git('add', '.')
@@ -161,10 +260,10 @@ describe('diff panel', function()
     git('rm', 'dummy.txt')
     git('commit', '-m', 'Remove historical file')
 
-    for _, revision in ipairs({ 'HEAD~1', 'HEAD~2..HEAD~1', 'HEAD~2...HEAD~1' }) do
+    for _, revision in ipairs({ 'HEAD~2..HEAD~1', 'HEAD~2...HEAD~1' }) do
       for _, separator in ipairs({ ' ', ' -- ' }) do
         open_diff_command(revision .. separator .. 'dummy.txt missing.txt')
-        eq({ ' M dummy.txt' }, api.nvim_buf_get_lines(0, 3, -1, false))
+        eq({ ' M dummy.txt' }, api.nvim_buf_get_lines(0, 1, -3, false))
         expect_diff({ 'original' }, { 'after' })
         helpers.feed('q')
       end
@@ -178,58 +277,285 @@ describe('diff panel', function()
     helpers.wait_for_attach()
     helpers.chdir_tmp()
     open_diff(nil, { 'dummy.txt' })
-    eq({ ' M dummy.txt' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    eq({ '  M dummy.txt' }, api.nvim_buf_get_lines(0, 1, -3, false))
     eq({ { 'original' }, { 'changed' } }, diff_state())
     helpers.feed('q')
     open_diff(nil, { 'missing.txt' })
-    eq({ 'No changes' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    eq({ 'No changes' }, api.nvim_buf_get_lines(0, 1, -3, false))
     eq({}, diff_state())
   end)
 
   it('shows staged, unstaged, and untracked files while excluding ignored files', function()
+    git('config', 'status.showUntrackedFiles', 'no')
+
+    -- Establish the tracked paths before mixing index and worktree changes.
     helpers.write_to_file(helpers.scratch .. '/deleted.txt', { 'deleted' })
     helpers.write_to_file(helpers.scratch .. '/old.txt', { 'renamed' })
     helpers.write_to_file(helpers.scratch .. '/recreated.txt', { 'tracked' })
     git('add', '.')
     git('commit', '-m', 'Add files')
+
     git('rm', 'deleted.txt')
     git('mv', 'old.txt', 'renamed.txt')
     git('rm', '--cached', 'recreated.txt')
     helpers.write_to_file(helpers.scratch .. '/recreated.txt', { 'replacement' })
+
     helpers.write_to_file(helpers.test_file, { 'staged' })
     helpers.write_to_file(helpers.scratch .. '/staged.txt', { 'added' })
     git('add', 'dummy.txt', 'staged.txt')
     helpers.write_to_file(helpers.test_file, { 'unstaged' })
+
     helpers.write_to_file(helpers.scratch .. '/new dir/new file.txt', { 'untracked' })
     helpers.write_to_file(helpers.scratch .. '/.git/info/exclude', { 'ignored.txt' })
     helpers.write_to_file(helpers.scratch .. '/ignored.txt', { 'ignored' })
 
-    open_diff()
-    eq('Diff: working tree', api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    open_diff('HEAD')
+    eq('Diff: HEAD', api.nvim_buf_get_lines(0, 0, 1, false)[1])
     eq({
-      ' D deleted.txt',
-      ' M dummy.txt',
       ' new dir/',
-      '   ? new file.txt',
-      ' M recreated.txt',
-      ' R old.txt -> renamed.txt',
-      ' A staged.txt',
-    }, api.nvim_buf_get_lines(0, 3, -1, false))
-    eq({ '-1', '+1 -1', '+1', '+1 -1', '+1' }, diffstat())
-    eq({ { 'deleted' }, { '' } }, diff_state())
-    select_file(' M dummy.txt')
+      '   ?? new file.txt',
+      ' D  deleted.txt',
+      ' MM dummy.txt',
+      ' D? recreated.txt',
+      ' R  old.txt -> renamed.txt',
+      ' A  staged.txt',
+    }, api.nvim_buf_get_lines(0, 1, -3, false))
+    eq({ '+1', '-1', '+1 -1', '+1 -1', '+1' }, diffstat())
+    eq({ { '' }, { 'untracked' } }, diff_state())
+
+    -- Every status still opens the full comparison against HEAD.
+    select_file('dummy.txt')
     expect_diff({ 'original' }, { 'unstaged' })
-    select_file(' M recreated.txt')
+
+    select_file('recreated.txt')
     expect_diff({ 'tracked' }, { 'replacement' })
-    select_file(' R old.txt -> renamed.txt')
+
+    select_file('renamed.txt')
     expect_diff({ 'renamed' }, { 'renamed' })
-    select_file(' A staged.txt')
+
+    select_file('staged.txt')
     expect_diff({ '' }, { 'added' })
-    select_file('   ? new file.txt')
+
+    select_file('new file.txt')
     expect_diff({ '' }, { 'untracked' })
     helpers.eq_path(helpers.scratch .. '/new dir/new file.txt', api.nvim_buf_get_name(0))
     eq(true, exec_lua('return vim.bo.modifiable'))
     helpers.wait_for_attach()
+  end)
+
+  it('stages saved changes without changing the diff or unsaved edits', function()
+    helpers.write_to_file(helpers.test_file, { 'top', 'original', 'bottom' })
+    git('commit', '-am', 'Add lines')
+
+    -- Give the index, disk, and editor buffer distinct contents.
+    helpers.write_to_file(helpers.test_file, { 'top', 'staged', 'bottom' })
+    git('add', 'dummy.txt')
+
+    local disk = { 'top', 'working', 'bottom' }
+    helpers.write_to_file(helpers.test_file, disk)
+
+    helpers.edit(helpers.test_file)
+    helpers.wait_for_attach()
+    local source = api.nvim_get_current_buf()
+    local unsaved = { 'top', 'unsaved', 'bottom' }
+    api.nvim_buf_set_lines(source, 0, -1, false, unsaved)
+
+    open_diff()
+    local panel, panel_win = api.nvim_get_current_buf(), api.nvim_get_current_win()
+    select_file('dummy.txt')
+    local right = api.nvim_get_current_win()
+    api.nvim_win_set_cursor(right, { 3, 0 })
+
+    exec_lua(function()
+      _G.diff_changed_files = {}
+      vim.api.nvim_create_autocmd('User', {
+        pattern = 'GitSignsChanged',
+        callback = function(args)
+          table.insert(_G.diff_changed_files, args.data.file)
+        end,
+      })
+    end)
+
+    -- Staging changes the index without reopening the diff or replacing unsaved text.
+    for i, action in ipairs({
+      { '<Space>', ' M ', disk },
+      { 'u', '  M', { 'top', 'original', 'bottom' } },
+    }) do
+      select_file('dummy.txt', action[1])
+      helpers.expectf(function()
+        eq({ action[2] .. ' dummy.txt' }, api.nvim_buf_get_lines(panel, 1, -3, false))
+
+        -- The test config disables the watcher: the action must refresh hunks itself.
+        eq(
+          { '-' .. action[3][2], '+unsaved' },
+          exec_lua(function(buf)
+            return assert(require('gitsigns').get_hunks(buf))[1].lines
+          end, source)
+        )
+        local changed_files = exec_lua('return _G.diff_changed_files')
+        eq(i, #changed_files)
+        helpers.eq_path(helpers.test_file, changed_files[i])
+      end)
+
+      eq(action[3], git_output('show', ':dummy.txt'))
+      eq(panel_win, api.nvim_get_current_win())
+      eq({ 3, 0 }, api.nvim_win_get_cursor(right))
+      expect_diff({ 'top', 'original', 'bottom' }, unsaved)
+    end
+
+    eq(true, api.nvim_get_option_value('modified', { buf = source }))
+    eq(disk, helpers.fn.readfile(helpers.test_file))
+  end)
+
+  it('stages and unstages listed directory descendants without opening files', function()
+    local paths = {
+      'src/changed.txt',
+      'src/nested/partial.txt',
+      'src/excluded.txt',
+      'src-other/changed.txt',
+    }
+    for _, path in ipairs(paths) do
+      helpers.write_to_file(helpers.scratch .. '/' .. path, { 'original' })
+    end
+    git('add', '.')
+    git('commit', '-m', 'Add directories')
+
+    -- Mix partial staging with excluded files and a similarly named sibling directory.
+    for _, path in ipairs(paths) do
+      helpers.write_to_file(helpers.scratch .. '/' .. path, { 'changed' })
+    end
+    git('add', 'src/nested/partial.txt')
+    helpers.write_to_file(helpers.scratch .. '/src/nested/partial.txt', { 'remaining' })
+    helpers.write_to_file(helpers.scratch .. '/src/new.txt', { 'new' })
+
+    open_diff(nil, { 'src/', 'src-other/', ':(exclude)src/excluded.txt' })
+    local panel, panel_win = api.nvim_get_current_buf(), api.nvim_get_current_win()
+    local diff = diff_state()
+    select_line('^ src/$')
+    local staged = { 'src/changed.txt', 'src/nested/partial.txt', 'src/new.txt' }
+
+    -- Acting on a closed directory must preserve its fold and the displayed file.
+    for _, action in ipairs({
+      { 's', staged },
+      { '<Space>', {} },
+    }) do
+      select_line('^ src/$', action[1])
+      helpers.expectf(function()
+        local status = #action[2] > 0 and '     M  ' or '      M '
+        eq({ status .. 'partial.txt' }, api.nvim_buf_get_lines(panel, 3, 4, false))
+      end)
+
+      eq(action[2], git_output('diff', '--cached', '--name-only'))
+      eq(panel_win, api.nvim_get_current_win())
+      eq(' src/', api.nvim_get_current_line())
+      eq(2, helpers.fn.foldclosed(2))
+      eq(diff, diff_state())
+      eq(-1, helpers.fn.bufnr(helpers.scratch .. '/src/changed.txt'))
+    end
+  end)
+
+  it('stages and unstages both sides of a rename using literal paths', function()
+    git('config', 'status.renames', 'false')
+
+    -- The destination looks like a pathspec that could also match the unrelated file.
+    local name = 'new[1].txt'
+    assert((vim.uv or vim.loop).fs_rename(helpers.test_file, helpers.scratch .. '/' .. name))
+    git('add', '-N', '--', name)
+    helpers.write_to_file(helpers.scratch .. '/new1.txt', { 'unrelated' })
+
+    open_diff()
+    local panel = api.nvim_get_current_buf()
+
+    select_file(name, '<Space>')
+    helpers.expectf(function()
+      eq(
+        { ' ?? new1.txt', ' R  dummy.txt -> ' .. name },
+        api.nvim_buf_get_lines(panel, 1, -3, false)
+      )
+    end)
+    eq({ 'original' }, git_output('show', ':' .. name))
+
+    select_file(name, '<Space>')
+    helpers.expectf(function()
+      eq(
+        { '  D dummy.txt', ' ?? new1.txt', ' ?? ' .. name },
+        api.nvim_buf_get_lines(panel, 1, -3, false)
+      )
+    end)
+
+    eq({ 'dummy.txt' }, git_output('ls-files'))
+    eq({ 'original' }, helpers.fn.readfile(helpers.scratch .. '/' .. name))
+    eq({ 'unrelated' }, helpers.fn.readfile(helpers.scratch .. '/new1.txt'))
+  end)
+
+  it('shows unresolved merge conflicts with both status columns', function()
+    git('checkout', '-b', 'other')
+    helpers.write_to_file(helpers.test_file, { 'theirs' })
+    git('commit', '-am', 'Other change')
+
+    git('checkout', '-b', 'review', 'HEAD~1')
+    helpers.write_to_file(helpers.test_file, { 'ours' })
+    git('commit', '-am', 'Our change')
+    git('merge', 'other')
+
+    open_diff()
+    eq({ ' UU dummy.txt' }, api.nvim_buf_get_lines(0, 1, -3, false))
+    expect_diff({ 'ours' }, helpers.fn.readfile(helpers.test_file))
+  end)
+
+  it('can stage away changes that cancel out between the index and working tree', function()
+    helpers.write_to_file(helpers.test_file, { 'staged' })
+    git('add', 'dummy.txt')
+    helpers.write_to_file(helpers.test_file, { 'original' })
+    open_diff()
+    local panel = api.nvim_get_current_buf()
+    eq({ ' MM dummy.txt' }, api.nvim_buf_get_lines(panel, 1, -3, false))
+    expect_diff({ 'original' }, { 'original' })
+    select_file('dummy.txt', '<Space>')
+    helpers.expectf(function()
+      eq({ 'No changes' }, api.nvim_buf_get_lines(panel, 1, -3, false))
+      eq({ { 'original' }, { 'original' } }, diff_state())
+    end)
+    eq({}, git_output('diff', '--cached'))
+  end)
+
+  it('keeps file actions aligned when leaving the tab during a staging refresh', function()
+    helpers.write_to_file(helpers.test_file, { 'staged' })
+    git('add', 'dummy.txt')
+    helpers.write_to_file(helpers.test_file, { 'original' })
+    helpers.write_to_file(helpers.scratch .. '/z.txt', { 'untracked' })
+
+    -- Pause after Git is read, before the panel can replace its rows and metadata.
+    exec_lua(function()
+      local read = require('gitsigns.git.diff')
+      local initial = true
+
+      package.loaded['gitsigns.git.diff'] = function(...)
+        local base, target, entries, commit = read(...)
+        if not initial then
+          require('gitsigns.async').await(1, function(resume)
+            _G.resume_stage = resume
+          end)
+        end
+        initial = false
+
+        return base, target, entries, commit
+      end
+    end)
+
+    open_diff()
+    local tab = api.nvim_get_current_tabpage()
+    select_file('dummy.txt', '<Space>')
+    helpers.expectf(function()
+      eq(true, exec_lua('return _G.resume_stage ~= nil'))
+    end)
+
+    -- The abandoned refresh must leave old rows aligned with their file actions.
+    api.nvim_command('tabnew')
+    exec_lua('_G.resume_stage()')
+    api.nvim_set_current_tabpage(tab)
+    select_file('z.txt')
+    expect_diff({ '' }, { 'untracked' })
   end)
 
   it('shows diffstat for renamed, binary, and untracked files', function()
@@ -243,7 +569,7 @@ describe('diff panel', function()
     helpers.write_to_file(helpers.scratch .. '/binary', { 'a\0b' })
     git('add', '.')
     git('commit', '-m', 'Rename and add binary')
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq({ 'Bin', '+1 -1' }, diffstat())
     helpers.feed('q')
 
@@ -273,7 +599,7 @@ describe('diff panel', function()
     open_diff()
 
     for _, file in ipairs({ 'a', 'b', 'a' }) do
-      select_file(' M ' .. file .. '.txt')
+      select_file(file .. '.txt')
       helpers.expectf(function()
         eq({ { file, 'before', file .. ' end' }, { file, 'after', file .. ' end' } }, diff_state())
         eq(
@@ -314,7 +640,7 @@ describe('diff panel', function()
     end)
     open_diff()
     eq({ { 'original' }, { 'unsaved' } }, diff_state())
-    select_file(' M dummy.txt')
+    select_file('dummy.txt')
     helpers.expectf(function()
       eq(source, api.nvim_get_current_buf())
     end)
@@ -324,7 +650,7 @@ describe('diff panel', function()
     api.nvim_buf_set_lines(untracked, 0, -1, false, { 'edited' })
     helpers.feed('[f')
     expect_diff({ 'original' }, { 'unsaved' })
-    select_file(' M dummy.txt', 'q')
+    select_file('dummy.txt', 'q')
     eq(source, api.nvim_get_current_buf())
     eq({ 'unsaved' }, api.nvim_buf_get_lines(source, 0, -1, false))
     eq({ 'edited' }, api.nvim_buf_get_lines(untracked, 0, -1, false))
@@ -350,7 +676,11 @@ describe('diff panel', function()
         git('rm', 'dummy.txt')
         git('commit', '-m', 'Remove from the working tree')
       end
-      open_diff(revision or nil)
+      if revision then
+        open_commit(revision)
+      else
+        open_diff()
+      end
       eq({ { 'café', 'before', 'end' }, { 'café', 'after', 'end' } }, diff_state())
       helpers.feed('q')
     end
@@ -381,7 +711,7 @@ describe('diff panel', function()
     end)
     open_diff()
     local panel_win = api.nvim_get_current_win()
-    select_file(' M dummy.txt')
+    select_file('dummy.txt')
     local diff_win = api.nvim_get_current_win()
 
     api.nvim_set_current_win(source_win)
@@ -413,36 +743,51 @@ describe('diff panel', function()
     helpers.write_to_file(helpers.scratch .. '/new.txt', { 'untracked' })
     api.nvim_set_current_dir(helpers.scratch)
     open_diff()
-    eq({ ' A dummy.txt', ' ? new.txt' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    local panel = api.nvim_get_current_buf()
+    eq({ ' AM dummy.txt', ' ?? new.txt' }, api.nvim_buf_get_lines(0, 1, -3, false))
     eq({ '+1', '+1' }, diffstat())
     eq({ { '' }, { 'working tree' } }, diff_state())
-    select_file(' ? new.txt')
+    select_file('new.txt')
     expect_diff({ '' }, { 'untracked' })
+    for _, action in ipairs({
+      { 's', ' A ', { 'dummy.txt', 'new.txt' } },
+      { 'u', ' ??', { 'dummy.txt' } },
+    }) do
+      select_file('new.txt', action[1])
+      helpers.expectf(function()
+        eq({ action[2] .. ' new.txt' }, api.nvim_buf_get_lines(panel, 2, 3, false))
+      end)
+      eq(action[3], git_output('ls-files'))
+    end
   end)
 
-  it('shows an untracked repository as a gitlink', function()
+  it('shows and refreshes an untracked repository as a gitlink', function()
     helpers.mkdir(helpers.scratch .. '/nested')
     git('-C', 'nested', 'init', '-q')
+    git('-C', 'nested', 'config', 'user.name', 'Test')
+    git('-C', 'nested', 'config', 'user.email', 'test@example.com')
     helpers.write_to_file(helpers.scratch .. '/nested/file.txt', { 'nested' })
     git('-C', 'nested', 'add', '.')
-    git(
-      '-C',
-      'nested',
-      '-c',
-      'user.name=Test',
-      '-c',
-      'user.email=test@example.com',
-      'commit',
-      '-qm',
-      'Nested commit'
-    )
-    local oid = vim.trim(
-      helpers.fn.system({ 'git', '-C', helpers.scratch .. '/nested', 'rev-parse', 'HEAD' })
-    )
+    git('-C', 'nested', 'commit', '-qm', 'Nested commit')
+    local oid = assert(git_output('-C', 'nested', 'rev-parse', 'HEAD')[1])
+
     open_diff()
-    eq({ ' ? nested' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    eq({ ' ?? nested' }, api.nvim_buf_get_lines(0, 1, -3, false))
     eq({ '+1' }, diffstat())
     eq({ { '' }, { 'Subproject commit ' .. oid } }, diff_state())
+
+    select_file('nested')
+    helpers.expectf(function()
+      eq(true, exec_lua('return vim.wo.diff'))
+    end)
+    local buf = api.nvim_get_current_buf()
+
+    -- Reopening the gitlink reads its current HEAD into the retained buffer.
+    git('-C', 'nested', 'commit', '--allow-empty', '-qm', 'Next nested commit')
+    oid = assert(git_output('-C', 'nested', 'rev-parse', 'HEAD')[1])
+    select_file('nested')
+    expect_diff({ '' }, { 'Subproject commit ' .. oid })
+    eq(buf, api.nvim_get_current_buf())
   end)
 
   it('compares the targets of working-tree symlinks', function()
@@ -458,17 +803,33 @@ describe('diff panel', function()
     assert(uv.fs_symlink('missing.txt', path))
     assert(uv.fs_symlink('dummy.txt', helpers.scratch .. '/new-link'))
     open_diff()
-    eq({ ' M link', ' ? new-link' }, api.nvim_buf_get_lines(0, 3, -1, false))
+    local panel = api.nvim_get_current_buf()
+    eq({ '  M link', ' ?? new-link' }, api.nvim_buf_get_lines(0, 1, -3, false))
     eq({ '+1 -1', '+1' }, diffstat())
     eq({ { 'dummy.txt' }, { 'missing.txt' } }, diff_state())
-    select_file(' ? new-link')
+
+    select_file('link')
+    local buf = api.nvim_get_current_buf()
+    select_file('new-link')
     expect_diff({ '' }, { 'dummy.txt' })
+
+    -- A staging refresh must not leave the old symlink target cached on revisit.
+    assert(uv.fs_unlink(path))
+    assert(uv.fs_symlink('latest.txt', path))
+    select_file('link', 's')
+    helpers.expectf(function()
+      eq({ ' M  link' }, api.nvim_buf_get_lines(panel, 1, 2, false))
+    end)
+
+    select_file('link')
+    expect_diff({ 'dummy.txt' }, { 'latest.txt' })
+    eq(buf, api.nvim_get_current_buf())
   end)
 
   it('reuses the startup window for a root commit and closes cleanly', function()
     local source_win = api.nvim_get_current_win()
     local source_tab = api.nvim_get_current_tabpage()
-    open_diff('HEAD')
+    open_commit()
     eq({ source_tab }, api.nvim_list_tabpages())
     eq(3, #api.nvim_tabpage_list_wins(0))
     eq(true, exec_lua('return vim.wo[...].diff', source_win))
@@ -505,7 +866,7 @@ describe('diff panel', function()
           focusable = focus,
         })
       end, focusable)
-      open_diff('HEAD')
+      open_commit('HEAD')
       eq({ source_tab }, api.nvim_list_tabpages())
       eq(true, exec_lua('return vim.wo[...].diff', source_win))
       eq(true, api.nvim_win_is_valid(float))
@@ -518,7 +879,7 @@ describe('diff panel', function()
     local source = api.nvim_get_current_buf()
     local source_win = api.nvim_get_current_win()
     api.nvim_buf_set_lines(source, 0, -1, false, { 'unsaved draft' })
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq(2, #api.nvim_list_tabpages())
     eq(source, api.nvim_win_get_buf(source_win))
     eq({ 'unsaved draft' }, api.nvim_buf_get_lines(source, 0, -1, false))
@@ -531,7 +892,7 @@ describe('diff panel', function()
     api.nvim_command('vsplit')
     local source_tab = api.nvim_get_current_tabpage()
     local wins = api.nvim_tabpage_list_wins(source_tab)
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq(2, #api.nvim_list_tabpages())
     eq(wins, api.nvim_tabpage_list_wins(source_tab))
     helpers.feed('q')
@@ -551,16 +912,16 @@ describe('diff panel', function()
     git('rm', 'renamed.txt', 'added.txt')
     git('commit', '-m', 'Remove historical paths from the checkout')
 
-    open_diff('HEAD~1')
+    open_commit('HEAD~1')
     local wins = api.nvim_tabpage_list_wins(0)
     eq({ { '' }, { 'added' } }, diff_state())
-    select_file(' D deleted.txt')
+    select_file('deleted.txt')
     expect_diff({ 'deleted' }, { '' })
-    select_file(' R dummy.txt -> renamed.txt')
+    select_file('renamed.txt')
     expect_diff({ 'original' }, { 'original' })
     eq(wins, api.nvim_tabpage_list_wins(0))
 
-    select_file(' R dummy.txt -> renamed.txt', 'O')
+    select_file('renamed.txt', 'O')
     helpers.expectf(function()
       eq(2, #api.nvim_list_tabpages())
     end)
@@ -577,13 +938,33 @@ describe('diff panel', function()
     local source = api.nvim_get_current_buf()
     api.nvim_buf_set_lines(source, 0, -1, false, { 'unsaved' })
     helpers.chdir_tmp()
-    open_diff('HEAD')
-    eq({ { 'original' }, { 'committed' } }, diff_state())
+    api.nvim_command('Gitsigns show_commit HEAD')
+    expect_diff({ 'original' }, { 'committed' })
     helpers.feed('q')
     eq(source, api.nvim_get_current_buf())
     eq({ 'unsaved' }, api.nvim_buf_get_lines(source, 0, -1, false))
     eq(true, exec_lua('return vim.bo.modified'))
     eq(false, exec_lua('return vim.wo.diff'))
+  end)
+
+  it('wraps the summary above a nonselectable separator', function()
+    local summary = 'Keep the commit summary readable when the file panel is narrow'
+    git('commit', '--allow-empty', '-m', summary)
+    open_commit()
+    local panel = api.nvim_get_current_win()
+    for _, case in ipairs({ { 36, 2 }, { 20, 4 } }) do
+      api.nvim_win_set_width(panel, case[1])
+      helpers.expectf(function()
+        eq(case[2], api.nvim_win_text_height(panel, { start_row = 1, end_row = 1 }).all)
+        eq(1, api.nvim_win_text_height(panel, { start_row = 2, end_row = 2 }).fill)
+      end)
+    end
+    helpers.feed('2j')
+    eq({ 3, 0 }, api.nvim_win_get_cursor(panel))
+    select_line('^' .. vim.pesc(summary) .. '$')
+    helpers.expectf(function()
+      eq('gitcommit', exec_lua('return vim.bo.filetype'))
+    end)
   end)
 
   it('switches between the commit message and file diffs beside the panel', function()
@@ -605,7 +986,8 @@ describe('diff panel', function()
     local sha =
       vim.trim(helpers.fn.system({ 'git', '-C', helpers.scratch, 'rev-parse', '--short', 'HEAD' }))
     local header = sha .. ' Explain the change'
-    open_diff('HEAD')
+
+    open_commit('HEAD')
     eq(
       false,
       exec_lua(function()
@@ -613,8 +995,9 @@ describe('diff panel', function()
         return ok
       end)
     )
-    eq(header, api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    eq({ sha, 'Explain the change' }, api.nvim_buf_get_lines(0, 0, 2, false))
     eq({ { 'original' }, { 'committed' } }, diff_state())
+
     local panel = api.nvim_get_current_win()
     local tab = api.nvim_get_current_tabpage()
     local message = vim.list_extend({
@@ -626,10 +1009,14 @@ describe('diff panel', function()
 
     -- Moving the ref must not change which commit the open panel describes.
     git('commit', '--allow-empty', '-m', 'A later commit')
+    local message_buf --- @type integer?
     for _, close in ipairs({ false, 'q', ':close<CR>' }) do
-      select_file(header)
+      select_line('^' .. vim.pesc(sha) .. '$')
       local win = api.nvim_get_current_win()
       local buf = api.nvim_get_current_buf()
+      message_buf = message_buf or buf
+
+      eq(message_buf, buf)
       eq(1, #api.nvim_list_tabpages())
       eq(tab, api.nvim_get_current_tabpage())
       eq(2, #api.nvim_tabpage_list_wins(0))
@@ -640,6 +1027,8 @@ describe('diff panel', function()
       eq(false, exec_lua('return vim.bo.modifiable'))
       eq(message, api.nvim_buf_get_lines(0, 0, -1, false))
       eq({}, diff_state())
+
+      -- Closing the message pane must still allow its buffer to be reused.
       helpers.feed('G')
       eq('Detail 40', api.nvim_get_current_line())
       if close then
@@ -648,13 +1037,20 @@ describe('diff panel', function()
         eq(panel, api.nvim_get_current_win())
         eq({ panel }, api.nvim_tabpage_list_wins(0))
       end
+
       eq({ 1, 0 }, api.nvim_win_get_cursor(panel))
-      select_file(' M dummy.txt')
+      select_file('dummy.txt')
       expect_diff({ 'original' }, { 'committed' })
-      eq(false, api.nvim_buf_is_valid(buf))
+      eq(true, api.nvim_buf_is_loaded(buf))
       eq(1, #api.nvim_list_tabpages())
       eq(3, #api.nvim_tabpage_list_wins(0))
     end
+
+    -- The retained message is released when the whole review closes.
+    select_file('dummy.txt', 'q')
+    helpers.expectf(function()
+      eq(false, api.nvim_buf_is_valid(message_buf))
+    end)
   end)
 
   it('keeps full commit navigation separate from the panel message', function()
@@ -665,7 +1061,7 @@ describe('diff panel', function()
     helpers.edit(helpers.test_file)
     helpers.wait_for_attach()
     local source = api.nvim_get_current_win()
-    api.nvim_command('Gitsigns show_commit ' .. sha)
+    api.nvim_command('Gitsigns show_commit ' .. sha .. ' vsplit')
     helpers.expectf(function()
       eq('commit ' .. sha, api.nvim_buf_get_lines(0, 0, 1, false)[1])
     end)
@@ -677,9 +1073,9 @@ describe('diff panel', function()
     local parent = full_text[3]:match('parent (%x+)')
 
     api.nvim_set_current_win(source)
-    open_diff(sha)
+    open_commit(sha)
     local header = api.nvim_buf_get_lines(0, 0, 1, false)[1]
-    select_file(header)
+    select_line('^' .. vim.pesc(header) .. '$')
     local message_buf = api.nvim_get_current_buf()
     local message_text = api.nvim_buf_get_lines(message_buf, 0, -1, false)
     eq(false, message_buf == full_buf)
@@ -706,9 +1102,9 @@ describe('diff panel', function()
 
   it('shows the message of a commit with no changed files', function()
     git('commit', '--allow-empty', '-m', 'An empty commit')
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq({ 1, 0 }, api.nvim_win_get_cursor(0))
-    eq('No changes', api.nvim_buf_get_lines(0, 3, -1, false)[1])
+    eq('No changes', api.nvim_buf_get_lines(0, 2, -3, false)[1])
     eq({}, diff_state())
     helpers.feed('<CR>')
     eq('An empty commit', api.nvim_buf_get_lines(0, 4, 5, false)[1])
@@ -719,12 +1115,12 @@ describe('diff panel', function()
   end)
 
   it('shows available keys and returns from help without changing the view', function()
-    open_diff('HEAD')
+    open_commit('HEAD')
     local panel = api.nvim_get_current_win()
     local panel_buf = api.nvim_get_current_buf()
     local cursor = api.nvim_win_get_cursor(panel)
     local wins = api.nvim_tabpage_list_wins(0)
-    eq(true, api.nvim_buf_get_lines(panel_buf, 1, 2, false)[1]:find('g? help', 1, true) ~= nil)
+    eq(true, api.nvim_buf_get_lines(panel_buf, -2, -1, false)[1]:find('g? help', 1, true) ~= nil)
 
     for _, close in ipairs({ '<Esc>', 'q', 'g?' }) do
       helpers.feed('g?')
@@ -757,14 +1153,39 @@ describe('diff panel', function()
     end
   end)
 
+  it('opens a clicked file from another window', function()
+    local screen = require('nvim-test.screen').new(110, 24)
+    screen:attach()
+    finally(function()
+      screen:detach()
+    end)
+
+    exec_lua("vim.o.mouse = 'a'; vim.o.mousetime = 0")
+    helpers.write_to_file(helpers.test_file, { 'changed' })
+    helpers.write_to_file(helpers.scratch .. '/z.txt', { 'new' })
+
+    open_diff()
+    local panel = api.nvim_get_current_win()
+    select_file('dummy.txt')
+
+    -- Click the panel while a diff window has focus, including both mouse events.
+    api.nvim_command('redraw')
+    local pos = helpers.fn.screenpos(panel, 3, 1)
+    api.nvim_input_mouse('left', 'press', '', 0, pos.row - 1, pos.col - 1)
+    api.nvim_input_mouse('left', 'release', '', 0, pos.row - 1, pos.col - 1)
+
+    expect_diff({ '' }, { 'new' })
+    eq(true, exec_lua('return vim.wo.diff'))
+  end)
+
   it('opens a diff with Shift-Enter without moving the panel cursor', function()
     helpers.write_to_file(helpers.test_file, { 'committed' })
     helpers.write_to_file(helpers.scratch .. '/z.txt', { 'z' })
     git('add', '.')
     git('commit', '-m', 'Change two files')
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq({ { 'original' }, { 'committed' } }, diff_state())
-    select_file(' A z.txt', '$')
+    select_file('z.txt', '$')
     local panel = api.nvim_get_current_win()
     local cursor = api.nvim_win_get_cursor(panel)
     helpers.feed('<S-CR>')
@@ -785,7 +1206,7 @@ describe('diff panel', function()
     helpers.write_to_file(helpers.scratch .. '/z.txt', { 'z' })
     git('add', '.')
     git('commit', '-m', 'Add nested files')
-    open_diff('HEAD')
+    open_commit('HEAD')
     local panel = api.nvim_get_current_win()
     --- Read highlighted filename text, independently of the cursor.
     --- @return string[]
@@ -802,47 +1223,47 @@ describe('diff panel', function()
         return lines
       end, panel)
     end
-    eq({ 'a.txt' }, selected())
-    select_file(' src/', 'zM')
-    select_file(' src/')
-    select_file('   A a.txt')
+    eq({ 'b.txt' }, selected())
+    select_line('^ src/$', 'zM')
+    select_line('^ src/$')
+    select_file('a.txt')
     helpers.expectf(function()
       eq(true, exec_lua('return vim.wo.diff'))
     end)
     local right = api.nvim_get_current_win()
     local left = helpers.fn.win_getid(helpers.fn.winnr('h'))
     -- Browsing the panel must not change where navigation starts in the diff.
-    select_file(' A z.txt', '0')
+    select_file('z.txt', '0')
     eq({ 'a.txt' }, selected())
     api.nvim_set_current_win(right)
-    helpers.feed(']f')
+    helpers.feed('[f')
     expect_diff({ '' }, { 'b' })
     eq({ 'b.txt' }, selected())
     eq(right, api.nvim_get_current_win())
-    eq({ 7, 0 }, api.nvim_win_get_cursor(panel))
+    eq({ 5, 0 }, api.nvim_win_get_cursor(panel))
     eq(
       -1,
       exec_lua(function(win)
         return vim.api.nvim_win_call(win, function()
-          return vim.fn.foldclosed(7)
+          return vim.fn.foldclosed(5)
         end)
       end, panel)
     )
 
     api.nvim_set_current_win(left)
-    helpers.feed(']f')
+    helpers.feed('2]f')
     expect_diff({ '' }, { 'z' })
     eq({ 'z.txt' }, selected())
     eq(left, api.nvim_get_current_win())
     helpers.feed(']f')
     eq({ { '' }, { 'z' } }, diff_state())
     helpers.feed('2[f')
-    expect_diff({ '' }, { 'a' })
-    eq({ 'a.txt' }, selected())
+    expect_diff({ '' }, { 'b' })
+    eq({ 'b.txt' }, selected())
     eq(left, api.nvim_get_current_win())
     helpers.feed('[f')
-    eq({ { '' }, { 'a' } }, diff_state())
-    select_file(' A z.txt', '<S-CR>')
+    eq({ { '' }, { 'b' } }, diff_state())
+    select_file('z.txt', '<S-CR>')
     expect_diff({ '' }, { 'z' })
     eq({ 'z.txt' }, selected())
     helpers.feed('gg<CR>')
@@ -857,9 +1278,9 @@ describe('diff panel', function()
     helpers.edit(helpers.test_file)
     helpers.wait_for_attach()
     local source_tab = api.nvim_get_current_tabpage()
-    open_diff('HEAD')
+    open_commit('HEAD')
     local first_tab = api.nvim_get_current_tabpage()
-    select_file(' A a.txt')
+    select_file('a.txt')
     helpers.expectf(function()
       eq(true, exec_lua('return vim.wo.diff'))
     end)
@@ -867,9 +1288,9 @@ describe('diff panel', function()
     local shared_buf = api.nvim_get_current_buf()
 
     api.nvim_set_current_tabpage(source_tab)
-    open_diff('HEAD')
+    open_commit('HEAD')
     local second_tab = api.nvim_get_current_tabpage()
-    select_file(' A a.txt')
+    select_file('a.txt')
     helpers.expectf(function()
       eq(true, exec_lua('return vim.wo.diff'))
     end)
@@ -886,14 +1307,14 @@ describe('diff panel', function()
     helpers.feed(']f')
     expect_diff({ '' }, { 'b' })
     eq(second_tab, api.nvim_get_current_tabpage())
-    select_file(' A b.txt', 'q')
+    select_file('b.txt', 'q')
     api.nvim_set_current_win(first_win)
     helpers.feed('[f')
     expect_diff({ '' }, { 'a' })
     eq(first_win, api.nvim_get_current_win())
   end)
 
-  it('folds nested directories and leading-space names with icons', function()
+  it('lists directories first and folds nested and leading-space names with icons', function()
     exec_lua(function()
       package.preload['nvim-web-devicons'] = function()
         return {
@@ -908,22 +1329,24 @@ describe('diff panel', function()
     helpers.write_to_file(helpers.scratch .. '/  src/ nested/  b.txt', { 'b' })
     helpers.write_to_file(helpers.scratch .. '/  src/z.txt', { 'z' })
     helpers.write_to_file(helpers.scratch .. '/tests/t.txt', { 'test' })
+    helpers.write_to_file(helpers.scratch .. '/aaa.txt', { 'root' })
     helpers.write_to_file(helpers.scratch .. '/top.txt', { 'top' })
     git('add', '.')
     git('commit', '-m', 'Add nested files')
-    open_diff('HEAD')
+    open_commit('HEAD')
     eq({
       ' \\  src/',
-      '   A   a.txt',
       '   \\ nested/',
       '     A   b.txt',
+      '   A   a.txt',
       '   A z.txt',
       ' tests/',
       '   A t.txt',
+      ' A aaa.txt',
       ' A top.txt',
-    }, api.nvim_buf_get_lines(0, 3, -1, false))
+    }, api.nvim_buf_get_lines(0, 2, -3, false))
     eq(
-      { DevIconDefault = 5, Directory = 3 },
+      { DevIconDefault = 6, Directory = 3 },
       exec_lua(function()
         local counts = {}
         for _, mark in ipairs(vim.api.nvim_buf_get_extmarks(0, -1, 0, -1, { details = true })) do
@@ -937,31 +1360,31 @@ describe('diff panel', function()
         return counts
       end)
     )
-    eq({ { '' }, { 'a' } }, diff_state())
-    eq(-1, exec_lua('return vim.fn.foldclosed(4)'))
+    eq({ { '' }, { 'b' } }, diff_state())
+    eq(-1, exec_lua('return vim.fn.foldclosed(3)'))
 
-    select_file('   \\ nested/')
-    eq({ 6, 7 }, exec_lua('return { vim.fn.foldclosed(7), vim.fn.foldclosedend(6) }'))
-    select_file(' \\  src/')
-    eq(8, exec_lua('return vim.fn.foldclosedend(4)'))
-    eq(-1, exec_lua('return vim.fn.foldclosed(9)'))
-    eq({ { '' }, { 'a' } }, diff_state())
+    select_line('^   \\ nested/$')
+    eq({ 4, 5 }, exec_lua('return { vim.fn.foldclosed(5), vim.fn.foldclosedend(4) }'))
+    select_line('^ \\  src/$')
+    eq(7, exec_lua('return vim.fn.foldclosedend(3)'))
+    eq(-1, exec_lua('return vim.fn.foldclosed(8)'))
+    eq({ { '' }, { 'b' } }, diff_state())
 
-    select_file(' A top.txt')
+    select_file('top.txt')
     expect_diff({ '' }, { 'top' })
-    select_file(' \\  src/')
-    eq(6, exec_lua('return vim.fn.foldclosed(6)'))
-    select_file('   \\ nested/')
-    select_file('     A   b.txt')
+    select_line('^ \\  src/$')
+    eq(4, exec_lua('return vim.fn.foldclosed(4)'))
+    select_line('^   \\ nested/$')
+    select_file('  b.txt')
     expect_diff({ '' }, { 'b' })
 
-    select_file(' \\  src/', 'zM')
+    select_line('^ \\  src/$', 'zM')
     eq(
-      { 8, 10, -1 },
-      exec_lua('return { vim.fn.foldclosedend(4), vim.fn.foldclosedend(9), vim.fn.foldclosed(11) }')
+      { 7, 9, -1 },
+      exec_lua('return { vim.fn.foldclosedend(3), vim.fn.foldclosedend(8), vim.fn.foldclosed(10) }')
     )
     helpers.feed('zR')
-    eq(-1, exec_lua('return vim.fn.foldclosed(7)'))
+    eq(-1, exec_lua('return vim.fn.foldclosed(6)'))
   end)
 
   it('groups a rename under its destination and opens its original path', function()
@@ -971,9 +1394,9 @@ describe('diff panel', function()
     helpers.mkdir(helpers.scratch .. '/new')
     git('mv', 'old/original.txt', 'new/renamed.txt')
     git('commit', '-m', 'Rename across directories')
-    open_diff('HEAD')
-    eq({ ' new/', '   R old/original.txt -> renamed.txt' }, api.nvim_buf_get_lines(0, 3, -1, false))
-    select_file('   R old/original.txt -> renamed.txt', 'O')
+    open_commit('HEAD')
+    eq({ ' new/', '   R old/original.txt -> renamed.txt' }, api.nvim_buf_get_lines(0, 2, -3, false))
+    select_file('renamed.txt', 'O')
     helpers.expectf(function()
       eq(2, #api.nvim_list_tabpages())
     end)
@@ -1008,7 +1431,7 @@ describe('diff panel', function()
     helpers.write_to_file(helpers.scratch .. '/b.txt', { 'b' })
     git('add', '.')
     git('commit', '-m', 'Add two files')
-    open_diff('HEAD')
+    open_commit('HEAD')
     exec_lua(function()
       local Repo = require('gitsigns.git.repo')
       local read = Repo.get_show_text
@@ -1020,11 +1443,11 @@ describe('diff panel', function()
         return read(self, object, encoding)
       end
     end)
-    select_file(' A b.txt')
+    select_file('b.txt')
     helpers.expectf(function()
       eq(true, exec_lua('return _G.resume_read ~= nil'))
     end)
-    select_file(' A b.txt', 'q')
+    select_file('b.txt', 'q')
     eq(1, #api.nvim_list_tabpages())
     exec_lua('_G.resume_read()')
     helpers.expectf(function()


### PR DESCRIPTION
The diff panel shows repository changes, but staging still requires leaving the panel and switching files resets the cursor. Add staging directly to the panel and keep review buffers loaded so returning to a file preserves your place.

- Show index and working-tree status together, with `s`, `u`, and `<Space>` to stage, unstage, or toggle a file or directory's listed descendants. These actions use saved files, preserve unsaved buffer edits, and refresh status without replacing the displayed diff.
- Jump to the first change only when loading a buffer. Retain reviewed buffers until the panel closes, preserving buffers already loaded, modified, or open elsewhere.
- Sort directories before files, show their changed-file counts and total diffstats, and add mouse selection, wrapped commit summaries, and clearer help.

Align the revision commands with Git: `:Gitsigns diff <commit>` now compares the commit with the working tree. Use `:Gitsigns show_commit <commit>` for the changes introduced by that commit; it now opens the file panel by default. Explicit `vsplit` and `tabnew` arguments retain the full commit text view.

Panel state is held in a private class, while Git modules handle comparison data and staging operations.
